### PR TITLE
feat(pi-antigravity): add /agy-usage quota command

### DIFF
--- a/.changeset/agy-usage-quota.md
+++ b/.changeset/agy-usage-quota.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-antigravity": minor
+---
+
+Add `/agy-usage` to inspect Antigravity weekly and 5-hour model quotas in the same Refresh/Close menu as `/usage`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Each extension has its own package and its own README under
 | [pi-goal](packages/pi-goal/README.md) | `/goal`, tools `get_goal`/`update_goal` | User-owned, editable objective with evidence-checked bounded continuation. |
 | [pi-todo](packages/pi-todo/README.md) | tool `todo` | Small shared todo list for multi-step work. |
 | [pi-web-search](packages/pi-web-search/README.md) | tools `web_search`/`web_fetch` | Clean web search & fetch via OpenAI Responses, Exa, Firecrawl, or Ollama. |
-| [pi-antigravity](packages/pi-antigravity/README.md) | `/agy` | Google Antigravity (`agy`) models inside pi via stream-json RPC. |
+| [pi-antigravity](packages/pi-antigravity/README.md) | `/agy`, `/agy-usage` | Google Antigravity (`agy`) models inside pi via stream-json RPC. |
 | [pi-vscode-bridge](packages/pi-vscode-bridge/README.md) | `/vscode-connect` | Send file/line/diff-hunk refs from VS Code into pi's editor. |
 
 ## Install

--- a/packages/pi-antigravity/README.md
+++ b/packages/pi-antigravity/README.md
@@ -9,6 +9,7 @@ Use **Google Antigravity** (`agy`) models inside the [pi coding agent](https://p
 - **Skills & MCP bridge** — your global pi Agent Skills become callable tools inside agy turns (`pi__p<pid>__skill__grilling`, …), and pi's MCP servers (via the `pi-mcp-adapter` tools) are reachable from agy with pi's permissions, hooks, and rendering. Per-session tool names keep concurrent pi sessions fully isolated.
 - **Background-task manager** — long-running agy commands are tracked in a dashboard and stoppable with one keystroke (`/agy-tasks`).
 - **Artifact browser** — images and files agy creates are listed and openable via `/agy-artifacts`, with a status-bar hint when new ones appear.
+- **Model quotas** — `/agy-usage` ports agy's `/usage` into the same Refresh/Close menu as `/usage`: weekly and 5-hour remaining bars per model group, refreshed without spending tokens.
 
 ## How it works
 
@@ -113,6 +114,24 @@ Images and files agy creates land in a per-conversation artifact store. A hint a
 
 The dashboard shows name, type, size, and origin (`generated` vs `uploaded`). Press `o` to open a file with the system default app. Non-interactive: `/agy-artifacts open <name>`.
 
+### Model quotas (`/agy-usage`)
+
+agy's interactive `/usage` (alias `/quota`) is a TUI-only slash command — there is no `agy usage` subcommand. `/agy-usage` expands the same slash command in print mode (`agy --print /usage --output-format json`), which returns structured quota groups and reports zero tokens.
+
+The menu matches `/usage`: per-group 5-hour and weekly remaining bars with clock-style reset times. Refresh re-queries; Close dismisses. Print/RPC modes print the same numbers as a notification.
+
+```text
+Gemini Models
+  5h limit:         [████████████████████] 98% left · resets 19:53
+
+  Weekly limit:     [███████████████████░] 97% left · resets 09:10 on 4 Sep
+
+Claude and GPT models
+  5h limit:         [████████████████████] 100% left · resets 20:08
+
+  Weekly limit:     [████████████████████] 100% left · resets 15:08 on 4 Sep
+```
+
 ## Commands
 
 | Command | What it does |
@@ -122,6 +141,7 @@ The dashboard shows name, type, size, and origin (`generated` vs `uploaded`). Pr
 | `/agy models` | Re-discover models and re-register the provider |
 | `/agy-tasks` | Background-task dashboard (`stop <task-id>|all` for scripts) |
 | `/agy-artifacts` | Artifact browser (`open <name>` for scripts) |
+| `/agy-usage` | Model quotas (weekly and 5-hour remaining per group) |
 
 ## Configuration flags
 

--- a/packages/pi-antigravity/index.ts
+++ b/packages/pi-antigravity/index.ts
@@ -8,6 +8,7 @@
 //   /agy            show agy conversation status (id, model, turns)
 //   /agy reset      drop the current agy conversation (next turn starts fresh)
 //   /agy models     re-discover models from `agy models` and re-register
+//   /agy-usage      show Antigravity model quotas (weekly and 5-hour limits)
 
 import type {
   ExtensionAPI,
@@ -48,10 +49,12 @@ import type { AgyActivity } from "./lib/reducer.ts";
 import { AgyReplayStore, type RecordedAgyTool } from "./lib/replay.ts";
 import { findAgyTask, listAgyTasks, stopAgyTask } from "./lib/tasks.ts";
 import { findAgyArtifact, listAgyArtifacts } from "./lib/artifacts.ts";
+import { fetchAgyUsage } from "./lib/usage.ts";
 import { WRAPPER_TOOL_DESCRIPTION, WRAPPER_TOOL_NAME } from "./lib/prompt.ts";
 import { wrapperToolActiveAfterModelSwitch } from "./lib/wrapper-activation.ts";
 import { openAgyTasksPicker } from "./src/tasks-ui.ts";
 import { openArtifact, openAgyArtifactsPicker } from "./src/artifacts-ui.ts";
+import { openAgyUsagePicker } from "./src/usage-ui.ts";
 import { agyToolLabel, formatAgyCall, summarizeAgyResult } from "./lib/render.ts";
 import { streamAntigravity } from "./src/provider.ts";
 import { AntigravityRuntime, createAntigravityRuntime, runAntigravity } from "./src/runtime.ts";
@@ -753,6 +756,17 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
       }
 
       await openAgyArtifactsPicker(ctx, rescan);
+    },
+  });
+
+  pi.registerCommand("agy-usage", {
+    description: "Show Antigravity model quotas (weekly and 5-hour limits)",
+    handler: async (args, ctx) => {
+      if (args.trim()) {
+        ctx.ui.notify('agy-usage: usage "/agy-usage".', "error");
+        return;
+      }
+      await openAgyUsagePicker(ctx, (signal) => fetchAgyUsage({ signal }));
     },
   });
 }

--- a/packages/pi-antigravity/lib/usage.ts
+++ b/packages/pi-antigravity/lib/usage.ts
@@ -1,0 +1,237 @@
+/**
+ * agy model-quota fetch — ports the interactive `/usage` (`/quota`) slash
+ * command by expanding it in print mode. agy has no `usage` subcommand; with
+ * slash expansion left enabled, `agy --print /usage --output-format json`
+ * returns the same structured quota payload the TUI panel shows, and reports
+ * zero tokens (it is a command, not a model turn).
+ */
+
+import { execFile } from "node:child_process";
+import { AGY_BINARY } from "./agy-client.ts";
+
+export const USAGE_TIMEOUT_MS = 30_000;
+
+export interface AgyUsageBucket {
+  id: string;
+  name: string;
+  description?: string;
+  window: string;
+  remainingFraction: number;
+  resetTime?: string;
+}
+
+export interface AgyUsageGroup {
+  name: string;
+  description?: string;
+  buckets: AgyUsageBucket[];
+}
+
+export interface AgyUsageReport {
+  description?: string;
+  groups: AgyUsageGroup[];
+}
+
+export interface FetchAgyUsageOptions {
+  binary?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  /** Test seam: replaces `execFile`. */
+  execFileOverride?: (
+    file: string,
+    args: readonly string[],
+    options: { timeout?: number; signal?: AbortSignal; encoding?: string; maxBuffer?: number },
+    callback: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => unknown;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function unwrapResult(parsed: unknown): Record<string, unknown> {
+  const root = asRecord(parsed);
+  if (!root) throw new Error("agy-usage: quota response was not an object.");
+  if (root.event === "result" && asRecord(root.result)) return asRecord(root.result)!;
+  return root;
+}
+
+function parseBucket(value: unknown): AgyUsageBucket | undefined {
+  const rec = asRecord(value);
+  if (!rec) return undefined;
+  const id = asString(rec.id) ?? asString(rec.name);
+  const name = asString(rec.name) ?? asString(rec.id);
+  const remaining =
+    asNumber(rec.remaining_fraction) ?? asNumber(rec.remainingFraction) ?? asNumber(rec.remaining);
+  if (!id || !name || remaining === undefined) return undefined;
+  return {
+    id,
+    name,
+    description: asString(rec.description),
+    window: asString(rec.window) ?? id,
+    remainingFraction: remaining,
+    resetTime: asString(rec.reset_time) ?? asString(rec.resetTime),
+  };
+}
+
+function parseGroup(value: unknown): AgyUsageGroup | undefined {
+  const rec = asRecord(value);
+  if (!rec) return undefined;
+  const name = asString(rec.name);
+  if (!name) return undefined;
+  const buckets = Array.isArray(rec.buckets)
+    ? rec.buckets.map(parseBucket).filter((bucket): bucket is AgyUsageBucket => bucket !== undefined)
+    : [];
+  return { name, description: asString(rec.description), buckets };
+}
+
+/** Parse `agy --print /usage --output-format json` stdout (or a stream-json result envelope). */
+export function parseAgyUsageJson(text: string): AgyUsageReport {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("agy-usage: quota response was not valid JSON.");
+  }
+  const result = unwrapResult(parsed);
+  const status = asString(result.status);
+  if (status && status !== "SUCCESS" && status !== "OK") {
+    throw new Error(asString(result.error) ?? `agy-usage: quota command failed (${status}).`);
+  }
+  const command = asRecord(result.command);
+  if (command && asString(command.name) && command.name !== "usage") {
+    throw new Error(`agy-usage: expected usage command, got "${asString(command.name)}".`);
+  }
+  const data = asRecord(command?.data) ?? asRecord(result.data);
+  const groups = Array.isArray(data?.groups)
+    ? data.groups.map(parseGroup).filter((group): group is AgyUsageGroup => group !== undefined)
+    : [];
+  if (groups.length === 0) {
+    throw new Error("agy-usage: no quota groups returned.");
+  }
+  return { description: asString(data?.description), groups };
+}
+
+const BAR_SEGMENTS = 20;
+const LABEL_COLUMN = 18;
+
+/** Remaining allowance as a 0–100 percentage. */
+export function remainingPercent(fraction: number): number {
+  return Math.round(Math.min(1, Math.max(0, fraction)) * 100);
+}
+
+function padTime(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+/** Clock-style reset matching pi-usage `/usage`: `14:30` today or `09:10 on 4 Sep`. */
+export function formatReset(iso: string, now: Date = new Date()): string | undefined {
+  const reset = new Date(iso);
+  if (Number.isNaN(reset.getTime())) return undefined;
+  const time = `${padTime(reset.getHours())}:${padTime(reset.getMinutes())}`;
+  if (reset.toDateString() === now.toDateString()) return time;
+  return `${time} on ${reset.getDate()} ${reset.toLocaleDateString("en-US", { month: "short" })}`;
+}
+
+export function usageBar(fraction: number, segments = BAR_SEGMENTS): string {
+  const filled = Math.round(Math.min(1, Math.max(0, fraction)) * segments);
+  return `[${"█".repeat(filled)}${"░".repeat(segments - filled)}]`;
+}
+
+/** Window label matching `/usage` (`weekly` → `Weekly limit`, `5h` → `5h limit`). */
+export function usageWindowLabel(bucket: AgyUsageBucket): string {
+  const window = bucket.window.toLowerCase();
+  if (window === "weekly" || window.includes("week")) return "Weekly limit";
+  if (window === "5h" || window.includes("5") || window.includes("hour")) return "5h limit";
+  const stripped = bucket.name.replace(/\s*limit remaining$/i, "").trim() || bucket.name;
+  return /limit$/i.test(stripped) ? stripped : `${stripped} limit`;
+}
+
+function windowRank(bucket: AgyUsageBucket): number {
+  const window = bucket.window.toLowerCase();
+  if (window === "5h" || window.includes("hour") || /\b5h\b/.test(window)) return 0;
+  if (window === "weekly" || window.includes("week")) return 1;
+  return 2;
+}
+
+function formatBucket(bucket: AgyUsageBucket, now: Date): string {
+  const label = `${usageWindowLabel(bucket)}:`.padEnd(LABEL_COLUMN);
+  const percent = remainingPercent(bucket.remainingFraction);
+  const parts = [`${usageBar(bucket.remainingFraction)} ${percent}% left`];
+  const reset = bucket.resetTime ? formatReset(bucket.resetTime, now) : undefined;
+  if (reset) parts.push(`resets ${reset}`);
+  return `  ${label}${parts.join(" · ")}`;
+}
+
+/** Multi-line report in the same layout as pi-usage `/usage`. */
+export function formatAgyUsageReport(report: AgyUsageReport, now: Date = new Date()): string {
+  return report.groups
+    .map((group) => {
+      const buckets = [...group.buckets].sort((a, b) => windowRank(a) - windowRank(b));
+      const lines = [group.name];
+      for (let i = 0; i < buckets.length; i++) {
+        if (i > 0) lines.push("");
+        lines.push(formatBucket(buckets[i], now));
+      }
+      return lines.join("\n");
+    })
+    .join("\n\n");
+}
+
+export function buildAgyUsageArgs(timeoutMs = USAGE_TIMEOUT_MS): string[] {
+  const timeout = Math.max(1, Math.ceil(timeoutMs / 1000));
+  // Slash expansion is the whole point: do NOT pass --disable-slash-commands.
+  // --print consumes the next token as the prompt, so /usage must follow it.
+  return ["--print", "/usage", "--output-format", "json", "--print-timeout", `${timeout}s`];
+}
+
+function defaultExec(
+  file: string,
+  args: readonly string[],
+  options: { timeout?: number; signal?: AbortSignal; encoding?: string; maxBuffer?: number },
+  callback: (error: Error | null, stdout: string, stderr: string) => void,
+): void {
+  execFile(file, [...args], { ...options, encoding: "utf8" }, (error, stdout, stderr) => {
+    callback(error, String(stdout), String(stderr));
+  });
+}
+
+/** Run `agy --print /usage` and parse the structured quota payload. */
+export function fetchAgyUsage(options: FetchAgyUsageOptions = {}): Promise<AgyUsageReport> {
+  const binary = options.binary ?? AGY_BINARY;
+  const timeoutMs = options.timeoutMs ?? USAGE_TIMEOUT_MS;
+  const run = options.execFileOverride ?? defaultExec;
+  return new Promise((resolve, reject) => {
+    run(
+      binary,
+      buildAgyUsageArgs(timeoutMs),
+      { timeout: timeoutMs, signal: options.signal, encoding: "utf8", maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          if (options.signal?.aborted || error.name === "AbortError") {
+            const abort = new Error(error.message);
+            abort.name = "AbortError";
+            reject(abort);
+            return;
+          }
+          reject(new Error(stderr.trim() || error.message));
+          return;
+        }
+        try {
+          resolve(parseAgyUsageJson(stdout));
+        } catch (parseError) {
+          reject(parseError);
+        }
+      },
+    );
+  });
+}

--- a/packages/pi-antigravity/lib/usage.ts
+++ b/packages/pi-antigravity/lib/usage.ts
@@ -61,7 +61,10 @@ function asNumber(value: unknown): number | undefined {
 function unwrapResult(parsed: unknown): Record<string, unknown> {
   const root = asRecord(parsed);
   if (!root) throw new Error("agy-usage: quota response was not an object.");
-  if (root.event === "result" && asRecord(root.result)) return asRecord(root.result)!;
+  if (root.event === "result") {
+    const inner = asRecord(root.result);
+    if (inner) return inner;
+  }
   return root;
 }
 
@@ -89,7 +92,9 @@ function parseGroup(value: unknown): AgyUsageGroup | undefined {
   const name = asString(rec.name);
   if (!name) return undefined;
   const buckets = Array.isArray(rec.buckets)
-    ? rec.buckets.map(parseBucket).filter((bucket): bucket is AgyUsageBucket => bucket !== undefined)
+    ? rec.buckets
+        .map(parseBucket)
+        .filter((bucket): bucket is AgyUsageBucket => bucket !== undefined)
     : [];
   return { name, description: asString(rec.description), buckets };
 }

--- a/packages/pi-antigravity/package.json
+++ b/packages/pi-antigravity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tian.zuo/pi-antigravity",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Use Antigravity (agy) models inside the pi coding agent via the agy stream-json RPC, with pi as the UI.",
   "type": "module",
   "keywords": [

--- a/packages/pi-antigravity/package.json
+++ b/packages/pi-antigravity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tian.zuo/pi-antigravity",
-  "version": "0.8.0",
+  "version": "0.7.3",
   "description": "Use Antigravity (agy) models inside the pi coding agent via the agy stream-json RPC, with pi as the UI.",
   "type": "module",
   "keywords": [

--- a/packages/pi-antigravity/src/usage-ui.ts
+++ b/packages/pi-antigravity/src/usage-ui.ts
@@ -1,0 +1,97 @@
+/**
+ * /agy-usage UI — same interaction as pi-usage `/usage`: a cancellable loader,
+ * then ctx.ui.select with the formatted report as the title and Refresh / Close.
+ * Data comes from lib/usage.ts (`agy --print /usage`).
+ */
+
+import { BorderedLoader, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { formatAgyUsageReport, type AgyUsageReport } from "../lib/usage.ts";
+
+const REFRESH = "Refresh";
+const CLOSE = "Close";
+
+type LoaderResult<T> = { ok: true; value: T } | { ok: false; error: unknown } | null;
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+async function runWithLoader<T>(
+  ctx: ExtensionCommandContext,
+  label: string,
+  parentSignal: AbortSignal,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T | undefined> {
+  if (ctx.mode !== "tui") return operation(parentSignal);
+  const result = await ctx.ui.custom<LoaderResult<T>>((tui, theme, _keybindings, done) => {
+    const loader = new BorderedLoader(tui, theme, label, { cancellable: true });
+    let finished = false;
+    const finish = (value: LoaderResult<T>) => {
+      if (finished) return;
+      finished = true;
+      done(value);
+    };
+    loader.onAbort = () => finish(null);
+    const signal = AbortSignal.any([parentSignal, loader.signal]);
+    void operation(signal)
+      .then((value) => finish({ ok: true, value }))
+      .catch((error) => {
+        if (isAbortError(error)) finish(null);
+        else finish({ ok: false, error });
+      });
+    return loader;
+  });
+  if (!result) return undefined;
+  if (!result.ok) throw result.error;
+  return result.value;
+}
+
+function notifyError(ctx: ExtensionCommandContext, error: unknown): void {
+  ctx.ui.notify(`agy-usage: ${error instanceof Error ? error.message : error}`, "error");
+}
+
+/** Entry point: fetch quotas (with a TUI loader) and open the /usage-style menu. */
+export async function openAgyUsagePicker(
+  ctx: ExtensionCommandContext,
+  fetchReport: (signal?: AbortSignal) => Promise<AgyUsageReport>,
+): Promise<void> {
+  if (!ctx.hasUI) {
+    try {
+      ctx.ui.notify(formatAgyUsageReport(await fetchReport()), "info");
+    } catch (error) {
+      notifyError(ctx, error);
+    }
+    return;
+  }
+
+  const controller = new AbortController();
+  try {
+    let report = await runWithLoader(ctx, "Checking agy quota…", controller.signal, fetchReport);
+    if (!report) return;
+    while (!controller.signal.aborted) {
+      const action = await ctx.ui.select(formatAgyUsageReport(report), [REFRESH, CLOSE], {
+        signal: controller.signal,
+      });
+      if (!action || action === CLOSE) return;
+      if (action === REFRESH) {
+        try {
+          const refreshed = await runWithLoader(
+            ctx,
+            "Refreshing usage…",
+            controller.signal,
+            fetchReport,
+          );
+          if (refreshed) report = refreshed;
+        } catch (error) {
+          if (isAbortError(error)) return;
+          notifyError(ctx, error);
+        }
+      }
+    }
+  } catch (error) {
+    if (isAbortError(error)) return;
+    notifyError(ctx, error);
+  } finally {
+    controller.abort();
+  }
+}

--- a/packages/pi-antigravity/test/usage.test.ts
+++ b/packages/pi-antigravity/test/usage.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildAgyUsageArgs,
+  fetchAgyUsage,
+  formatAgyUsageReport,
+  formatReset,
+  parseAgyUsageJson,
+  remainingPercent,
+  usageBar,
+  usageWindowLabel,
+  type FetchAgyUsageOptions,
+} from "../lib/usage.ts";
+
+const USAGE_JSON = `{
+  "conversation_id": "",
+  "status": "SUCCESS",
+  "response": "Gemini Models\\tWeekly Limit Remaining\\t97%\\t2026-09-04T01:10:30Z\\n",
+  "duration_seconds": 0,
+  "num_turns": 0,
+  "usage": { "input_tokens": 0, "output_tokens": 0, "total_tokens": 0 },
+  "command": {
+    "name": "usage",
+    "data": {
+      "description": "Within each group, models share a weekly limit and a 5-hour limit.",
+      "groups": [
+        {
+          "name": "Gemini Models",
+          "description": "Models within this group: Gemini Flash, Gemini Pro",
+          "buckets": [
+            {
+              "id": "gemini-weekly",
+              "name": "Weekly Limit Remaining",
+              "window": "weekly",
+              "remaining_fraction": 0.9719216227531433,
+              "reset_time": "2026-09-04T01:10:30Z"
+            },
+            {
+              "id": "gemini-5h",
+              "name": "Five Hour Limit Remaining",
+              "window": "5h",
+              "remaining_fraction": 0.9795392751693726,
+              "reset_time": "2026-08-28T11:53:42Z"
+            }
+          ]
+        },
+        {
+          "name": "Claude and GPT models",
+          "description": "Models within this group: Claude Opus, Claude Sonnet, GPT-OSS",
+          "buckets": [
+            {
+              "id": "3p-weekly",
+              "name": "Weekly Limit Remaining",
+              "window": "weekly",
+              "remaining_fraction": 1,
+              "reset_time": "2026-09-04T07:08:42Z"
+            },
+            {
+              "id": "3p-5h",
+              "name": "Five Hour Limit Remaining",
+              "window": "5h",
+              "remaining_fraction": 1,
+              "reset_time": "2026-08-28T12:08:42Z"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}`;
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+function fakeExec(
+  impl: (file: string, args: readonly string[], cb: ExecCallback) => void,
+): NonNullable<FetchAgyUsageOptions["execFileOverride"]> {
+  return (file, args, _opts, cb) => {
+    impl(file, args, cb);
+  };
+}
+
+test("buildAgyUsageArgs expands /usage in print mode without disabling slash commands", () => {
+  const args = buildAgyUsageArgs(30_000);
+  assert.deepEqual(args, [
+    "--print",
+    "/usage",
+    "--output-format",
+    "json",
+    "--print-timeout",
+    "30s",
+  ]);
+  assert.ok(!args.includes("--disable-slash-commands"));
+  assert.ok(!args.includes("--dangerously-skip-permissions"));
+  assert.ok(!args.includes("--conversation"));
+});
+
+test("parseAgyUsageJson reads groups and remaining fractions from command.data", () => {
+  const report = parseAgyUsageJson(USAGE_JSON);
+  assert.equal(report.groups.length, 2);
+  assert.equal(report.groups[0].name, "Gemini Models");
+  assert.equal(report.groups[0].buckets[0].id, "gemini-weekly");
+  assert.equal(report.groups[0].buckets[0].remainingFraction, 0.9719216227531433);
+  assert.equal(report.groups[1].buckets[1].remainingFraction, 1);
+  assert.match(report.description ?? "", /weekly limit/);
+});
+
+test("parseAgyUsageJson unwraps a stream-json result envelope", () => {
+  const report = parseAgyUsageJson(
+    JSON.stringify({ event: "result", result: JSON.parse(USAGE_JSON) }),
+  );
+  assert.equal(report.groups[0].name, "Gemini Models");
+});
+
+test("parseAgyUsageJson rejects invalid JSON, failed status, and empty groups", () => {
+  assert.throws(() => parseAgyUsageJson("not-json"), /not valid JSON/);
+  assert.throws(
+    () => parseAgyUsageJson(JSON.stringify({ status: "ERROR", error: "not logged in" })),
+    /not logged in/,
+  );
+  assert.throws(
+    () => parseAgyUsageJson(JSON.stringify({ status: "SUCCESS", command: { name: "tasks" } })),
+    /expected usage command/,
+  );
+  assert.throws(
+    () =>
+      parseAgyUsageJson(
+        JSON.stringify({ status: "SUCCESS", command: { name: "usage", data: { groups: [] } } }),
+      ),
+    /no quota groups/,
+  );
+});
+
+test("remainingPercent and usageBar clamp and round", () => {
+  assert.equal(remainingPercent(0.9719216227531433), 97);
+  assert.equal(remainingPercent(1), 100);
+  assert.equal(remainingPercent(0), 0);
+  assert.equal(remainingPercent(1.5), 100);
+  assert.equal(remainingPercent(-0.2), 0);
+  assert.equal(usageBar(1, 4), "[████]");
+  assert.equal(usageBar(0, 4), "[░░░░]");
+  assert.equal(usageBar(0.5, 4), "[██░░]");
+});
+
+test("usageWindowLabel matches /usage window names", () => {
+  assert.equal(
+    usageWindowLabel({
+      id: "gemini-weekly",
+      name: "Weekly Limit Remaining",
+      window: "weekly",
+      remainingFraction: 1,
+    }),
+    "Weekly limit",
+  );
+  assert.equal(
+    usageWindowLabel({
+      id: "gemini-5h",
+      name: "Five Hour Limit Remaining",
+      window: "5h",
+      remainingFraction: 1,
+    }),
+    "5h limit",
+  );
+});
+
+test("formatReset uses local clock time like /usage", () => {
+  const now = new Date(2026, 7, 28, 12, 0, 0);
+  const laterToday = new Date(2026, 7, 28, 19, 53, 0);
+  const nextWeek = new Date(2026, 8, 4, 9, 10, 0);
+  assert.equal(formatReset(laterToday.toISOString(), now), "19:53");
+  assert.equal(formatReset(nextWeek.toISOString(), now), "09:10 on 4 Sep");
+  assert.equal(formatReset("not-a-date", now), undefined);
+});
+
+test("formatAgyUsageReport matches the /usage layout", () => {
+  const report = parseAgyUsageJson(USAGE_JSON);
+  const now = new Date("2026-08-28T07:08:42Z");
+  const lines = formatAgyUsageReport(report, now).split("\n");
+  assert.equal(lines[0], "Gemini Models");
+  assert.match(lines[1], /^  5h limit:\s+\[█+░*\] 98% left · resets /);
+  assert.equal(lines[2], "");
+  assert.match(lines[3], /^  Weekly limit:\s+\[█+░*\] 97% left · resets /);
+  assert.equal(lines[4], "");
+  assert.equal(lines[5], "Claude and GPT models");
+  assert.match(lines[6], /^  5h limit:\s+\[█{20}\] 100% left · resets /);
+  assert.equal(lines[7], "");
+  assert.match(lines[8], /^  Weekly limit:\s+\[█{20}\] 100% left · resets /);
+  assert.equal(lines[1].indexOf("5h limit:"), 2);
+  assert.equal(lines[1].indexOf("["), 20);
+});
+
+test("fetchAgyUsage parses stdout from the injected exec", async () => {
+  const captured: { file: string; args: readonly string[] } = { file: "", args: [] };
+  const report = await fetchAgyUsage({
+    binary: "agy-test",
+    execFileOverride: fakeExec((file, args, cb) => {
+      captured.file = file;
+      captured.args = args;
+      queueMicrotask(() => cb(null, USAGE_JSON, ""));
+    }),
+  });
+  assert.equal(captured.file, "agy-test");
+  assert.equal(captured.args[1], "/usage");
+  assert.ok(!captured.args.includes("--disable-slash-commands"));
+  assert.equal(report.groups.length, 2);
+});
+
+test("fetchAgyUsage surfaces stderr when the process fails", async () => {
+  await assert.rejects(
+    () =>
+      fetchAgyUsage({
+        execFileOverride: fakeExec((_file, _args, cb) => {
+          queueMicrotask(() =>
+            cb(Object.assign(new Error("spawn failed"), { code: 1 }), "", "not logged in\n"),
+          );
+        }),
+      }),
+    /not logged in/,
+  );
+});
+
+test("fetchAgyUsage preserves AbortError when the caller cancels", async () => {
+  const signal = AbortSignal.abort();
+  await assert.rejects(
+    () =>
+      fetchAgyUsage({
+        signal,
+        execFileOverride: fakeExec((_file, _args, cb) => {
+          const err = Object.assign(new Error("aborted"), { name: "AbortError" });
+          queueMicrotask(() => cb(err, "", ""));
+        }),
+      }),
+    (error: unknown) => error instanceof Error && error.name === "AbortError",
+  );
+});

--- a/packages/pi-antigravity/test/usage.test.ts
+++ b/packages/pi-antigravity/test/usage.test.ts
@@ -176,14 +176,14 @@ test("formatAgyUsageReport matches the /usage layout", () => {
   const now = new Date("2026-08-28T07:08:42Z");
   const lines = formatAgyUsageReport(report, now).split("\n");
   assert.equal(lines[0], "Gemini Models");
-  assert.match(lines[1], /^  5h limit:\s+\[█+░*\] 98% left · resets /);
+  assert.match(lines[1], /^ {2}5h limit:\s+\[█+░*\] 98% left · resets /);
   assert.equal(lines[2], "");
-  assert.match(lines[3], /^  Weekly limit:\s+\[█+░*\] 97% left · resets /);
+  assert.match(lines[3], /^ {2}Weekly limit:\s+\[█+░*\] 97% left · resets /);
   assert.equal(lines[4], "");
   assert.equal(lines[5], "Claude and GPT models");
-  assert.match(lines[6], /^  5h limit:\s+\[█{20}\] 100% left · resets /);
+  assert.match(lines[6], /^ {2}5h limit:\s+\[█{20}\] 100% left · resets /);
   assert.equal(lines[7], "");
-  assert.match(lines[8], /^  Weekly limit:\s+\[█{20}\] 100% left · resets /);
+  assert.match(lines[8], /^ {2}Weekly limit:\s+\[█{20}\] 100% left · resets /);
   assert.equal(lines[1].indexOf("5h limit:"), 2);
   assert.equal(lines[1].indexOf("["), 20);
 });


### PR DESCRIPTION
## Summary
- Port Antigravity's `/usage` slash command into pi as `/agy-usage`, fetching weekly and 5-hour quotas via `agy --print /usage` (zero tokens).
- Present the same Refresh/Close menu layout as `/usage` (padded labels, remaining bars, clock-style reset times).
- Document the command with a demo display in the package README and list it in the repo index. Package version is 0.8.0.

## Test plan
- [x] `pnpm --filter @tian.zuo/pi-antigravity test`
- [x] `pi -e ./packages/pi-antigravity` then run `/agy-usage` while logged into agy
- [x] Confirm Gemini and Claude/GPT groups show 5h + weekly bars with reset times
- [x] Press Refresh and confirm quotas re-query; Close dismisses the menu
- [x] In print/RPC mode, `/agy-usage` prints the same numbers as a notification


Made with [Cursor](https://cursor.com)