### PR TITLE
chore: add per-extension release notes

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,15 @@
+# Changesets
+
+Every publishable extension change needs a changeset. Run:
+
+```bash
+pnpm changeset
+```
+
+Select the affected package, choose the semantic version bump, and write the
+user-facing release note. Commit the generated Markdown file with the change.
+Do not edit package versions or changelogs manually.
+
+After changes reach `main`, the publish workflow opens or updates a release PR.
+Merging that PR publishes each changed package, updates its `CHANGELOG.md`, and
+creates a package-specific GitHub release.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
+  "baseBranch": "main",
+  "access": "public",
+  "format": "auto",
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "TianZuo555/pi-extensions" }
+  ],
+  "commit": false,
+  "ignore": [],
+  "fixed": [],
+  "linked": [],
+  "updateInternalDependencies": "patch",
+  "privatePackages": {
+    "version": false,
+    "tag": false
+  }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,11 +5,14 @@ on:
     branches: [main]
     paths:
       - "packages/**"
+      - ".changeset/**"
       - ".github/workflows/publish.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Run in dry-run mode (no actual publish)"
+        description: "Preview pending releases without publishing"
         type: boolean
         default: false
 
@@ -21,11 +24,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write # required for npm provenance
+      contents: write
+      pull-requests: write
+      id-token: write # required for npm trusted publishing and provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -52,12 +58,20 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-      - name: Publish changed packages
+      - name: Preview pending releases
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         env:
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          published_any=false
+          pnpm changeset:status
+          if find .changeset -maxdepth 1 -type f -name '*.md' ! -name README.md | grep -q .; then
+            pnpm version-packages
+          else
+            echo "No pending changesets; previewing unpublished manifest versions."
+          fi
+
+          found=false
           for dir in packages/*/; do
             [ -f "$dir/package.json" ] || continue
 
@@ -65,26 +79,27 @@ jobs:
             version=$(node -p "require('./$dir/package.json').version")
             private=$(node -p "Boolean(require('./$dir/package.json').private)")
 
-            if [ "$private" = "true" ]; then
-              echo "⏭  $name is private, skipping"
+            if [ "$private" = "true" ] || npm view "$name@$version" version >/dev/null 2>&1; then
               continue
             fi
 
-            if npm view "$name@$version" version >/dev/null 2>&1; then
-              echo "✔  $name@$version already published, skipping"
-              continue
-            fi
-
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "🧪 [dry-run] would publish $name@$version"
-              (cd "$dir" && npm publish --dry-run --provenance --access public)
-            else
-              echo "🚀 Publishing $name@$version"
-              (cd "$dir" && npm publish --provenance --access public)
-              published_any=true
-            fi
+            found=true
+            echo "🧪 [dry-run] would publish $name@$version"
+            (cd "$dir" && npm publish --dry-run --provenance --access public)
           done
 
-          if [ "$published_any" = "false" ] && [ "$DRY_RUN" != "true" ]; then
-            echo "No new package versions to publish."
+          if [ "$found" = "false" ]; then
+            echo "No unpublished package versions found."
           fi
+
+      - name: Create release PR or publish packages
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+        uses: changesets/action@v2
+        with:
+          version-script: pnpm version-packages
+          publish-script: pnpm release
+          pr-title: "chore: release extensions"
+          commit-message: "chore: release extensions"
+          create-github-releases: true
+        env:
+          NPM_CONFIG_PROVENANCE: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,5 +24,5 @@ A collection of independent extensions for the [pi coding agent](https://pi.dev)
 - **TUI Width Safety:** All renderers (`Component.render(width)`, `setWidget`, tool renderers) must guarantee `visibleWidth(line) <= width` (e.g., via ANSI-aware truncation or wrapping).
 - **Prompt Separation:** Keep all model-facing text (tool descriptions, system prompts, schema strings) in a dedicated `prompt.ts` module (`lib/prompt.ts` or `src/prompt.ts`), separated from runtime execution logic.
 - **State & Auth:** Machine-local state and caches belong under `~/.pi/...`, never inside the repository.
-- **Publishing & Versioning:** Bump `version` in `packages/<pkg>/package.json` when modifying an extension. To temporarily disable CI publishing for a package, set `"private": true` in its `package.json`.
+- **Publishing & Versioning:** Add a Changeset (`pnpm changeset`) for every publishable extension change; do not edit package versions or changelogs manually. To temporarily disable CI publishing for a package, set `"private": true` in its `package.json`.
 - **Pre-push Verification:** Ensure `pnpm run typecheck`, `pnpm run check`, and `pnpm test` pass before committing.

--- a/README.md
+++ b/README.md
@@ -80,18 +80,23 @@ Extensions import pi's runtime packages (`@earendil-works/*`, `typebox`) as
 
 ## Publishing
 
-The [`Publish`](.github/workflows/publish.yml) workflow publishes to npm on
-every push to `main` that touches `packages/**`: it runs the checks and test
-suites, compares each workspace's version against npm, and publishes only
-versions not yet present — bumping one `package.json` version is enough to
-release it. Packages are published with npm provenance via OIDC trusted
-publishing (no token secret needed). The workflow can also be run manually
-from *Actions → Publish* with an optional dry-run toggle.
+Releases use [Changesets](https://github.com/changesets/changesets). For every
+publishable extension change, run `pnpm changeset`, select the package and
+semantic version bump, and commit the generated release-note file. Do not bump
+package versions manually.
 
-Manual publish for a single package:
+On pushes to `main`, the [`Publish`](.github/workflows/publish.yml) workflow
+runs all checks and opens or updates a release PR. Merging that PR publishes
+each changed package to npm, updates its package-specific `CHANGELOG.md`, and
+creates a separate tagged GitHub release. npm trusted publishing supplies OIDC
+provenance without a token secret. The workflow can also be run manually from
+*Actions → Publish* in dry-run mode to preview pending releases. The repository
+must allow GitHub Actions to create pull requests under *Settings → Actions →
+General → Workflow permissions*.
 
 ```bash
-pnpm --filter @tian.zuo/pi-commit publish --access public --no-git-checks
+pnpm changeset          # add release notes for changed packages
+pnpm changeset:status   # inspect pending releases
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pi-extensions",
   "version": "0.1.0",
+  "private": true,
   "description": "A collection of extensions for the pi coding agent: per-repository defaults, skill toggles, commits, token speed, and more.",
   "type": "module",
   "packageManager": "pnpm@11.21.0",
@@ -65,6 +66,10 @@
     "test:vscode-bridge": "pnpm --filter @tian.zuo/pi-vscode-bridge test",
     "test:web-search": "pnpm --filter @tian.zuo/pi-web-search test",
     "test:find": "pnpm --filter @tian.zuo/pi-find test",
+    "changeset": "changeset",
+    "changeset:status": "changeset status",
+    "version-packages": "changeset version",
+    "release": "changeset publish",
     "pack:check": "pnpm -r pack --dry-run"
   },
   "peerDependencies": {
@@ -75,6 +80,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.10",
+    "@changesets/changelog-github": "^1.0.0",
+    "@changesets/cli": "^3.0.1",
     "@earendil-works/pi-ai": "^0.84.2",
     "@earendil-works/pi-coding-agent": "^0.84.2",
     "@earendil-works/pi-tui": "^0.84.2",

--- a/packages/pi-antigravity/CHANGELOG.md
+++ b/packages/pi-antigravity/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-antigravity
+
+## 0.7.3
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-antigravity/README.md
+++ b/packages/pi-antigravity/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-antigravity
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-antigravity/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Use **Google Antigravity** (`agy`) models inside the [pi coding agent](https://pi.dev). pi stays your UI — chat, model picker, tool cards, sessions — while the selected Antigravity model runs underneath through the `agy` CLI.
 
 ## Highlights

--- a/packages/pi-antigravity/package.json
+++ b/packages/pi-antigravity/package.json
@@ -26,7 +26,8 @@
   "files": [
     "index.ts",
     "lib",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-ask-user/CHANGELOG.md
+++ b/packages/pi-ask-user/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-ask-user
+
+## 0.2.1
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-ask-user/README.md
+++ b/packages/pi-ask-user/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-ask-user
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-ask-user/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Let the model ask you a multiple-choice question from [pi](https://pi.dev).
 
 > **Token-light by design.** The entire model-facing surface — tool description, schema docs, and three guideline bullets — totals **≈560 characters**. The most-downloaded alternative `ask_user` package ([@eko24ive/pi-ask](https://www.npmjs.com/package/@eko24ive/pi-ask)) spends ≈1,700 on its tool description and schema alone, and popular pi extensions generally run 2–3k (pi-mcp-adapter: ≈2.5k across 12 tools; pi-web-access: ≈3.2k on `web_search` alone). Same interactive form, a third of the prompt weight — the wording lives in one small `lib/prompt.ts` instead of prose sprayed through the schema.

--- a/packages/pi-ask-user/package.json
+++ b/packages/pi-ask-user/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "index.ts",
-    "lib"
+    "lib",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-background-terminals/CHANGELOG.md
+++ b/packages/pi-background-terminals/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-background-terminals
+
+## 0.5.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-background-terminals/README.md
+++ b/packages/pi-background-terminals/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-background-terminals
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-background-terminals/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 A managed replacement for Pi's built-in `bash` tool.
 
 Every model shell command follows one path: start it, wait briefly, and return

--- a/packages/pi-background-terminals/package.json
+++ b/packages/pi-background-terminals/package.json
@@ -27,7 +27,8 @@
   "files": [
     "index.ts",
     "src",
-    "docs"
+    "docs",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-commit/CHANGELOG.md
+++ b/packages/pi-commit/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-commit
+
+## 0.1.1
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-commit/README.md
+++ b/packages/pi-commit/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-commit
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-commit/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Generate and review Git commit messages with a dedicated model without changing the model used by the current Pi session.
 
 ## Commands

--- a/packages/pi-commit/package.json
+++ b/packages/pi-commit/package.json
@@ -25,7 +25,8 @@
   "files": [
     "index.ts",
     "lib",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-compact-output/CHANGELOG.md
+++ b/packages/pi-compact-output/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-compact-output
+
+## 0.1.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-compact-output/README.md
+++ b/packages/pi-compact-output/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-compact-output
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-compact-output/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 TUI-only [pi coding agent](https://pi.dev) extension that keeps the transcript compact without changing tool execution, schemas, results, or session data.
 
 ## What it does

--- a/packages/pi-compact-output/package.json
+++ b/packages/pi-compact-output/package.json
@@ -28,7 +28,8 @@
     "index.ts",
     "lib",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-edit-safe/CHANGELOG.md
+++ b/packages/pi-edit-safe/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-edit-safe
+
+## 0.1.1
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-edit-safe/README.md
+++ b/packages/pi-edit-safe/README.md
@@ -1,5 +1,7 @@
 # pi-edit-safe
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-edit-safe/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 A drop-in replacement for the **pi coding agent**'s built-in `edit` tool, with a
 stricter matcher that refuses to silently edit the wrong place — and a call shape
 that weaker models can actually use.

--- a/packages/pi-edit-safe/package.json
+++ b/packages/pi-edit-safe/package.json
@@ -24,7 +24,8 @@
   "files": [
     "index.ts",
     "lib",
-    "NOTICES.md"
+    "NOTICES.md",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-find/CHANGELOG.md
+++ b/packages/pi-find/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-find
+
+## 0.3.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-find/README.md
+++ b/packages/pi-find/README.md
@@ -1,5 +1,7 @@
 # pi-find
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-find/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Simple, bounded `grep` and `find` tools for the [pi coding agent](https://pi.dev),
 backed by ripgrep and fd.
 

--- a/packages/pi-find/package.json
+++ b/packages/pi-find/package.json
@@ -29,7 +29,8 @@
     "lib",
     "src",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-goal/CHANGELOG.md
+++ b/packages/pi-goal/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-goal
+
+## 0.2.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -1,5 +1,7 @@
 # pi-goal
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-goal/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 A Codex-style persistent goal mode for the **pi coding agent**. It turns a
 thread into a bounded work loop: an explicit objective is persisted in the
 session, injected into each model turn, checked against evidence, and continued

--- a/packages/pi-goal/package.json
+++ b/packages/pi-goal/package.json
@@ -25,7 +25,8 @@
   "files": [
     "index.ts",
     "lib",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-image-cache/CHANGELOG.md
+++ b/packages/pi-image-cache/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-image-cache
+
+## 0.1.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-image-cache/README.md
+++ b/packages/pi-image-cache/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-image-cache
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-image-cache/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Temporary pasted-image caching with compact placeholders for the [pi coding agent](https://pi.dev).
 
 ```bash

--- a/packages/pi-image-cache/package.json
+++ b/packages/pi-image-cache/package.json
@@ -24,7 +24,8 @@
   "files": [
     "index.ts",
     "lib",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-repo-model/CHANGELOG.md
+++ b/packages/pi-repo-model/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-repo-model
+
+## 0.1.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-repo-model/README.md
+++ b/packages/pi-repo-model/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-repo-model
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-repo-model/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Per-repository default model and thinking-level preferences for the [pi coding agent](https://pi.dev).
 
 ```bash

--- a/packages/pi-repo-model/package.json
+++ b/packages/pi-repo-model/package.json
@@ -24,7 +24,8 @@
   "files": [
     "index.ts",
     "lib",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-repo-skills/CHANGELOG.md
+++ b/packages/pi-repo-skills/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-repo-skills
+
+## 0.1.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-repo-skills/README.md
+++ b/packages/pi-repo-skills/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-repo-skills
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-repo-skills/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Per-repository skill enable and disable controls for the [pi coding agent](https://pi.dev).
 
 ```bash

--- a/packages/pi-repo-skills/package.json
+++ b/packages/pi-repo-skills/package.json
@@ -24,7 +24,8 @@
   "files": [
     "index.ts",
     "lib",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-subagents/CHANGELOG.md
+++ b/packages/pi-subagents/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-subagents
+
+## 0.1.1
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-subagents
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-subagents/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Delegate bounded tasks to isolated subagent runs from [pi](https://pi.dev). Each profile can run on a **Herdr pane backend** (interactive agent CLIs in dedicated panes) or fall back to the legacy **RPC child backend** (`pi --mode rpc` headless children).
 
 ```bash

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -27,7 +27,8 @@
     "src",
     "profiles",
     "docs",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-todo/CHANGELOG.md
+++ b/packages/pi-todo/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-todo
+
+## 0.1.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -1,5 +1,7 @@
 # pi-todo
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-todo/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 A small `todo` tool for the **pi coding agent**.
 
 Install: `npm:@tian.zuo/pi-todo` · npm package `@tian.zuo/pi-todo` · workspace `packages/pi-todo`

--- a/packages/pi-todo/package.json
+++ b/packages/pi-todo/package.json
@@ -24,7 +24,8 @@
   "files": [
     "index.ts",
     "lib",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-token-speed/CHANGELOG.md
+++ b/packages/pi-token-speed/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-token-speed
+
+## 0.1.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-token-speed/README.md
+++ b/packages/pi-token-speed/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-token-speed
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-token-speed/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Live and final tokens-per-second reporting for the [pi coding agent](https://pi.dev).
 
 ```bash

--- a/packages/pi-token-speed/package.json
+++ b/packages/pi-token-speed/package.json
@@ -24,7 +24,8 @@
   "files": [
     "index.ts",
     "lib",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-usage/CHANGELOG.md
+++ b/packages/pi-usage/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-usage
+
+## 0.1.2
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-usage/README.md
+++ b/packages/pi-usage/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-usage
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-usage/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Show **OpenAI Codex**, **GitHub Copilot**, **Z.ai (GLM Coding Plan)**,
 **Z.ai Coding Plan (China)**, and **DeepSeek** account usage from inside the
 [pi coding agent](https://pi.dev), plus a `/tokens` dashboard of the token and

--- a/packages/pi-usage/package.json
+++ b/packages/pi-usage/package.json
@@ -37,7 +37,8 @@
   "files": [
     "index.ts",
     "lib",
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/packages/pi-web-search/CHANGELOG.md
+++ b/packages/pi-web-search/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @tian.zuo/pi-web-search
+
+## 0.4.0
+
+- Changelog tracking was introduced after this release.

--- a/packages/pi-web-search/README.md
+++ b/packages/pi-web-search/README.md
@@ -1,5 +1,7 @@
 # @tian.zuo/pi-web-search
 
+Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-web-search/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+
 Web search and web fetch for the [pi coding agent](https://pi.dev). Two tools, six providers plus a built-in keyless fetcher, automatic fallback — no single point of failure. **Works with zero configuration** thanks to Firecrawl's keyless tier (search + fetch, no signup).
 
 > **Token-light by design.** The whole extension adds **196 characters** of model-facing text — two tool descriptions of one sentence each. For comparison, [pi-web-access](https://www.npmjs.com/package/pi-web-access) spends ≈3,200 characters on its `web_search` tool alone (1,853-char description + parameter guidance) — **~16× our entire prompt surface**, across 4 tools vs our 2. All the routing intelligence (fallback orders, keyless ladders, quota handling) lives in extension code, not in the prompt, so the model spends its attention on your code instead of reading tool manuals.

--- a/packages/pi-web-search/package.json
+++ b/packages/pi-web-search/package.json
@@ -33,7 +33,8 @@
     "lib",
     "src",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md"
   ],
   "pi": {
     "extensions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,12 @@ importers:
       '@biomejs/biome':
         specifier: ^2.5.10
         version: 2.5.10
+      '@changesets/changelog-github':
+        specifier: ^1.0.0
+        version: 1.0.0
+      '@changesets/cli':
+        specifier: ^3.0.1
+        version: 3.0.1
       '@earendil-works/pi-ai':
         specifier: ^0.84.2
         version: 0.84.2(ws@8.21.3)(zod@4.4.3)
@@ -565,6 +571,83 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@changesets/apply-release-plan@8.0.0':
+    resolution: {integrity: sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/assemble-release-plan@7.0.0':
+    resolution: {integrity: sha512-oEW8BxdA604kGGtDSCiHr5w9Tv4UWe9I2k61IBNZzCOE1kbYaJj4v+lFQNgcEZFkUc2pV/+hASErGDvpJOZCTg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/changelog-git@1.0.0':
+    resolution: {integrity: sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/changelog-github@1.0.0':
+    resolution: {integrity: sha512-PNCSH5CGJrqOKxRjrMp2NLhceQv2QBs6HkjrLvYQqsEE2/ItN5R8GD/mskZZluoNWYvjPYFsY9T6swXfp5E0UA==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/cli@3.0.1':
+    resolution: {integrity: sha512-3IVpRSgiKDj2aRbBHKtWTXSRH2/iR3bWxau9iQUoEsZjDhRIj9nhl90k7FWMxZAJvLgJBbgMq8+qS0xQsenYsQ==}
+    engines: {node: ^22.11 || ^24 || >=26, npm: '>=10.9.0', pnpm: '>=10.0.0', yarn: '>=4.5.2'}
+    hasBin: true
+
+  '@changesets/config@4.0.0':
+    resolution: {integrity: sha512-mw95/YrkOuhZZxfnVAA4bSXOFUi+KlhzOBTM8C4x777NhUU6HWIl9Z+K+nME+E4PVsv5NQVQwTfiHihAS1A/ow==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/errors@1.0.0':
+    resolution: {integrity: sha512-ElN/mEzn6zmETgjwf5MclCMa9ef59sAR0lfO8VSYIsiRvbC2FbLB/92EoYw10Sl0kGixxHFiJZUSv7dA+YpR8g==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/format@0.1.2':
+    resolution: {integrity: sha512-Caez5XtNXCFS/G5bwyav3wuXL0tMxVd2ZGbaumWbzN08tyzO21asCw7JZhNtVsAZDCvDRUzZN+Iit9SyRITSYA==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/get-dependents-graph@3.0.0':
+    resolution: {integrity: sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/get-github-info@1.0.0':
+    resolution: {integrity: sha512-nf5zPSqEKW0eXiJ4ltbjyIQ/srUHfxbghkLCjKdOLI3LehKXhiqxXcpja39eGPaj6qqGx2lFCrLJ7VWYUf9H2w==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/git@4.0.0':
+    resolution: {integrity: sha512-uIEswpPUgzBBqrC0qg13byNaPorzhf05LE2T+gRizEKCXvMsJC6NPJp5iNDSV/gYj4Viqh09UiOF5E7XWeH5lQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/parse@1.0.0':
+    resolution: {integrity: sha512-P0iaMb9p9CRYZiTgAllEIF9AUMQHIy1G72tKlcIqJp61icZSsKQNiOPdxAMZG8m/DvZwt/oz5xEbTpike//dWg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/pre@3.0.0':
+    resolution: {integrity: sha512-Zm/6YliV/a2oeWTqHJf6KxLrQwgcK1i/BRDl2m0EKZvbnxV5fG9QRhwJJGshjsZTUTS6dkfURQ2K6aAvgNw/3Q==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/read@1.0.0':
+    resolution: {integrity: sha512-8TdE2PwG6yArPt5Ozej83Z6iHz1G8BDBKvIEKZ455MccR4K3GNbLR2XqjBxa+5yLFnEd3xAOPXYboBg1pt8stQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/should-skip-package@1.0.0':
+    resolution: {integrity: sha512-pwqoJmbONn1XgXmZXPEExgAaT+HdZLjALFTDgIm+PnS5KeO2nLtzA2/Q+4aMFY14kFMuXKG30MObhvDzWgzDgg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/types@7.0.0':
+    resolution: {integrity: sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/write@1.0.1':
+    resolution: {integrity: sha512-q/ThtP9gcnEP6xlv7LrY26C2mHqdGBti/MmOVngt/M/oIGYkssmQGxPK9WzBNt2juVcH/vml2WQ+ra8LXYOTaA==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
+
   '@earendil-works/pi-agent-core@0.84.2':
     resolution: {integrity: sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==}
     engines: {node: '>=22.19.0'}
@@ -646,6 +729,18 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
+
+  '@manypkg/find-root@3.1.0':
+    resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
+    engines: {node: '>=20.0.0'}
+
+  '@manypkg/get-packages@3.1.0':
+    resolution: {integrity: sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@manypkg/tools@2.1.2':
+    resolution: {integrity: sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==}
+    engines: {node: '>=20.0.0'}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
@@ -751,6 +846,10 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@pnpm/deps.graph-sequencer@1100.0.1':
+    resolution: {integrity: sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==}
+    engines: {node: '>=22.13'}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -987,6 +1086,10 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
@@ -1013,6 +1116,9 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  dataloader@2.2.3:
+    resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1089,6 +1195,24 @@ packages:
     resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
     engines: {node: '>=12.17.0'}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -1156,9 +1280,16 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  human-id@4.2.1:
+    resolution: {integrity: sha512-zPGsiS+dWoTZtZ4AtpA9Y+BdSFSNWvnouNlWNoUFyAM6xHOHmdCvqO3k8AIbdamCOv4gUFUVNPf6rJFfc4UiJw==}
+    hasBin: true
+
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   ini@7.0.0:
     resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
@@ -1171,12 +1302,18 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -1186,6 +1323,9 @@ packages:
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
+
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   lefthook-darwin-arm64@2.1.10:
     resolution: {integrity: sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg==}
@@ -1322,6 +1462,9 @@ packages:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
@@ -1332,6 +1475,13 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
 
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
@@ -1359,6 +1509,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1367,12 +1522,27 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   temml@0.13.4:
     resolution: {integrity: sha512-k1yolMBswx34Jw9hZn5Xh2/GBlwqlW+wiN7QaUYUMhSa1ypfti6rlCfSmCxWyooxH1G32C/Z+qVvgAsBOELZBQ==}
     engines: {node: '>=18.13.0'}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
 
   toml@4.3.0:
     resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
@@ -1704,6 +1874,131 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.10':
     optional: true
 
+  '@changesets/apply-release-plan@8.0.0':
+    dependencies:
+      '@changesets/config': 4.0.0
+      '@changesets/format': 0.1.2
+      '@changesets/git': 4.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      import-meta-resolve: 4.2.0
+      jsonc-parser: 3.3.1
+      semver: 7.8.5
+
+  '@changesets/assemble-release-plan@7.0.0':
+    dependencies:
+      '@changesets/errors': 1.0.0
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      semver: 7.8.5
+
+  '@changesets/changelog-git@1.0.0':
+    dependencies:
+      '@changesets/types': 7.0.0
+
+  '@changesets/changelog-github@1.0.0':
+    dependencies:
+      '@changesets/get-github-info': 1.0.0
+      '@changesets/types': 7.0.0
+
+  '@changesets/cli@3.0.1':
+    dependencies:
+      '@changesets/apply-release-plan': 8.0.0
+      '@changesets/assemble-release-plan': 7.0.0
+      '@changesets/changelog-git': 1.0.0
+      '@changesets/config': 4.0.0
+      '@changesets/errors': 1.0.0
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/git': 4.0.0
+      '@changesets/pre': 3.0.0
+      '@changesets/read': 1.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      '@changesets/write': 1.0.1
+      '@clack/prompts': 1.7.0
+      '@manypkg/get-packages': 3.1.0
+      '@pnpm/deps.graph-sequencer': 1100.0.1
+      cac: 7.0.0
+      import-meta-resolve: 4.2.0
+      launch-editor: 2.14.1
+      package-manager-detector: 1.8.0
+      semver: 7.8.5
+      tinyexec: 1.3.0
+
+  '@changesets/config@4.0.0':
+    dependencies:
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.7
+
+  '@changesets/errors@1.0.0': {}
+
+  '@changesets/format@0.1.2':
+    dependencies:
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
+
+  '@changesets/get-dependents-graph@3.0.0':
+    dependencies:
+      '@changesets/types': 7.0.0
+      semver: 7.8.5
+
+  '@changesets/get-github-info@1.0.0':
+    dependencies:
+      dataloader: 2.2.3
+
+  '@changesets/git@4.0.0':
+    dependencies:
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.7
+      tinyexec: 1.3.0
+
+  '@changesets/parse@1.0.0':
+    dependencies:
+      '@changesets/types': 7.0.0
+      yaml: 2.9.0
+
+  '@changesets/pre@3.0.0':
+    dependencies:
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+
+  '@changesets/read@1.0.0':
+    dependencies:
+      '@changesets/git': 4.0.0
+      '@changesets/parse': 1.0.0
+      '@changesets/types': 7.0.0
+
+  '@changesets/should-skip-package@1.0.0':
+    dependencies:
+      '@changesets/types': 7.0.0
+
+  '@changesets/types@7.0.0': {}
+
+  '@changesets/write@1.0.1':
+    dependencies:
+      '@changesets/format': 0.1.2
+      '@changesets/types': 7.0.0
+      human-id: 4.2.1
+
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@earendil-works/pi-agent-core@0.84.2(ws@8.21.3)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-ai': 0.84.2(ws@8.21.3)(zod@4.4.3)
@@ -1833,6 +2128,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@manypkg/find-root@3.1.0':
+    dependencies:
+      '@manypkg/tools': 2.1.2
+
+  '@manypkg/get-packages@3.1.0':
+    dependencies:
+      '@manypkg/find-root': 3.1.0
+      '@manypkg/tools': 2.1.2
+
+  '@manypkg/tools@2.1.2':
+    dependencies:
+      jju: 1.4.0
+      tinyglobby: 0.2.17
+      yaml: 2.9.0
+
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     optional: true
 
@@ -1899,6 +2209,8 @@ snapshots:
     optional: true
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@pnpm/deps.graph-sequencer@1100.0.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -2066,6 +2378,8 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  cac@7.0.0: {}
+
   chalk@5.6.2: {}
 
   commander@12.1.0: {}
@@ -2089,6 +2403,8 @@ snapshots:
   cssom@0.5.0: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  dataloader@2.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -2175,6 +2491,20 @@ snapshots:
     dependencies:
       pure-rand: 8.4.2
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -2258,13 +2588,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-id@4.2.1: {}
+
   ignore@7.0.5: {}
+
+  import-meta-resolve@4.2.0: {}
 
   ini@7.0.0: {}
 
   isexe@2.0.0: {}
 
   jiti@2.7.0: {}
+
+  jju@1.4.0: {}
 
   json-bigint@1.0.0:
     dependencies:
@@ -2274,6 +2610,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
+
+  jsonc-parser@3.3.1: {}
 
   jwa@2.0.1:
     dependencies:
@@ -2287,6 +2625,11 @@ snapshots:
       safe-buffer: 5.2.1
 
   kubernetes-types@1.30.0: {}
+
+  launch-editor@2.14.1:
+    dependencies:
+      picocolors: 1.1.1
+      shell-quote: 1.10.0
 
   lefthook-darwin-arm64@2.1.10:
     optional: true
@@ -2407,6 +2750,8 @@ snapshots:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
+  package-manager-detector@1.8.0: {}
+
   partial-json@0.1.7: {}
 
   path-key@3.1.1: {}
@@ -2415,6 +2760,10 @@ snapshots:
     dependencies:
       lru-cache: 11.5.2
       minipass: 7.1.3
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.7: {}
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -2446,16 +2795,29 @@ snapshots:
 
   semver@7.8.0: {}
 
+  semver@7.8.5: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.10.0: {}
+
   signal-exit@3.0.7: {}
+
+  sisteransi@1.0.5: {}
 
   temml@0.13.4:
     optional: true
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
 
   toml@4.3.0: {}
 


### PR DESCRIPTION
## Summary

- adopt Changesets v3 and `changesets/action@v2` for package-specific release PRs, tags, and GitHub releases
- add baseline `CHANGELOG.md` files for all 16 public extensions and include them in npm tarballs
- link each extension's npm README to its changelog and GitHub releases
- preserve npm trusted publishing with OIDC provenance and the manual dry-run workflow

npm does not provide a native per-version release-notes field, so the package description remains stable while release history is exposed through the README and packed changelog.

## Verification

- `pnpm run typecheck`
- `pnpm run check`
- `pnpm test`
- `pnpm run lint` (existing warnings only; no errors)
- `pnpm run pack:check`
