### PR TITLE
fix(background-terminals): prevent Windows timeout orphans

### DIFF
--- a/.changeset/strong-windows-trees.md
+++ b/.changeset/strong-windows-trees.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-background-terminals": patch
+---
+
+Force-kill Windows process trees atomically so timeouts cannot leave detached descendants running.

--- a/packages/pi-background-terminals/docs/implementation-guide.md
+++ b/packages/pi-background-terminals/docs/implementation-guide.md
@@ -419,15 +419,16 @@ so paging always advances.
 ## 13. Process lifecycle and termination
 
 Children use separate stdout/stderr pipes and no interactive stdin. On POSIX,
-`detached: true` gives the child its own process group. Windows uses `taskkill
-/T`, with `/F` for force kill.
+`detached: true` gives the child its own process group. Windows has no portable
+graceful process-tree signal, so termination uses `taskkill /F /T` on the first
+attempt. A non-forced `taskkill` can remove the shell while leaving descendants
+alive, which destroys the stable tree root before escalation can find them.
 
 Termination is:
 
 ```text
-SIGTERM whole tree
-wait up to 2 seconds for close
-SIGKILL whole tree
+POSIX:  SIGTERM whole tree → wait up to 2 seconds → SIGKILL whole tree
+Windows: taskkill /F /T whole tree → bounded close wait → forced retry if needed
 bounded final close/settle wait
 ```
 

--- a/packages/pi-background-terminals/index.test.ts
+++ b/packages/pi-background-terminals/index.test.ts
@@ -79,7 +79,10 @@ function harness(extension = testExtension) {
   };
 }
 
-async function pollUntil(check: () => boolean, timeoutMs = 5_000) {
+async function pollUntil(
+  check: () => boolean,
+  timeoutMs = process.platform === "win32" ? 15_000 : 5_000,
+) {
   const deadline = Date.now() + timeoutMs;
   while (!check()) {
     if (Date.now() >= deadline) return false;
@@ -476,25 +479,35 @@ test("bash mirrors Pi's managed bin PATH handling", async () => {
       );
   };
 
+  const assertManagedPath = (result: any, expectedPath: string) => {
+    const text = result.content[0].text as string;
+    if (process.platform !== "win32") {
+      assert.ok(
+        text.includes(`stdout:\n${JSON.stringify({ value: expectedPath, count: 1 })}`),
+        text,
+      );
+      return;
+    }
+
+    // Git Bash prepends its own runtime directories and normalizes Windows
+    // PATH entries. The managed contract is that Pi's bin directory survives
+    // exactly once, not that Bash leaves the complete PATH byte-identical.
+    const output = /stdout:\n({[^\n]+})/.exec(text);
+    assert.ok(output, text);
+    const parsed = JSON.parse(output[1]) as { value: string; count: number };
+    assert.equal(parsed.count, 1, text);
+    assert.equal(parsed.value.split(path.delimiter).includes(binDir), true, text);
+  };
+
   try {
     const prependedPath = [binDir, basePath].filter(Boolean).join(path.delimiter);
     const prepended = await inspectPath("call-managed-path-prepend");
-    assert.ok(
-      prepended.content[0].text.includes(
-        `stdout:\n${JSON.stringify({ value: prependedPath, count: 1 })}`,
-      ),
-      prepended.content[0].text,
-    );
+    assertManagedPath(prepended, prependedPath);
 
     const existingPath = [basePath, binDir].filter(Boolean).join(path.delimiter);
     process.env[pathKey] = existingPath;
     const preserved = await inspectPath("call-managed-path-preserve");
-    assert.ok(
-      preserved.content[0].text.includes(
-        `stdout:\n${JSON.stringify({ value: existingPath, count: 1 })}`,
-      ),
-      preserved.content[0].text,
-    );
+    assertManagedPath(preserved, existingPath);
   } finally {
     await app.shutdown();
     if (previousPath === undefined) delete process.env[pathKey];

--- a/packages/pi-background-terminals/manager.test.ts
+++ b/packages/pi-background-terminals/manager.test.ts
@@ -108,7 +108,8 @@ test("process exit safety net kills managed process groups", async () => {
   const result = spawnSync(process.execPath, ["--experimental-strip-types", crashExitFixture], {
     cwd,
     encoding: "utf8",
-    timeout: 15_000,
+    // A fresh Pi package import is materially slower on Windows hosts.
+    timeout: process.platform === "win32" ? 45_000 : 15_000,
     windowsHide: true,
   });
   const pid = Number(result.stdout.trim().split(/\s+/).at(-1));
@@ -298,6 +299,53 @@ test("hard runtime timeout terminates the tree and settles timed_out", async () 
   });
 });
 
+test("Windows timeout force-kills detached descendants before losing the shell root", {
+  skip: process.platform !== "win32",
+}, async () => {
+  let parent: number | undefined;
+  let descendant: number | undefined;
+  try {
+    await withManager(async (manager, runtime) => {
+      const started = await runTool(
+        runtime,
+        manager.start({
+          command: nodeCmd(
+            'const { spawn } = require("node:child_process"); const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "ignore", windowsHide: true }); child.unref(); console.log("parent:" + process.pid + " descendant:" + child.pid); setInterval(() => {}, 1000);',
+          ),
+          title: "windows-detached-deadline",
+          cwd,
+          timeoutMs: 1_000,
+        }),
+      );
+
+      assert.ok(
+        await pollUntil(() =>
+          (manager.view.get(started.id)?.stdout.text ?? "").includes("descendant:"),
+        ),
+        "detached descendant pid was printed",
+      );
+      const output = manager.view.get(started.id)?.stdout.text ?? "";
+      const match = /parent:(\d+) descendant:(\d+)/.exec(output);
+      assert.ok(match, "parsed parent and detached descendant pids");
+      parent = Number(match[1]);
+      descendant = Number(match[2]);
+      assert.equal(processGone(parent), false);
+      assert.equal(processGone(descendant), false);
+
+      const { snap: timedOut } = await settlement(manager, started.id);
+      assert.equal(timedOut.status, "timed_out");
+      assert.ok(await pollUntil(() => processGone(parent!)), "command process is gone");
+      assert.ok(
+        await pollUntil(() => processGone(descendant!)),
+        "detached descendant is gone after timeout",
+      );
+    });
+  } finally {
+    if (parent && !processGone(parent)) forceKillTree(parent);
+    if (descendant && !processGone(descendant)) forceKillTree(descendant);
+  }
+});
+
 test("manager invokes Bash syntax and passes the requested environment", async () => {
   await withManager(async (manager, runtime) => {
     const started = await runTool(
@@ -350,10 +398,17 @@ test("kill settles a never-exiting process as killed and resolves after settle; 
     assert.equal(report[0].status, "killed");
     assert.equal(report[0].killed, true);
     assert.equal(report[0].wasRunning, true);
-    assert.match(report[0].exit, /^SIG/);
     const after = manager.view.get(snap.id);
     assert.equal(after?.status, "killed");
-    assert.ok(after?.signal);
+    if (process.platform === "win32") {
+      // Windows TerminateProcess reports an exit code instead of a POSIX signal.
+      assert.equal(report[0].exit, "exit 1");
+      assert.equal(after?.exitCode, 1);
+      assert.equal(after?.signal, undefined);
+    } else {
+      assert.match(report[0].exit, /^SIG/);
+      assert.ok(after?.signal);
+    }
 
     const second = await runTool(runtime, manager.kill([snap.id]));
     assert.equal(second[0].killed, false);

--- a/packages/pi-background-terminals/package.json
+++ b/packages/pi-background-terminals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tian.zuo/pi-background-terminals",
-  "version": "0.5.1",
+  "version": "0.5.0",
   "description": "Replace Pi's built-in Bash with automatic background yielding, exactly-once completion notifications, and a /ps viewer.",
   "type": "module",
   "keywords": [

--- a/packages/pi-background-terminals/package.json
+++ b/packages/pi-background-terminals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tian.zuo/pi-background-terminals",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Replace Pi's built-in Bash with automatic background yielding, exactly-once completion notifications, and a /ps viewer.",
   "type": "module",
   "keywords": [

--- a/packages/pi-background-terminals/src/manager.ts
+++ b/packages/pi-background-terminals/src/manager.ts
@@ -257,15 +257,17 @@ function shellInvocation(command: string, shellPath?: string) {
 }
 
 /** Signal the whole process group on POSIX so descendants (servers a shell
- * command spawned) die with it; a wedged child must not orphan its tree. */
+ * command spawned) die with it; a wedged child must not orphan its tree.
+ * Windows has no graceful process-tree signal: taskkill without /F can remove
+ * the shell before its descendants, leaving no stable root for escalation.
+ * Force the complete tree in the first call so that snapshot-and-kill is atomic. */
 function killTree(child: ChildProcess, signal: NodeJS.Signals) {
   if (process.platform === "win32" && child.pid) {
     try {
-      const killer = spawn(
-        "taskkill",
-        ["/pid", String(child.pid), "/T", ...(signal === "SIGKILL" ? ["/F"] : [])],
-        { stdio: "ignore", windowsHide: true },
-      );
+      const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
       killer.once("error", () => {
         try {
           child.kill(signal);
@@ -315,9 +317,10 @@ function awaitChildClose(child: ChildProcess, closed: () => boolean) {
   });
 }
 
-/** SIGTERM → deadline → SIGKILL; waits for stdio closure rather than only the
- * shell's exit because descendants can keep the inherited pipes and process
- * group alive after the shell itself is gone. */
+/** POSIX uses SIGTERM → deadline → SIGKILL. Windows force-kills the tree on
+ * the first call, then retains the same bounded wait/retry path. Waiting for
+ * stdio closure rather than only the shell's exit detects surviving descendants
+ * that inherited the pipes. */
 function terminateChild(child: ChildProcess, closed: () => boolean, onSignal: () => void) {
   return Effect.suspend(() => {
     if (closed()) return Effect.void;


### PR DESCRIPTION
## Summary

- force the complete Windows process tree on the first `taskkill` call
- add a Windows regression that reproduces timeout cleanup with a detached descendant
- make existing lifecycle and PATH assertions reflect Windows process and Git Bash behavior
- add a patch Changeset

## Root cause

The Windows teardown first called `taskkill /T` without `/F`, then planned to escalate with `/F`. The non-forced call could terminate the shell while leaving detached descendants alive. Once the shell PID disappeared, the forced retry no longer had a stable tree root and could not discover those descendants.

Windows has no portable graceful process-tree signal, so this change uses `taskkill /F /T` on the first attempt. POSIX keeps its existing SIGTERM-to-SIGKILL escalation.

## Verification

- reproduced the released `0.5.0` failure on Windows: both command and detached descendant remained alive after a hard timeout
- focused Windows lifecycle tests: 3 passed, 0 failed
- complete background-terminal suite with Node `--test-force-exit`: 95 passed, 0 failed, 4 POSIX-only skips
- `pnpm --filter @tian.zuo/pi-background-terminals run check`
- `pnpm run typecheck`
- `pnpm run check`
- `pnpm run lint`: no errors, existing warnings only
- package tarball dry run passed

The repository aggregate test command was also exercised on Windows. The patched package passed; an unrelated `pi-repo-model` test still compares slash-normalized Git output with a native Windows path.
