### PR TITLE
ci: split CI from Release and gate publishing on the full suite

### DIFF
--- a/.changeset/agy-home-windows.md
+++ b/.changeset/agy-home-windows.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-antigravity": patch
+---
+
+Shorten home-directory paths in tool cards via `os.homedir()` instead of `$HOME`, so `~/...` also renders on Windows, where that variable is unset.

--- a/.changeset/background-terminals-force-exit.md
+++ b/.changeset/background-terminals-force-exit.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-background-terminals": patch
+---
+
+Force exit after the background-terminal test suite finishes and run test files serially. On Windows the test runner could linger for many minutes after all tests passed when a spawned shell handle outlived its test, and the serial run avoids the open Node test-runner race (nodejs/node#64833) where `--test-force-exit` with concurrency can drop verdicts.

--- a/.changeset/image-cache-native-tmpdir.md
+++ b/.changeset/image-cache-native-tmpdir.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-image-cache": patch
+---
+
+Detect temp-directory sources through native real paths, so clipboard images under a Windows 8.3 short path are still recognized as temporary.

--- a/.changeset/repo-skills-native-key.md
+++ b/.changeset/repo-skills-native-key.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-repo-skills": patch
+---
+
+Canonicalize git-derived repo roots to native real paths so registry keys stay consistent on Windows, where git prints slash-normalized paths.

--- a/.changeset/subagents-native-worktree-subdir.md
+++ b/.changeset/subagents-native-worktree-subdir.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-subagents": patch
+---
+
+Resolve the worktree subdirectory through native real paths, so a subagent on Windows no longer works in a path derived from git's slash-normalized, 8.3 short-name output.

--- a/.changeset/tame-buses-attend.md
+++ b/.changeset/tame-buses-attend.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-repo-model": patch
+---
+
+Canonicalize git-derived repo roots to native real paths so registry keys stay consistent and tests pass on Windows.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Normalize line endings so Biome's `lineEnding: lf` check passes on Windows CI.
+* text=auto eol=lf
+
+# Binary assets must never be normalized.
+*.png binary
+*.jpg binary
+*.gif binary
+*.webp binary
+*.vsix binary
+*.tgz binary
+
+# Generated files: keep diffs collapsed in reviews.
+pnpm-lock.yaml linguist-generated=true -diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  # `github.workflow` keeps the reusable invocation from Release in its own
+  # group, so it never cancels the standalone CI run for the same commit.
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 26
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck monorepo
+        run: pnpm run typecheck
+
+      - name: Typecheck Effect packages
+        run: pnpm run check
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Pack dry run
+        run: pnpm run pack:check
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 26
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+  ci-ok:
+    name: CI
+    runs-on: ubuntu-latest
+    needs: [checks, test]
+    if: always()
+    steps:
+      - name: Verify all jobs succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          echo "job results: $RESULTS"
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" = "true" ]; then
+            echo "One or more CI jobs did not succeed."
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Release
 
 on:
   push:
@@ -6,9 +6,10 @@ on:
     paths:
       - "packages/**"
       - ".changeset/**"
-      - ".github/workflows/publish.yml"
+      - ".github/workflows/release.yml"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -17,11 +18,18 @@ on:
         default: false
 
 concurrency:
-  group: publish-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  publish:
+  # Publishing to npm is irreversible, and the Changesets release PR is opened
+  # with the default GITHUB_TOKEN, so it never triggers `pull_request` CI.
+  # Gate every release on the full CI suite instead.
+  verify:
+    uses: ./.github/workflows/ci.yml
+
+  release:
+    needs: verify
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -39,24 +47,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: 26
+          node-version: 26 # ships npm 11.19+, which supports trusted publishing
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 
-      - name: Upgrade npm for trusted publishing
-        run: npm install --global npm@^11.5.1
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Typecheck monorepo
-        run: pnpm run typecheck
-
-      - name: Typecheck Effect packages
-        run: pnpm run check
-
-      - name: Run tests
-        run: pnpm test
 
       - name: Preview pending releases
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
@@ -64,7 +60,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          pnpm changeset:status
+          pnpm changeset:status || true
           if find .changeset -maxdepth 1 -type f -name '*.md' ! -name README.md | grep -q .; then
             pnpm version-packages
           else

--- a/README.md
+++ b/README.md
@@ -85,14 +85,23 @@ publishable extension change, run `pnpm changeset`, select the package and
 semantic version bump, and commit the generated release-note file. Do not bump
 package versions manually.
 
-On pushes to `main`, the [`Publish`](.github/workflows/publish.yml) workflow
-runs all checks and opens or updates a release PR. Merging that PR publishes
-each changed package to npm, updates its package-specific `CHANGELOG.md`, and
-creates a separate tagged GitHub release. npm trusted publishing supplies OIDC
-provenance without a token secret. The workflow can also be run manually from
-*Actions → Publish* in dry-run mode to preview pending releases. The repository
-must allow GitHub Actions to create pull requests under *Settings → Actions →
-General → Workflow permissions*.
+Two workflows automate quality and delivery. [`CI`](.github/workflows/ci.yml)
+runs on every pull request and push to `main`: typecheck, Effect checks, lint,
+and a packing dry run on Ubuntu, plus the full test suite on Ubuntu, Windows,
+and macOS. Make its `CI` summary job a required status check on `main`.
+
+On pushes to `main`, [`Release`](.github/workflows/release.yml) reuses that same
+CI workflow as a gate and then opens or updates a release PR. Merging that PR
+publishes each changed package to npm, updates its package-specific
+`CHANGELOG.md`, and creates a separate tagged GitHub release. npm trusted
+publishing supplies OIDC provenance without a token secret. The workflow can
+also be run manually from *Actions → Release* in dry-run mode to preview pending
+releases. The repository must allow GitHub Actions to create pull requests under
+*Settings → Actions → General → Workflow permissions*.
+
+The release PR is created with the default `GITHUB_TOKEN`, so it never triggers
+`pull_request` CI — that is why `Release` runs the checks itself instead of
+relying on the PR's status.
 
 ```bash
 pnpm changeset          # add release notes for changed packages

--- a/packages/pi-antigravity/lib/render.ts
+++ b/packages/pi-antigravity/lib/render.ts
@@ -7,6 +7,7 @@
  * are single-line; pi's Text component handles wrapping and width safety.
  */
 
+import os from "node:os";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 
 /** agy tool name → native-equivalent label shown on the card. */
@@ -35,9 +36,10 @@ function pickArg(input: Record<string, unknown>, keys: string[]): string | undef
   return undefined;
 }
 
-/** Shorten an absolute path under $HOME to `~/...` like pi's own renderers. */
+/** Shorten an absolute path under the home directory to `~/...` like pi's own renderers. */
 function shortenPath(path: string): string {
-  const home = process.env.HOME;
+  // `os.homedir()` also resolves on Windows, where `$HOME` is unset.
+  const home = os.homedir();
   if (home && path.startsWith(home)) return `~${path.slice(home.length)}`;
   return path;
 }

--- a/packages/pi-antigravity/test/render.test.ts
+++ b/packages/pi-antigravity/test/render.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import os from "node:os";
 import { test } from "node:test";
 import { agyToolLabel, formatAgyCall, summarizeAgyResult } from "../lib/render.ts";
 
@@ -37,7 +38,7 @@ test("formatAgyCall renders native-style call lines", () => {
 });
 
 test("formatAgyCall shortens $HOME paths and bounds unknown-tool JSON", () => {
-  const home = process.env.HOME ?? "";
+  const home = os.homedir();
   assert.equal(
     formatAgyCall("view_file", { AbsolutePath: `${home}/notes` }, theme),
     "read ~/notes",

--- a/packages/pi-background-terminals/package.json
+++ b/packages/pi-background-terminals/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "check": "tsc --noEmit -p .",
     "prepare": "effect-tsgo patch",
-    "test": "node --test --experimental-strip-types index.test.ts manager.test.ts output.test.ts prompt.test.ts command-shape.test.ts result-delivery.test.ts ps.test.ts spill-source.test.ts"
+    "test": "node --test --test-force-exit --test-concurrency=1 --experimental-strip-types index.test.ts manager.test.ts output.test.ts prompt.test.ts command-shape.test.ts result-delivery.test.ts ps.test.ts spill-source.test.ts"
   },
   "dependencies": {
     "effect": "4.0.0-beta.101"

--- a/packages/pi-image-cache/lib/helpers.ts
+++ b/packages/pi-image-cache/lib/helpers.ts
@@ -123,8 +123,11 @@ export function findByHash(images: Iterable<CachedImage>, hash: string): CachedI
 
 export function isInsideTmpDir(candidate: string): boolean {
   try {
-    const root = realpathSync(tmpdir());
-    const resolved = realpathSync(candidate);
+    // `.native` also expands Windows 8.3 short names (`RUNNER~1`), which the JS
+    // `realpathSync` keeps — otherwise a long-form candidate never matches the
+    // short-form `tmpdir()` and clipboard images look like user files.
+    const root = realpathSync.native(tmpdir());
+    const resolved = realpathSync.native(candidate);
     return isPathWithin(root, resolved);
   } catch {
     return false;

--- a/packages/pi-repo-model/lib/repo-registry.ts
+++ b/packages/pi-repo-model/lib/repo-registry.ts
@@ -22,6 +22,16 @@ export interface RepoMeta {
 
 const repoMetaCache = new Map<string, RepoMeta>();
 
+/** Git prints slash-normalized paths on Windows; canonicalize to the native
+ * real path so registry keys match Node-side paths and stay stable. */
+function toRepoKey(gitPath: string): string {
+  try {
+    return fs.realpathSync.native(gitPath);
+  } catch {
+    return path.normalize(gitPath);
+  }
+}
+
 function execGit(cwd: string, args: string[]): string | null {
   try {
     return execFileSync("git", args, {
@@ -50,9 +60,10 @@ export function getRepoMeta(cwd: string): RepoMeta {
   const worktreeList = execGit(abs, ["worktree", "list", "--porcelain"]);
   const worktreeLine = worktreeList?.split("\n").find((line) => line.startsWith("worktree "));
   const mainRoot = worktreeLine?.slice("worktree ".length);
-  const root = mainRoot ?? gitRoot ?? abs;
+  const root = mainRoot ?? gitRoot;
+  const key = root ? toRepoKey(root) : abs;
 
-  const meta: RepoMeta = { key: root, name: path.basename(root) };
+  const meta: RepoMeta = { key, name: path.basename(key) };
   repoMetaCache.set(abs, meta);
   return meta;
 }

--- a/packages/pi-repo-model/test/runtime.test.ts
+++ b/packages/pi-repo-model/test/runtime.test.ts
@@ -27,7 +27,9 @@ test("RepoModelRuntime preserves spaces in Git worktree paths", async () => {
   try {
     execFileSync("git", ["init", "--quiet", repoDir]);
     const meta = await runRepoModel(runtime, service.getRepoMeta(repoDir));
-    assert.equal(meta.key, fs.realpathSync(repoDir));
+    // The runtime canonicalizes through `realpathSync.native`, which also expands
+    // Windows 8.3 short names (`RUNNER~1`) that the JS `realpathSync` keeps.
+    assert.equal(meta.key, fs.realpathSync.native(repoDir));
     assert.equal(meta.name, "repo with spaces");
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/pi-repo-skills/lib/repo-registry.ts
+++ b/packages/pi-repo-skills/lib/repo-registry.ts
@@ -22,6 +22,16 @@ export interface RepoMeta {
 
 const repoMetaCache = new Map<string, RepoMeta>();
 
+/** Git prints slash-normalized paths on Windows; canonicalize to the native
+ * real path so registry keys match Node-side paths and stay stable. */
+function toRepoKey(gitPath: string): string {
+  try {
+    return fs.realpathSync.native(gitPath);
+  } catch {
+    return path.normalize(gitPath);
+  }
+}
+
 function execGit(cwd: string, args: string[]): string | null {
   try {
     return execFileSync("git", args, {
@@ -50,9 +60,10 @@ export function getRepoMeta(cwd: string): RepoMeta {
   const worktreeList = execGit(abs, ["worktree", "list", "--porcelain"]);
   const worktreeLine = worktreeList?.split("\n").find((line) => line.startsWith("worktree "));
   const mainRoot = worktreeLine?.slice("worktree ".length);
-  const root = mainRoot ?? gitRoot ?? abs;
+  const root = mainRoot ?? gitRoot;
+  const key = root ? toRepoKey(root) : abs;
 
-  const meta: RepoMeta = { key: root, name: path.basename(root) };
+  const meta: RepoMeta = { key, name: path.basename(key) };
   repoMetaCache.set(abs, meta);
   return meta;
 }

--- a/packages/pi-repo-skills/test/runtime.test.ts
+++ b/packages/pi-repo-skills/test/runtime.test.ts
@@ -16,7 +16,9 @@ test("RepoSkillsRuntime preserves spaces in Git worktree paths", async () => {
   try {
     execFileSync("git", ["init", "--quiet", repoDir]);
     const meta = await runRepoSkills(runtime, service.getRepoMeta(repoDir));
-    assert.equal(meta.key, fs.realpathSync(repoDir));
+    // The runtime canonicalizes through `realpathSync.native`, which also expands
+    // Windows 8.3 short names (`RUNNER~1`) that the JS `realpathSync` keeps.
+    assert.equal(meta.key, fs.realpathSync.native(repoDir));
     assert.equal(meta.name, "repo with spaces");
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/pi-subagents/lib/worktree.ts
+++ b/packages/pi-subagents/lib/worktree.ts
@@ -167,7 +167,11 @@ function resolveWorktreeRoots(
 
   let subdir: string;
   try {
-    subdir = relative(realpathSync(root.out), realpathSync(cwd));
+    // `.native` collapses both of git's Windows quirks — slash-normalized output
+    // and 8.3 short names — onto one canonical form. Plain `realpathSync` keeps
+    // them, which made `relative()` invent a bogus subdir and place the
+    // worktree work path outside the worktree.
+    subdir = relative(realpathSync.native(root.out), realpathSync.native(cwd));
   } catch {
     return undefined;
   }

--- a/packages/pi-subagents/test/backend-herdr.test.ts
+++ b/packages/pi-subagents/test/backend-herdr.test.ts
@@ -86,6 +86,8 @@ function initGitRepo(dir: string): void {
     GIT_CONFIG_SYSTEM: "/dev/null",
   };
   execFileSync("git", ["init"], { cwd: dir, stdio: "pipe", env });
+  // Windows CI runners default to core.autocrlf=true; keep fixtures byte-exact.
+  execFileSync("git", ["config", "core.autocrlf", "false"], { cwd: dir, stdio: "pipe", env });
   execFileSync("git", ["config", "user.name", "pi-herdr test"], { cwd: dir, stdio: "pipe", env });
   execFileSync("git", ["config", "user.email", "pi-herdr-test@example.invalid"], {
     cwd: dir,

--- a/packages/pi-subagents/test/patch-apply.test.ts
+++ b/packages/pi-subagents/test/patch-apply.test.ts
@@ -27,6 +27,8 @@ const fakeModel = {
 
 function initGitRepo(dir: string): void {
   execFileSync("git", ["init"], { cwd: dir, stdio: "pipe" });
+  // Windows CI runners default to core.autocrlf=true; keep fixtures byte-exact.
+  execFileSync("git", ["config", "core.autocrlf", "false"], { cwd: dir, stdio: "pipe" });
   execFileSync("git", ["config", "user.name", "pi-subagents test"], { cwd: dir, stdio: "pipe" });
   execFileSync("git", ["config", "user.email", "pi-subagents-test@example.invalid"], {
     cwd: dir,

--- a/packages/pi-subagents/test/platform.ts
+++ b/packages/pi-subagents/test/platform.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+/**
+ * Shared platform guards for the test suite.
+ *
+ * Windows differs from POSIX in two ways this suite depends on:
+ *
+ *  1. There are no POSIX permission bits. `stat().mode` reports 0o666/0o444 no
+ *     matter how a file was created, so the 0o700/0o600 privacy checks cannot
+ *     hold there — artifact privacy on Windows rests on the ACLs of the user
+ *     profile directory instead.
+ *  2. Git behaviour that the tests drive through internal state (corrupting
+ *     `.git/worktrees/<id>/index` to force a status failure) is not reproducible.
+ */
+export const posixOnly = process.platform === "win32" ? { skip: "POSIX-only semantics" } : {};
+
+/** Assert a private permission mask, skipped on Windows where it cannot hold. */
+export function assertPrivateMode(target: string, expected: number): void {
+  if (process.platform === "win32") return;
+  assert.equal(fs.statSync(target).mode & 0o777, expected);
+}

--- a/packages/pi-subagents/test/report-file.test.ts
+++ b/packages/pi-subagents/test/report-file.test.ts
@@ -9,6 +9,7 @@ import {
   reportPathFor,
   semanticReportFromFile,
 } from "../lib/report-file.ts";
+import { assertPrivateMode } from "./platform.ts";
 
 function tempArtifactRoot(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-report-"));
@@ -19,8 +20,7 @@ describe("report-file", () => {
     const root = tempArtifactRoot();
     const reportPath = reportPathFor(root, "sa-test123");
     assert.equal(reportPath, path.join(root, "runs", "sa-test123", "report.json"));
-    const mode = fs.statSync(path.join(root, "runs", "sa-test123")).mode & 0o777;
-    assert.equal(mode, 0o700);
+    assertPrivateMode(path.join(root, "runs", "sa-test123"), 0o700);
     fs.rmSync(root, { recursive: true, force: true });
   });
 

--- a/packages/pi-subagents/test/supervisor-lifecycle.test.ts
+++ b/packages/pi-subagents/test/supervisor-lifecycle.test.ts
@@ -27,6 +27,8 @@ function isolatedAgentDir(): string {
 
 function initGitRepo(dir: string): void {
   execFileSync("git", ["init"], { cwd: dir, stdio: "pipe" });
+  // Windows CI runners default to core.autocrlf=true; keep fixtures byte-exact.
+  execFileSync("git", ["config", "core.autocrlf", "false"], { cwd: dir, stdio: "pipe" });
   execFileSync("git", ["config", "user.name", "pi-subagents test"], { cwd: dir, stdio: "pipe" });
   execFileSync("git", ["config", "user.email", "pi-subagents-test@example.invalid"], {
     cwd: dir,

--- a/packages/pi-subagents/test/worktree.test.ts
+++ b/packages/pi-subagents/test/worktree.test.ts
@@ -14,6 +14,7 @@ import {
   PATCH_ARTIFACT_RETENTION_RUNS,
   type WorktreeInfo,
 } from "../lib/worktree.ts";
+import { assertPrivateMode, posixOnly } from "./platform.ts";
 
 const FIXTURE = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -72,6 +73,8 @@ afterEach(() => {
 function initGitRepo(dir: string, withRepoIdentity = true): void {
   const env = isolatedGitEnv();
   execFileSync("git", ["init"], { cwd: dir, stdio: "pipe", env });
+  // Windows CI runners default to core.autocrlf=true; keep fixtures byte-exact.
+  execFileSync("git", ["config", "core.autocrlf", "false"], { cwd: dir, stdio: "pipe", env });
   if (withRepoIdentity) {
     execFileSync("git", ["config", "user.name", "pi-subagents test"], {
       cwd: dir,
@@ -235,7 +238,7 @@ describe("worktree finalization", () => {
     fs.rmSync(repo, { recursive: true, force: true });
   });
 
-  it("retains worktree when porcelain status cannot be determined", async () => {
+  it("retains worktree when porcelain status cannot be determined", posixOnly, async () => {
     const repo = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-wt-"));
     initGitRepo(repo);
 
@@ -308,14 +311,10 @@ describe("worktree finalization", () => {
     assert.ok(result.delivery.patch);
     assert.ok(result.delivery.patch!.path.startsWith(artifactRoot));
     assert.ok(!result.delivery.patch!.path.startsWith(repo));
-    const mode = fs.statSync(result.delivery.patch!.path).mode & 0o777;
-    assert.equal(mode, 0o600);
-    const runDirMode = fs.statSync(path.dirname(result.delivery.patch!.path)).mode & 0o777;
-    assert.equal(runDirMode, 0o700);
-    const runsDirMode = fs.statSync(path.join(artifactRoot, "runs")).mode & 0o777;
-    assert.equal(runsDirMode, 0o700);
-    const rootMode = fs.statSync(artifactRoot).mode & 0o777;
-    assert.equal(rootMode, 0o700);
+    assertPrivateMode(result.delivery.patch!.path, 0o600);
+    assertPrivateMode(path.dirname(result.delivery.patch!.path), 0o700);
+    assertPrivateMode(path.join(artifactRoot, "runs"), 0o700);
+    assertPrivateMode(artifactRoot, 0o700);
 
     const patch = await writePatchArtifact({
       runId: "patch-run-2",

--- a/packages/pi-vscode-bridge/test/copies.test.ts
+++ b/packages/pi-vscode-bridge/test/copies.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-const root = new URL("..", import.meta.url).pathname;
+// `URL.pathname` yields `/D:/...` on Windows, which `join` turns into `D:\D:\...`.
+const root = fileURLToPath(new URL("..", import.meta.url));
 
 test("lib/protocol.ts matches vscode/src/protocol.ts byte-for-byte", () => {
   const lib = readFileSync(join(root, "lib/protocol.ts"));

--- a/packages/pi-vscode-bridge/test/runtime.test.ts
+++ b/packages/pi-vscode-bridge/test/runtime.test.ts
@@ -14,6 +14,13 @@ import {
   type BridgeHello,
 } from "../src/runtime.ts";
 
+/**
+ * The bridge transport is a Unix domain socket. Windows has no UDS support in
+ * Node (it would need named pipes), so `listen` fails with EACCES there; skip
+ * the transport tests instead of pretending the extension runs on Windows.
+ */
+const posixOnly = process.platform === "win32" ? { skip: "requires Unix domain sockets" } : {};
+
 interface TestServer {
   readonly dir: string;
   readonly socketPath: string;
@@ -75,7 +82,7 @@ function withAgentDir<T>(agentDir: string, fn: () => Promise<T>): Promise<T> {
   });
 }
 
-test("discover finds related servers and ignores unrelated cwd", async () => {
+test("discover finds related servers and ignores unrelated cwd", posixOnly, async () => {
   const workspace = join(tmpdir(), `bridge-ws-${Date.now()}`);
   const testServer = await startTestServer(workspace);
   try {
@@ -98,7 +105,7 @@ test("discover finds related servers and ignores unrelated cwd", async () => {
   }
 });
 
-test("discover skips registries whose socket is gone", async () => {
+test("discover skips registries whose socket is gone", posixOnly, async () => {
   const workspace = join(tmpdir(), `bridge-ws-${Date.now()}`);
   const testServer = await startTestServer(workspace);
   try {
@@ -115,7 +122,7 @@ test("discover skips registries whose socket is gone", async () => {
   }
 });
 
-test("connect resolves on welcome and delivers prefill callbacks", async () => {
+test("connect resolves on welcome and delivers prefill callbacks", posixOnly, async () => {
   const workspace = join(tmpdir(), `bridge-ws-${Date.now()}`);
   const testServer = await startTestServer(workspace);
   const hello = makeHello(join(workspace, "pkg"));
@@ -186,7 +193,7 @@ test("connect resolves on welcome and delivers prefill callbacks", async () => {
   }
 });
 
-test("reject fails connect with BridgeRejectedError", async () => {
+test("reject fails connect with BridgeRejectedError", posixOnly, async () => {
   const workspace = join(tmpdir(), `bridge-ws-${Date.now()}`);
   const testServer = await startTestServer(workspace);
   const hello = makeHello(workspace);
@@ -239,7 +246,7 @@ test("reject fails connect with BridgeRejectedError", async () => {
   }
 });
 
-test("detached suppresses retry", async () => {
+test("detached suppresses retry", posixOnly, async () => {
   const workspace = join(tmpdir(), `bridge-ws-${Date.now()}`);
   const testServer = await startTestServer(workspace);
   const hello = makeHello(workspace);
@@ -311,7 +318,7 @@ test("detached suppresses retry", async () => {
   }
 });
 
-test("disconnect writes bye frame", async () => {
+test("disconnect writes bye frame", posixOnly, async () => {
   const workspace = join(tmpdir(), `bridge-ws-${Date.now()}`);
   const testServer = await startTestServer(workspace);
   const hello = makeHello(workspace);
@@ -374,7 +381,7 @@ test("disconnect writes bye frame", async () => {
   }
 });
 
-test("reattaches after an unexpected close", async () => {
+test("reattaches after an unexpected close", posixOnly, async () => {
   const workspace = join(tmpdir(), `bridge-ws-${Date.now()}`);
   const testServer = await startTestServer(workspace);
   const hello = makeHello(workspace);
@@ -447,7 +454,7 @@ test("reattaches after an unexpected close", async () => {
   }
 });
 
-test("calls onLost when every retry fails", async () => {
+test("calls onLost when every retry fails", posixOnly, async () => {
   const workspace = join(tmpdir(), `bridge-ws-${Date.now()}`);
   const testServer = await startTestServer(workspace);
   const registryPath = join(testServer.dir, "vscode-bridge", `${process.pid}.json`);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - "packages/*"
 
+# Run package scripts through pnpm's bash-like shell so POSIX syntax such as
+# `FOO=1 node ...` also works on Windows (CI runs the test matrix there).
+shellEmulator: true
+
 overrides:
   brace-expansion: ^5.0.8
   "@earendil-works/pi-ai": ^0.84.2


### PR DESCRIPTION
## Why

Publishing to npm is irreversible, but the previous `publish.yml` could do it with **zero verification**:

- The Changesets release PR is created with the default `GITHUB_TOKEN`, and GitHub does not trigger `pull_request` workflows for token-authored PRs — so that PR never ran CI.
- After the split, `release.yml` no longer ran typecheck/tests itself, and it does not wait for the `push` CI run of the same commit.

This PR closes that gap and makes the new 3-OS matrix actually able to pass.

## What

### Release gating

- `ci.yml` is now reusable (`on: workflow_call`); `release.yml` runs it as a `verify` job and `release` depends on it.
- Split into `checks` (ubuntu-only: typecheck, Effect check, lint, pack dry run) + `test` (ubuntu/windows/macos matrix) + a `ci-ok` summary job named **`CI`** — use that single job as the required status check.
- Concurrency group is namespaced by `github.workflow`, otherwise the reusable invocation and the standalone run for the same commit cancel each other.
- Added `permissions: contents: read` and `timeout-minutes`.
- Dropped the global npm upgrade step: Node 26 ships npm 11.19.0, which already supports trusted publishing (verified against nodejs.org/dist).
- `release.yml` `paths` now includes `pnpm-workspace.yaml`; the dry-run preview no longer aborts if `changeset status` exits non-zero.

### Windows matrix fixes

- `shellEmulator: true` in `pnpm-workspace.yaml` — pnpm 11 defaults it to `false`, so `PI_SUBAGENTS_DISABLE_HERDR=1 node ...` would fail on cmd.exe. (The script itself cannot change: `backend-selection.test.ts` asserts on it.)
- `.gitattributes` with `* text=auto eol=lf` — Windows runners check out CRLF, which would make Biome (`lineEnding: lf`) flag every file. No tracked file currently contains CRLF, so this is a no-op for existing content.
- `pi-repo-model` resolves git-derived roots through `fs.realpathSync.native`, so registry keys match Node-side paths on Windows.

## Verification

`pnpm lint`, `pnpm run typecheck`, `pnpm run check`, `pnpm test` all pass locally (17 packages, 0 failures).

## Follow-up (manual, after merge)

1. Let CI run once so the `CI` check name is registered, then create the branch ruleset for `main` requiring it.
2. Because the release PR gets no `pull_request` CI, either give **Repository admin** a bypass on that ruleset (safe: `release.yml` re-runs the full suite before publishing), or switch `changesets/action` to a PAT via `github-token:`.
