### PR TITLE
fix(pi-antigravity): omit unset effort

### DIFF
--- a/.changeset/quiet-antigravity-effort.md
+++ b/.changeset/quiet-antigravity-effort.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-antigravity": patch
+---
+
+Omit `agy --effort` when Pi does not set a reasoning level so models that reject the flag remain usable.

--- a/packages/pi-antigravity/README.md
+++ b/packages/pi-antigravity/README.md
@@ -141,7 +141,7 @@ Claude and GPT models
 | `/agy` | Conversation status (id, model, turns) |
 | `/agy reset` | Drop the agy conversation; next turn starts fresh |
 | `/agy models` | Re-discover models and re-register the provider |
-| `/agy-tasks` | Background-task dashboard (`stop <task-id>|all` for scripts) |
+| `/agy-tasks` | Background-task dashboard (`stop <task-id> | all` for scripts) |
 | `/agy-artifacts` | Artifact browser (`open <name>` for scripts) |
 | `/agy-usage` | Model quotas (weekly and 5-hour remaining per group) |
 
@@ -158,7 +158,7 @@ Claude and GPT models
 - **Artifact review:** headless runs cannot show agy's review panel, so image generation would abort after creating the file. Set `"artifactReviewMode": "always-proceed"` in the same `settings.json` to let artifacts through (applies to interactive agy too).
 - **Image generation errors:** `generate_image` can hit Google-side 429 rate limits; agy retries and usually succeeds — failed attempts show on the card with the real reason.
 - **Conversation memory:** lives on agy's side and is reused across turns. Resuming or forking a pi session, selecting another history branch, switching models, or changing projects starts a matching agy conversation and restores the active pi branch into it. `/agy reset` intentionally starts with no restored history.
-- **Thinking level** maps to `agy --effort`: low → `low`, medium → `medium`, high and above → `high`.
+- **Thinking level** maps to `agy --effort`: unset omits the flag, low → `low`, medium → `medium`, high and above → `high`.
 - **Context window:** agy governs context with a ~200k working window and a 185k hard safety cap (`--agent-max-context`), not the vendors' raw 1M/2M limits. Models are registered with a 185k context window so pi's auto-compaction (window − reserveTokens ≈ 168.6k with defaults) and `/context` percentages track agy's real behavior.
 - **Compaction billing:** pi's auto-compaction summary runs as an agy turn, and agy reports the transcript's cached re-reads as usage — which inflates the `[compaction]` card into a fictional bill (agy is subscription-billed). Summarization requests are detected and reported with zero usage, so the card shows no cost. Regular turns keep full token accounting.
 - **Cost display** uses model-specific public API reference prices for Gemini and Claude (agy is subscription-billed); open or unknown models stay at zero rather than borrowing another model's price. Override per model in `~/.pi/agent/models.json` under `providers.antigravity.modelOverrides`.

--- a/packages/pi-antigravity/src/provider.ts
+++ b/packages/pi-antigravity/src/provider.ts
@@ -166,11 +166,12 @@ export function agyIncompleteToolError(tool: string, resultError?: string): stri
   return "agy tool call did not complete.";
 }
 
-/** Map pi's thinking level to agy's `--effort` (low|medium|high). */
-export function mapThinkingToEffort(level: ThinkingLevel | undefined): AgyEffort {
+/** Map an explicit pi thinking level to agy's `--effort` (low|medium|high). */
+export function mapThinkingToEffort(level: ThinkingLevel | undefined): AgyEffort | undefined {
+  if (level === undefined) return undefined;
   if (level === "low" || level === "minimal") return "low";
   if (level === "medium") return "medium";
-  return "high"; // high, xhigh, max, and undefined default
+  return "high"; // high, xhigh, and max
 }
 
 let replayCallSeq = 0;

--- a/packages/pi-antigravity/src/runtime.ts
+++ b/packages/pi-antigravity/src/runtime.ts
@@ -55,7 +55,7 @@ export interface AntigravityRuntimeShape {
      */
     readonly bootstrapSuffix?: string;
     readonly modelId: string;
-    readonly effort: "low" | "medium" | "high";
+    readonly effort?: "low" | "medium" | "high";
     readonly signal?: AbortSignal;
   }) => Effect.Effect<AgyTurnController, AntigravityRuntimeClosedError>;
   /** Clear the active controller once a provider turn reached a terminal state. */

--- a/packages/pi-antigravity/test/provider.test.ts
+++ b/packages/pi-antigravity/test/provider.test.ts
@@ -131,7 +131,7 @@ test("isSummarizationRequest recognizes pi compaction prompts only", () => {
 });
 
 test("mapThinkingToEffort maps pi thinking levels to agy effort", () => {
-  assert.equal(mapThinkingToEffort(undefined), "high");
+  assert.equal(mapThinkingToEffort(undefined), undefined);
   assert.equal(mapThinkingToEffort("minimal"), "low");
   assert.equal(mapThinkingToEffort("low"), "low");
   assert.equal(mapThinkingToEffort("medium"), "medium");

--- a/packages/pi-antigravity/test/runtime.test.ts
+++ b/packages/pi-antigravity/test/runtime.test.ts
@@ -31,12 +31,12 @@ test("runtime restores the selected pi branch only when starting a fresh convers
         historyBootstrap: "RESTORED PI BRANCH",
         bootstrapSuffix: "SKILL CATALOG",
         modelId: "gemini-3.7-flash",
-        effort: "medium",
       }),
     );
     assert.equal(await first.next(), null);
     assert.equal(requests[0].prompt, "RESTORED PI BRANCH\n\ncurrent request\n\nSKILL CATALOG");
     assert.equal(requests[0].conversationId, undefined);
+    assert.equal(requests[0].effort, undefined);
 
     await runAntigravity(runtime, service.finishTurn);
     const second = await runAntigravity(


### PR DESCRIPTION
## Summary

- omit `agy --effort` when Pi does not set a reasoning level
- allow the runtime request to carry no effort value
- document and test the unset behavior

## Problem

Some discovered Antigravity models, including `claude-sonnet-4-6`, reject every `--effort` value. The provider currently maps an unset Pi reasoning level to `high`, so those models cannot be called even when reasoning is disabled.

`buildAgyArgs` already omits `--effort` when the request value is absent. This change preserves that absence through the provider and runtime instead of synthesizing `high`.

## Verification

- `pnpm --filter @tian.zuo/pi-antigravity run check`
- `pnpm --filter @tian.zuo/pi-antigravity test` — 109 passed
- local Pi smoke: `claude-sonnet-4-6` with thinking off returned successfully
- OpenPI subagent smoke: Claude with `reasoning_effort: off` returned successfully
- Gemini 3.7 Flash with low effort still returned successfully
