### PR TITLE
fix(pi-background-terminals): reap Windows process trees with a per-child Job Object

### DIFF
--- a/.changeset/background-terminals-win32-job.md
+++ b/.changeset/background-terminals-win32-job.md
@@ -2,4 +2,4 @@
 "@tian.zuo/pi-background-terminals": patch
 ---
 
-Create a dedicated Windows Job Object before starting each background terminal, then use a pre-shell launcher to join the job before the requested Bash process can run. Closing the manager-owned `KILL_ON_JOB_CLOSE` handle now reaps the complete tree—including descendants re-parented after the shell exits—without a post-spawn assignment race. PID-based `taskkill /T` remains the first termination attempt.
+Create a dedicated Windows Job Object before starting each background terminal, then use a pre-shell launcher to join the job before the requested Bash process can run. Closing the manager-owned `KILL_ON_JOB_CLOSE` handle now reaps the complete tree—including descendants re-parented after the shell exits—without a post-spawn assignment race. A startup probe preserves direct-spawn/taskkill fallback on hosts whose outer Job Object forbids nesting.

--- a/.changeset/background-terminals-win32-job.md
+++ b/.changeset/background-terminals-win32-job.md
@@ -1,5 +1,5 @@
 ---
-"@tian.zuo/pi-background-terminals": minor
+"@tian.zuo/pi-background-terminals": patch
 ---
 
-Assign each background terminal to a dedicated Windows Job Object with `KILL_ON_JOB_CLOSE`, so the whole process tree — including descendants re-parented after the shell exited while still holding the inherited stdio pipes — is reaped reliably on settle, kill, and crash. PID-based `taskkill /T` remains as a graceful first attempt; the job close is the kernel-level backstop.
+Create a dedicated Windows Job Object before starting each background terminal, then use a pre-shell launcher to join the job before the requested Bash process can run. Closing the manager-owned `KILL_ON_JOB_CLOSE` handle now reaps the complete tree—including descendants re-parented after the shell exits—without a post-spawn assignment race. PID-based `taskkill /T` remains the first termination attempt.

--- a/.changeset/background-terminals-win32-job.md
+++ b/.changeset/background-terminals-win32-job.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-background-terminals": minor
+---
+
+Assign each background terminal to a dedicated Windows Job Object with `KILL_ON_JOB_CLOSE`, so the whole process tree — including descendants re-parented after the shell exited while still holding the inherited stdio pipes — is reaped reliably on settle, kill, and crash. PID-based `taskkill /T` remains as a graceful first attempt; the job close is the kernel-level backstop.

--- a/packages/pi-background-terminals/README.md
+++ b/packages/pi-background-terminals/README.md
@@ -136,9 +136,13 @@ While at least one terminal runs, a one-line widget renders above the editor.
   transport may receive the script over stdin, but that pipe is closed
   immediately and cannot be used interactively.
 - **Process-tree termination.** POSIX children use their own process group;
-  Windows uses `taskkill /T`. Shutdown and hard timeouts send SIGTERM and
-  escalate to SIGKILL after two seconds. A synchronous process-exit tracker
-  also kills managed trees when a Pi crash bypasses normal extension cleanup.
+  Windows assigns each terminal to a dedicated Job Object
+  (`KILL_ON_JOB_CLOSE`) so closing it reliably reaps the whole tree —
+  including descendants that outlive the shell and keep the stdio pipes
+  open — with `taskkill /T` as the graceful first attempt. Shutdown and hard
+  timeouts send SIGTERM and escalate to SIGKILL after two seconds. A
+  synchronous process-exit tracker also kills managed trees when a Pi crash
+  bypasses normal extension cleanup.
 - **Session scoped.** `/new`, `/resume`, `/fork`, `/reload`, and quit terminate
   every process tree and remove the remaining spill directory.
 

--- a/packages/pi-background-terminals/README.md
+++ b/packages/pi-background-terminals/README.md
@@ -141,7 +141,9 @@ While at least one terminal runs, a one-line widget renders above the editor.
   descendant therefore inherits `KILL_ON_JOB_CLOSE` membership without an
   assignment race. Closing the handle reliably reaps descendants that outlive
   the shell and keep stdio pipes open, with `taskkill /T` as the first attempt.
-  Shutdown and hard timeouts send SIGTERM and escalate to SIGKILL after two
+  Hosts whose outer Windows job forbids nesting are detected once and retain
+  the legacy direct-spawn/taskkill fallback. Shutdown and hard timeouts send
+  SIGTERM and escalate to SIGKILL after two
   seconds. A synchronous process-exit tracker also kills managed trees when a
   Pi crash bypasses normal extension cleanup.
 - **Session scoped.** `/new`, `/resume`, `/fork`, `/reload`, and quit terminate

--- a/packages/pi-background-terminals/README.md
+++ b/packages/pi-background-terminals/README.md
@@ -135,14 +135,15 @@ While at least one terminal runs, a one-line widget renders above the editor.
 - **No interactive stdin.** Normal commands see EOF. The legacy WSL Bash
   transport may receive the script over stdin, but that pipe is closed
   immediately and cannot be used interactively.
-- **Process-tree termination.** POSIX children use their own process group;
-  Windows assigns each terminal to a dedicated Job Object
-  (`KILL_ON_JOB_CLOSE`) so closing it reliably reaps the whole tree —
-  including descendants that outlive the shell and keep the stdio pipes
-  open — with `taskkill /T` as the graceful first attempt. Shutdown and hard
-  timeouts send SIGTERM and escalate to SIGKILL after two seconds. A
-  synchronous process-exit tracker also kills managed trees when a Pi crash
-  bypasses normal extension cleanup.
+- **Process-tree termination.** POSIX children use their own process group.
+  On Windows the manager creates a dedicated Job Object before starting a
+  terminal, and a pre-shell launcher joins it before Bash can run; every
+  descendant therefore inherits `KILL_ON_JOB_CLOSE` membership without an
+  assignment race. Closing the handle reliably reaps descendants that outlive
+  the shell and keep stdio pipes open, with `taskkill /T` as the first attempt.
+  Shutdown and hard timeouts send SIGTERM and escalate to SIGKILL after two
+  seconds. A synchronous process-exit tracker also kills managed trees when a
+  Pi crash bypasses normal extension cleanup.
 - **Session scoped.** `/new`, `/resume`, `/fork`, `/reload`, and quit terminate
   every process tree and remove the remaining spill directory.
 

--- a/packages/pi-background-terminals/docs/implementation-guide.md
+++ b/packages/pi-background-terminals/docs/implementation-guide.md
@@ -421,8 +421,14 @@ so paging always advances.
 Children use separate stdout/stderr pipes and no interactive stdin. On POSIX,
 `detached: true` gives the child its own process group. Windows has no portable
 graceful process-tree signal, so termination uses `taskkill /F /T` on the first
-attempt. A non-forced `taskkill` can remove the shell while leaving descendants
-alive, which destroys the stable tree root before escalation can find them.
+attempt — a non-forced `taskkill` can remove the shell while leaving
+descendants alive, destroying the stable tree root before escalation can find
+them. Each spawned shell is also assigned to a dedicated Job Object with
+`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (loaded through koffi; pre-Windows-8
+nested-job limits or load failures degrade to the taskkill path alone). Job
+membership is inherited by every descendant, so closing the job handle lets
+the kernel terminate tree members that PID-based walks cannot reach after the
+shell exits and its children are re-parented.
 
 Termination is:
 
@@ -435,17 +441,19 @@ bounded final close/settle wait
 Exit metadata is recorded on Node's `exit` event, but settlement occurs on
 `close` so output has reached EOF. If descendants inherit the pipes and hold
 them open after the shell exits, bounded cleanup closes the entry scope and
-reaps the process group.
+reaps the process group — on Windows, closing the job kills the survivors and
+releases the pipes they hold.
 
 The entry scope is the single cleanup path for `/ps` stop, hard timeout,
 pruning, internal kill calls, and runtime disposal.
 
 Pi's detached-child tracker is internal and not exported. The manager therefore
 registers its own synchronous Node `exit` listener while live, tracks every
-spawned pid until close/scope cleanup, and sends a best-effort process-tree
-SIGKILL (`taskkill /F /T` on Windows) if an uncaught crash or emergency terminal
-exit bypasses `session_shutdown`. Runtime disposal removes the listener and
-sweeps any residual pid after normal bounded teardown.
+spawned pid until close/scope cleanup, and closes every tracked job object
+followed by a best-effort process-tree SIGKILL (`taskkill /F /T` on Windows) if
+an uncaught crash or emergency terminal exit bypasses `session_shutdown`.
+Runtime disposal removes the listener and sweeps any residual pid after normal
+bounded teardown.
 
 ## 14. Capacity and pruning
 

--- a/packages/pi-background-terminals/docs/implementation-guide.md
+++ b/packages/pi-background-terminals/docs/implementation-guide.md
@@ -131,6 +131,8 @@ src/domain.ts               Snapshot/status/error types
 src/manager.ts              Effect service and process lifecycle
 src/output.ts               Bounded head+tail stream retention
 src/process-tracker.ts      Synchronous abnormal-exit process-tree safety net
+src/win32-job.ts            Native named Job Object creation and membership
+src/win32-child.mjs         Plain-JS pre-shell launcher that joins the job first
 src/prompt.ts               Tool metadata and model-facing formatting
 src/result-delivery.ts      Drain-once completion delivery map
 src/runtime.ts              ManagedRuntime and Effect→Promise boundary
@@ -189,8 +191,12 @@ manager.start(...)
 manager.waitForSettlement(id, yield_time_ms)
 ```
 
-`start` is uninterruptible between `spawn()` and registry insertion. This avoids
-an abort window where a live child exists without a manager entry or scope.
+`start` is uninterruptible between process creation and registry insertion. This
+avoids an abort window where a live child exists without a manager entry or
+scope. On Windows it first creates and tracks an empty named Job Object, then
+starts a small launcher. The launcher joins that job before spawning the real
+Bash process, so no command process can run outside the job. POSIX starts Bash
+directly as before.
 
 During the initial wait, a per-terminal subscription emits bounded progress
 updates at most every 100 ms. The custom renderer shows a sanitized preview of
@@ -423,12 +429,13 @@ Children use separate stdout/stderr pipes and no interactive stdin. On POSIX,
 graceful process-tree signal, so termination uses `taskkill /F /T` on the first
 attempt — a non-forced `taskkill` can remove the shell while leaving
 descendants alive, destroying the stable tree root before escalation can find
-them. Each spawned shell is also assigned to a dedicated Job Object with
-`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (loaded through koffi; pre-Windows-8
-nested-job limits or load failures degrade to the taskkill path alone). Job
-membership is inherited by every descendant, so closing the job handle lets
-the kernel terminate tree members that PID-based walks cannot reach after the
-shell exits and its children are re-parented.
+them. Before spawning anything, the manager creates a named Job Object with
+`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` through Koffi. It then starts a small Node
+launcher, which joins itself to that job before it is allowed to spawn Bash.
+Bash and every descendant inherit membership from process creation onward;
+there is no window where a fast shell can launch an untracked child before a
+post-spawn assignment. If native job creation is unavailable, startup degrades
+to the previous direct-spawn/taskkill path.
 
 Termination is:
 
@@ -449,11 +456,12 @@ pruning, internal kill calls, and runtime disposal.
 
 Pi's detached-child tracker is internal and not exported. The manager therefore
 registers its own synchronous Node `exit` listener while live, tracks every
-spawned pid until close/scope cleanup, and closes every tracked job object
-followed by a best-effort process-tree SIGKILL (`taskkill /F /T` on Windows) if
-an uncaught crash or emergency terminal exit bypasses `session_shutdown`.
-Runtime disposal removes the listener and sweeps any residual pid after normal
-bounded teardown.
+spawned pid and open job until close/scope cleanup, and closes every tracked job
+object followed by a best-effort process-tree SIGKILL (`taskkill /F /T` on
+Windows) if an uncaught crash or emergency terminal exit bypasses
+`session_shutdown`. Closed jobs are untracked immediately, so long sessions do
+not retain one handle object per historical command. Runtime disposal removes
+the listener and sweeps any residual pid after normal bounded teardown.
 
 ## 14. Capacity and pruning
 
@@ -553,7 +561,8 @@ The package test suite covers:
 - hard timeout status and tree termination;
 - Bash-specific syntax on the resolved shell;
 - abort leaving eventual completion deliverable;
-- process-tree kill, SIGKILL escalation, and abnormal process-exit cleanup;
+- process-tree kill, pre-shell Windows job membership, reload-safe native FFI,
+  SIGKILL escalation, and abnormal process-exit cleanup;
 - session disposal, spill-directory cleanup, and per-entry pruning cleanup;
 - output head stability, rolling tail, UTF-8 boundaries, and omission counts;
 - complete spill capture beyond the memory cap;

--- a/packages/pi-background-terminals/docs/implementation-guide.md
+++ b/packages/pi-background-terminals/docs/implementation-guide.md
@@ -434,8 +434,11 @@ them. Before spawning anything, the manager creates a named Job Object with
 launcher, which joins itself to that job before it is allowed to spawn Bash.
 Bash and every descendant inherit membership from process creation onward;
 there is no window where a fast shell can launch an untracked child before a
-post-spawn assignment. If native job creation is unavailable, startup degrades
-to the previous direct-spawn/taskkill path.
+post-spawn assignment. Manager startup probes the complete create → launcher
+join path once. If native job creation is unavailable, or an outer host Job
+Object (for example a restrictive CI runner) forbids nesting, terminals degrade
+to the previous direct-spawn/taskkill path without starting a command during
+the probe.
 
 Termination is:
 

--- a/packages/pi-background-terminals/manager.test.ts
+++ b/packages/pi-background-terminals/manager.test.ts
@@ -130,6 +130,25 @@ test("process exit safety net kills managed process groups", async () => {
   }
 });
 
+test("Windows job FFI survives Pi-style module reloads", {
+  skip: process.platform !== "win32",
+}, async () => {
+  const firstModuleUrl = new URL(`./src/win32-job.ts?reload=${Date.now()}-first`, import.meta.url);
+  const first = await import(firstModuleUrl.href);
+  const firstJob = await first.createChildJob();
+  assert.ok(firstJob, "first module instance created a job");
+  firstJob.close();
+
+  const secondModuleUrl = new URL(
+    `./src/win32-job.ts?reload=${Date.now()}-second`,
+    import.meta.url,
+  );
+  const second = await import(secondModuleUrl.href);
+  const secondJob = await second.createChildJob();
+  assert.ok(secondJob, "reloaded module instance created a job");
+  secondJob.close();
+});
+
 test("happy path: stdout and stderr captured separately, settles done, hook fires once unconsumed", async () => {
   await withManager(async (manager, runtime) => {
     const settled: Array<{ id: string; status: string; consumed: boolean }> = [];
@@ -499,9 +518,9 @@ test("kill terminates the whole process tree (grandchildren die)", async () => {
     const snap = await runTool(
       runtime,
       manager.start({
-        // sh spawns node in the background and prints the grandchild pid,
-        // then waits forever so the group stays alive.
-        command: `node -e 'const fs = require("node:fs"); const file = ${JSON.stringify(sentinel)}; let n = 0; fs.writeFileSync(file, String(n)); setInterval(() => fs.writeFileSync(file, String(++n)), 25)' & echo "child:$!"; wait`,
+        // The child prints its own native pid (Bash's $! is an MSYS pid on
+        // Windows), then the shell waits forever so the tree stays alive.
+        command: `node -e 'const fs = require("node:fs"); const file = ${JSON.stringify(sentinel)}; console.log("child:" + process.pid); let n = 0; fs.writeFileSync(file, String(n)); setInterval(() => fs.writeFileSync(file, String(++n)), 25)' & wait`,
         title: "tree",
         cwd,
       }),
@@ -545,7 +564,7 @@ test("a shell exit with inherited pipes open settles naturally and reaps descend
     const snap = await runTool(
       runtime,
       manager.start({
-        command: `node -e "setInterval(()=>{},1e3)" & echo "child:$!"; exit 0`,
+        command: `node -e "console.log('child:' + process.pid); setInterval(()=>{},1e3)" & exit 0`,
         title: "exited-shell",
         cwd,
       }),
@@ -579,7 +598,7 @@ test("kill preserves a natural exit observed before the signal point", async () 
     const snap = await runTool(
       runtime,
       manager.start({
-        command: `node -e "setInterval(()=>{},1e3)" & echo "child:$!"; exit 0`,
+        command: `node -e "console.log('child:' + process.pid); setInterval(()=>{},1e3)" & exit 0`,
         title: "natural-race",
         cwd,
       }),
@@ -984,7 +1003,7 @@ test("terminal_log_read pages a multi-byte archive without corrupting it", async
       runtime,
       manager.start({
         command: nodeCmd(
-          'for (let i = 0; i < 4000; i++) console.log(`行\${i}:${"漢".repeat(20)}🚀`);',
+          'for (let i = 0; i < 4000; i++) console.log(`行${i}:${"漢".repeat(20)}🚀`);',
         ),
         title: "utf8-archive",
         cwd,

--- a/packages/pi-background-terminals/manager.test.ts
+++ b/packages/pi-background-terminals/manager.test.ts
@@ -559,8 +559,12 @@ test("kill terminates the whole process tree (grandchildren die)", async () => {
   });
 });
 
-test("a shell exit with inherited pipes open settles naturally and reaps descendants", async () => {
+test("a shell exit with inherited pipes open settles naturally and reaps descendants", async (t) => {
   await withManager(async (manager, runtime) => {
+    if (process.platform === "win32" && !manager.windowsJobSupport.available) {
+      t.skip(manager.windowsJobSupport.reason);
+      return;
+    }
     const snap = await runTool(
       runtime,
       manager.start({
@@ -593,8 +597,12 @@ test("a shell exit with inherited pipes open settles naturally and reaps descend
   });
 });
 
-test("kill preserves a natural exit observed before the signal point", async () => {
+test("kill preserves a natural exit observed before the signal point", async (t) => {
   await withManager(async (manager, runtime) => {
+    if (process.platform === "win32" && !manager.windowsJobSupport.available) {
+      t.skip(manager.windowsJobSupport.reason);
+      return;
+    }
     const snap = await runTool(
       runtime,
       manager.start({

--- a/packages/pi-background-terminals/manager.test.ts
+++ b/packages/pi-background-terminals/manager.test.ts
@@ -520,9 +520,11 @@ test("kill terminates the whole process tree (grandchildren die)", async () => {
       manager.start({
         // The child prints its own native pid (Bash's $! is an MSYS pid on
         // Windows), then the shell waits forever so the tree stays alive.
-        command: `node -e 'const fs = require("node:fs"); const file = ${JSON.stringify(sentinel)}; console.log("child:" + process.pid); let n = 0; fs.writeFileSync(file, String(n)); setInterval(() => fs.writeFileSync(file, String(++n)), 25)' & wait`,
+        command:
+          'node -e \'const fs = require("node:fs"); const file = process.env.BT_TREE_SENTINEL; let n = 0; fs.writeFileSync(file, String(n)); console.log("child:" + process.pid); setInterval(() => fs.writeFileSync(file, String(++n)), 25)\' & wait',
         title: "tree",
         cwd,
+        env: { ...process.env, BT_TREE_SENTINEL: sentinel },
       }),
     );
 

--- a/packages/pi-background-terminals/manager.test.ts
+++ b/packages/pi-background-terminals/manager.test.ts
@@ -492,9 +492,7 @@ test("concurrent overlapping multi-id kills observe each settlement exactly once
   });
 });
 
-test("kill terminates the whole process tree (grandchildren die)", {
-  skip: process.platform === "win32",
-}, async () => {
+test("kill terminates the whole process tree (grandchildren die)", async () => {
   await withManager(async (manager, runtime) => {
     const sentinelDir = fs.mkdtempSync(path.join(os.tmpdir(), "bt-tree-test-"));
     const sentinel = path.join(sentinelDir, "heartbeat");
@@ -542,9 +540,7 @@ test("kill terminates the whole process tree (grandchildren die)", {
   });
 });
 
-test("a shell exit with inherited pipes open settles naturally and reaps descendants", {
-  skip: process.platform === "win32",
-}, async () => {
+test("a shell exit with inherited pipes open settles naturally and reaps descendants", async () => {
   await withManager(async (manager, runtime) => {
     const snap = await runTool(
       runtime,
@@ -578,9 +574,7 @@ test("a shell exit with inherited pipes open settles naturally and reaps descend
   });
 });
 
-test("kill preserves a natural exit observed before the signal point", {
-  skip: process.platform === "win32",
-}, async () => {
+test("kill preserves a natural exit observed before the signal point", async () => {
   await withManager(async (manager, runtime) => {
     const snap = await runTool(
       runtime,

--- a/packages/pi-background-terminals/package.json
+++ b/packages/pi-background-terminals/package.json
@@ -41,7 +41,8 @@
     "test": "node --test --test-force-exit --test-concurrency=1 --experimental-strip-types index.test.ts manager.test.ts output.test.ts prompt.test.ts command-shape.test.ts result-delivery.test.ts ps.test.ts spill-source.test.ts"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.101"
+    "effect": "4.0.0-beta.101",
+    "koffi": "^3.1.6"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/packages/pi-background-terminals/src/manager.ts
+++ b/packages/pi-background-terminals/src/manager.ts
@@ -12,7 +12,7 @@
  * and issue fire-and-forget kills without touching the Effect runtime.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -63,6 +63,39 @@ const SETTLE_GRACE_MS = 1_000;
 const SPILL_FLUSH_TIMEOUT_MS = 1_500;
 const ERROR_TEXT_MAX_LENGTH = 4_096;
 const WIN32_CHILD_PATH = fileURLToPath(new URL("./win32-child.mjs", import.meta.url));
+
+export interface WindowsJobSupport {
+  readonly available: boolean;
+  readonly reason?: string;
+}
+
+let windowsJobSupportPromise: Promise<WindowsJobSupport> | undefined;
+
+async function detectWindowsJobSupport(): Promise<WindowsJobSupport> {
+  if (process.platform !== "win32") return { available: false, reason: "not running on Windows" };
+  const job = await createChildJob();
+  if (!job) return { available: false, reason: "native Job Object creation is unavailable" };
+  try {
+    const probe = spawnSync(process.execPath, [WIN32_CHILD_PATH, "--probe", job.name], {
+      encoding: "utf8",
+      stdio: ["ignore", "ignore", "pipe"],
+      timeout: 10_000,
+      windowsHide: true,
+    });
+    if (probe.status === 0) return { available: true };
+    const reason = probe.stderr.trim() || probe.error?.message || `launcher exited ${probe.status}`;
+    return { available: false, reason };
+  } catch (error) {
+    return { available: false, reason: boundedError(error) };
+  } finally {
+    job.close();
+  }
+}
+
+function getWindowsJobSupport() {
+  windowsJobSupportPromise ??= detectWindowsJobSupport();
+  return windowsJobSupportPromise;
+}
 
 function bounded(text: string) {
   return text.slice(0, ERROR_TEXT_MAX_LENGTH);
@@ -240,6 +273,8 @@ export interface TerminalManagerShape {
   /** Tracked terminals ordered by creation time, newest first. */
   readonly list: Effect.Effect<ReadonlyArray<TerminalSnapshot>>;
   readonly disposeAll: Effect.Effect<void>;
+  /** Whether this host permits the nested Job Object used by Windows cleanup. */
+  readonly windowsJobSupport: WindowsJobSupport;
   readonly view: TerminalReadModel;
 }
 
@@ -366,6 +401,7 @@ const makeManager = Effect.gen(function* () {
   // Warm the Windows job-object surface before the first terminal needs a
   // pre-created job (POSIX resolves immediately without loading Koffi).
   yield* Effect.promise(preloadChildJobSupport);
+  const windowsJobSupport = yield* Effect.promise(getWindowsJobSupport);
   // Scoped detached forker for sync contexts (read-model kills, process-event
   // settlement, pruning). Completed fibers remove themselves; manager scope
   // close interrupts any work that outlives the bounded disposeAll wait.
@@ -707,8 +743,9 @@ const makeManager = Effect.gen(function* () {
         // Create the Windows kill switch before any process in the command
         // tree exists. The launcher joins it before spawning the real shell,
         // eliminating the post-spawn assignment race from issue #5.
-        const childJob =
-          process.platform === "win32" ? yield* Effect.promise(createChildJob) : undefined;
+        const childJob = windowsJobSupport.available
+          ? yield* Effect.promise(createChildJob)
+          : undefined;
         if (childJob) detachedChildren.trackJob(childJob);
 
         const child = yield* Effect.try({
@@ -1251,6 +1288,7 @@ const makeManager = Effect.gen(function* () {
     kill,
     list: Effect.sync(listNewestFirst),
     disposeAll,
+    windowsJobSupport,
     view,
   });
 });

--- a/packages/pi-background-terminals/src/manager.ts
+++ b/packages/pi-background-terminals/src/manager.ts
@@ -16,6 +16,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { getShellConfig } from "@earendil-works/pi-coding-agent";
 import { Context, Deferred, Effect, Exit, FiberSet, Layer, Scope } from "effect";
 import {
@@ -29,7 +30,7 @@ import {
 } from "./domain.ts";
 import { OutputBuffer } from "./output.ts";
 import { createDetachedChildTracker } from "./process-tracker.ts";
-import { assignChildJob, preloadChildJobSupport, type ChildJobHandle } from "./win32-job.ts";
+import { createChildJob, preloadChildJobSupport, type ChildJobHandle } from "./win32-job.ts";
 import { codePointStart, completeCodePointEnd } from "./utf8.ts";
 
 export const MAX_RUNNING = 8;
@@ -61,6 +62,7 @@ const SETTLE_GRACE_MS = 1_000;
  * scope-close bound, so teardown remains bounded end to end. */
 const SPILL_FLUSH_TIMEOUT_MS = 1_500;
 const ERROR_TEXT_MAX_LENGTH = 4_096;
+const WIN32_CHILD_PATH = fileURLToPath(new URL("./win32-child.mjs", import.meta.url));
 
 function bounded(text: string) {
   return text.slice(0, ERROR_TEXT_MAX_LENGTH);
@@ -361,8 +363,8 @@ function terminateChild(
 // --- Implementation --------------------------------------------------------------
 
 const makeManager = Effect.gen(function* () {
-  // Warm the Windows job-object surface now so per-terminal assignment runs
-  // synchronously in the same tick as each spawn (POSIX: resolves at once).
+  // Warm the Windows job-object surface before the first terminal needs a
+  // pre-created job (POSIX resolves immediately without loading Koffi).
   yield* Effect.promise(preloadChildJobSupport);
   // Scoped detached forker for sync contexts (read-model kills, process-event
   // settlement, pruning). Completed fibers remove themselves; manager scope
@@ -561,6 +563,7 @@ const makeManager = Effect.gen(function* () {
     // The tree is final: close the Windows job so detached descendants that
     // no PID path can reach are reaped now rather than at Pi exit.
     entry.childJob?.close();
+    if (entry.childJob) detachedChildren.untrackJob(entry.childJob);
     notify(s.id);
     try {
       // During teardown, don't queue results into a shutting-down session.
@@ -701,40 +704,66 @@ const makeManager = Effect.gen(function* () {
               fallbackSafe: true,
             }),
         });
+        // Create the Windows kill switch before any process in the command
+        // tree exists. The launcher joins it before spawning the real shell,
+        // eliminating the post-spawn assignment race from issue #5.
+        const childJob =
+          process.platform === "win32" ? yield* Effect.promise(createChildJob) : undefined;
+        if (childJob) detachedChildren.trackJob(childJob);
+
         const child = yield* Effect.try({
           try: () => {
-            const spawned = spawn(invocation.shell, invocation.args, {
-              cwd: options.cwd,
-              env: options.env ?? process.env,
-              // No interactive stdin. The sole exception is legacy WSL Bash's
-              // one-shot script transport, which is closed immediately below.
-              stdio: [invocation.commandInput === undefined ? "ignore" : "pipe", "pipe", "pipe"],
-              // Own process group on POSIX → group kill takes the whole tree.
-              detached: process.platform !== "win32",
-              windowsHide: true,
-            });
-            if (invocation.commandInput !== undefined) {
-              spawned.stdin?.on("error", () => {});
+            const env = options.env ?? process.env;
+            const spawned = childJob
+              ? spawn(process.execPath, [WIN32_CHILD_PATH, childJob.name], {
+                  cwd: options.cwd,
+                  env,
+                  // One-shot JSON launch configuration; the requested shell
+                  // still receives no interactive stdin.
+                  stdio: ["pipe", "pipe", "pipe"],
+                  detached: false,
+                  windowsHide: true,
+                })
+              : spawn(invocation.shell, invocation.args, {
+                  cwd: options.cwd,
+                  env,
+                  // No interactive stdin. The sole exception is legacy WSL
+                  // Bash's one-shot script transport, closed immediately.
+                  stdio: [
+                    invocation.commandInput === undefined ? "ignore" : "pipe",
+                    "pipe",
+                    "pipe",
+                  ],
+                  // Own process group on POSIX → group kill takes the tree.
+                  detached: process.platform !== "win32",
+                  windowsHide: true,
+                });
+            spawned.stdin?.on("error", () => {});
+            if (childJob) {
+              spawned.stdin?.end(
+                JSON.stringify({
+                  shell: invocation.shell,
+                  args: invocation.args,
+                  commandInput: invocation.commandInput,
+                }),
+              );
+            } else if (invocation.commandInput !== undefined) {
               spawned.stdin?.end(invocation.commandInput);
             }
             return spawned;
           },
-          catch: (error) =>
-            new SpawnError({
+          catch: (error) => {
+            childJob?.close();
+            if (childJob) detachedChildren.untrackJob(childJob);
+            return new SpawnError({
               message: boundedError(error),
               fallbackSafe: true,
-            }),
+            });
+          },
         });
 
         const childPid = child.pid;
         if (childPid) detachedChildren.track(childPid);
-        // Assign the tree to a dedicated Windows job in the same tick as the
-        // spawn, before the shell can create descendants. Never fails start:
-        // cleanup falls back to the PID-based paths when unavailable.
-        const childJob = childPid
-          ? yield* Effect.promise(() => assignChildJob(childPid))
-          : undefined;
-        if (childJob) detachedChildren.trackJob(childJob);
 
         const id = `bt-${++counter}`;
         const entryRef = () => entries.get(id);
@@ -884,6 +913,7 @@ const makeManager = Effect.gen(function* () {
               // job terminates any descendant still holding stdio pipes —
               // PID-based kills cannot reach the re-parented survivors.
               entry.childJob?.close();
+              if (entry.childJob) detachedChildren.untrackJob(entry.childJob);
               if (childPid) detachedChildren.untrack(childPid);
             }),
           ),

--- a/packages/pi-background-terminals/src/manager.ts
+++ b/packages/pi-background-terminals/src/manager.ts
@@ -29,6 +29,7 @@ import {
 } from "./domain.ts";
 import { OutputBuffer } from "./output.ts";
 import { createDetachedChildTracker } from "./process-tracker.ts";
+import { assignChildJob, preloadChildJobSupport, type ChildJobHandle } from "./win32-job.ts";
 import { codePointStart, completeCodePointEnd } from "./utf8.ts";
 
 export const MAX_RUNNING = 8;
@@ -97,6 +98,10 @@ interface MutableSnapshot extends TerminalSnapshot {
 interface Entry {
   snapshot: MutableSnapshot;
   child: ChildProcess;
+  /** Dedicated Windows job containing the whole tree; closing it reaps
+   * descendants PID-based kills cannot reach. `undefined` elsewhere or when
+   * job support is unavailable. */
+  childJob: ChildJobHandle | undefined;
   scope: Scope.Closeable;
   stdoutBuf: OutputBuffer;
   stderrBuf: OutputBuffer;
@@ -260,7 +265,10 @@ function shellInvocation(command: string, shellPath?: string) {
  * command spawned) die with it; a wedged child must not orphan its tree.
  * Windows has no graceful process-tree signal: taskkill without /F can remove
  * the shell before its descendants, leaving no stable root for escalation.
- * Force the complete tree in the first call so that snapshot-and-kill is atomic. */
+ * Force the complete tree in the first call so that snapshot-and-kill is
+ * atomic. The per-child Job Object (see win32-job.ts) is the reliable
+ * backstop: taskkill cannot reach descendants re-parented after the shell
+ * exited, so the job close in the teardown path does the actual reaping. */
 function killTree(child: ChildProcess, signal: NodeJS.Signals) {
   if (process.platform === "win32" && child.pid) {
     try {
@@ -320,8 +328,15 @@ function awaitChildClose(child: ChildProcess, closed: () => boolean) {
 /** POSIX uses SIGTERM → deadline → SIGKILL. Windows force-kills the tree on
  * the first call, then retains the same bounded wait/retry path. Waiting for
  * stdio closure rather than only the shell's exit detects surviving descendants
- * that inherited the pipes. */
-function terminateChild(child: ChildProcess, closed: () => boolean, onSignal: () => void) {
+ * that inherited the pipes. `onEscalation` fires with the SIGKILL escalation —
+ * the Windows job close there releases pipes the dead shell's descendants
+ * still hold. */
+function terminateChild(
+  child: ChildProcess,
+  closed: () => boolean,
+  onSignal: () => void,
+  onEscalation: () => void,
+) {
   return Effect.suspend(() => {
     if (closed()) return Effect.void;
     return Effect.gen(function* () {
@@ -334,7 +349,10 @@ function terminateChild(child: ChildProcess, closed: () => boolean, onSignal: ()
         Effect.ignore,
       );
       if (closed()) return;
-      yield* Effect.sync(() => killTree(child, "SIGKILL"));
+      yield* Effect.sync(() => {
+        killTree(child, "SIGKILL");
+        onEscalation();
+      });
       yield* awaitChildClose(child, closed).pipe(Effect.timeout(500), Effect.ignore);
     });
   });
@@ -343,6 +361,9 @@ function terminateChild(child: ChildProcess, closed: () => boolean, onSignal: ()
 // --- Implementation --------------------------------------------------------------
 
 const makeManager = Effect.gen(function* () {
+  // Warm the Windows job-object surface now so per-terminal assignment runs
+  // synchronously in the same tick as each spawn (POSIX: resolves at once).
+  yield* Effect.promise(preloadChildJobSupport);
   // Scoped detached forker for sync contexts (read-model kills, process-event
   // settlement, pruning). Completed fibers remove themselves; manager scope
   // close interrupts any work that outlives the bounded disposeAll wait.
@@ -537,6 +558,9 @@ const makeManager = Effect.gen(function* () {
     for (const waiter of waiters ?? []) waiter.consumed = true;
     const consumed = (killInterest.get(s.id) ?? 0) > 0 || (waiters?.size ?? 0) > 0;
     Deferred.doneUnsafe(entry.settled, Effect.void);
+    // The tree is final: close the Windows job so detached descendants that
+    // no PID path can reach are reaped now rather than at Pi exit.
+    entry.childJob?.close();
     notify(s.id);
     try {
       // During teardown, don't queue results into a shutting-down session.
@@ -704,6 +728,13 @@ const makeManager = Effect.gen(function* () {
 
         const childPid = child.pid;
         if (childPid) detachedChildren.track(childPid);
+        // Assign the tree to a dedicated Windows job in the same tick as the
+        // spawn, before the shell can create descendants. Never fails start:
+        // cleanup falls back to the PID-based paths when unavailable.
+        const childJob = childPid
+          ? yield* Effect.promise(() => assignChildJob(childPid))
+          : undefined;
+        if (childJob) detachedChildren.trackJob(childJob);
 
         const id = `bt-${++counter}`;
         const entryRef = () => entries.get(id);
@@ -744,6 +775,7 @@ const makeManager = Effect.gen(function* () {
         const entry: Entry = {
           snapshot,
           child,
+          childJob,
           scope,
           stdoutBuf,
           stderrBuf,
@@ -823,6 +855,7 @@ const makeManager = Effect.gen(function* () {
                 () => {
                   entry.killSignaled ||= !entry.exited && entry.snapshot.status === "running";
                 },
+                () => entry.childJob?.close(),
               );
               // Give the natural close→flush→settle path a bounded grace,
               // then force the settle: a grandchild holding the pipe open
@@ -847,6 +880,10 @@ const makeManager = Effect.gen(function* () {
                 yield* flushSpillStreams(entry);
                 settle(entry);
               }
+              // The backstop: whatever the settle path decided, closing the
+              // job terminates any descendant still holding stdio pipes —
+              // PID-based kills cannot reach the re-parented survivors.
+              entry.childJob?.close();
               if (childPid) detachedChildren.untrack(childPid);
             }),
           ),

--- a/packages/pi-background-terminals/src/process-tracker.ts
+++ b/packages/pi-background-terminals/src/process-tracker.ts
@@ -42,6 +42,8 @@ export interface DetachedChildTracker {
    * exited), so the sweep closes jobs before falling back to pid sweeps.
    */
   trackJob(job: ChildJobHandle): void;
+  /** Stop retaining a job after its idempotent handle has been closed. */
+  untrackJob(job: ChildJobHandle): void;
   /** Remove the process listener and synchronously kill any residual trees. */
   dispose(): void;
 }
@@ -78,9 +80,10 @@ export function createDetachedChildTracker(): DetachedChildTracker {
       pids.delete(pid);
     },
     trackJob(job) {
-      // Entries settle (closing their own job) long before a crash sweep;
-      // double-close is a no-op, so settled jobs may remain in the set.
       if (!disposed) jobs.add(job);
+    },
+    untrackJob(job) {
+      jobs.delete(job);
     },
     dispose() {
       if (disposed) return;

--- a/packages/pi-background-terminals/src/process-tracker.ts
+++ b/packages/pi-background-terminals/src/process-tracker.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import type { ChildJobHandle } from "./win32-job.ts";
 
 /**
  * Synchronously kill a process tree during Node's `exit` event, where async
@@ -35,6 +36,12 @@ function killProcessTreeSync(pid: number) {
 export interface DetachedChildTracker {
   track(pid: number): void;
   untrack(pid: number): void;
+  /**
+   * Track a dedicated per-child Windows job object. Job close is the reliable
+   * tree kill (taskkill cannot reach descendants re-parented after the shell
+   * exited), so the sweep closes jobs before falling back to pid sweeps.
+   */
+  trackJob(job: ChildJobHandle): void;
   /** Remove the process listener and synchronously kill any residual trees. */
   dispose(): void;
 }
@@ -46,9 +53,16 @@ export interface DetachedChildTracker {
  */
 export function createDetachedChildTracker(): DetachedChildTracker {
   const pids = new Set<number>();
+  const jobs = new Set<ChildJobHandle>();
   let disposed = false;
 
   const sweep = () => {
+    // Jobs first: closing one terminates the whole tree synchronously at the
+    // kernel level, including PID-unreachable orphans holding stdio pipes.
+    const pendingJobs = [...jobs];
+    jobs.clear();
+    for (const job of pendingJobs) job.close();
+
     const pending = [...pids];
     pids.clear();
     for (const pid of pending) killProcessTreeSync(pid);
@@ -62,6 +76,11 @@ export function createDetachedChildTracker(): DetachedChildTracker {
     },
     untrack(pid) {
       pids.delete(pid);
+    },
+    trackJob(job) {
+      // Entries settle (closing their own job) long before a crash sweep;
+      // double-close is a no-op, so settled jobs may remain in the set.
+      if (!disposed) jobs.add(job);
     },
     dispose() {
       if (disposed) return;

--- a/packages/pi-background-terminals/src/win32-child.mjs
+++ b/packages/pi-background-terminals/src/win32-child.mjs
@@ -30,7 +30,9 @@ function closeHandle(close, handle) {
 }
 
 function joinJob(name) {
-  if (process.platform !== "win32" || !name) return false;
+  if (process.platform !== "win32" || !name) {
+    return { ok: false, reason: "not running on Windows or missing job name" };
+  }
   try {
     const lib = koffi.load("kernel32.dll");
     const handle = koffi.pointer(koffi.opaque());
@@ -49,19 +51,26 @@ function joinJob(name) {
       handle,
     ]);
     const close = lib.func("__stdcall", "CloseHandle", "int32_t", [handle]);
+    const getLastError = lib.func("__stdcall", "GetLastError", "uint32_t", []);
 
     const job = openJobObjectW(JOB_OBJECT_ASSIGN_PROCESS, false, name);
-    if (!job) return false;
+    if (!job) return { ok: false, reason: `OpenJobObjectW error ${getLastError()}` };
     let currentProcess;
     try {
       currentProcess = openProcess(PROCESS_TERMINATE | PROCESS_SET_QUOTA, false, process.pid);
-      return Boolean(currentProcess && assignProcessToJobObject(job, currentProcess));
+      if (!currentProcess) {
+        return { ok: false, reason: `OpenProcess error ${getLastError()}` };
+      }
+      if (!assignProcessToJobObject(job, currentProcess)) {
+        return { ok: false, reason: `AssignProcessToJobObject error ${getLastError()}` };
+      }
+      return { ok: true };
     } finally {
       if (currentProcess) closeHandle(close, currentProcess);
       closeHandle(close, job);
     }
-  } catch {
-    return false;
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
   }
 }
 
@@ -86,8 +95,11 @@ async function readConfiguration() {
   }
 }
 
-const jobName = process.argv[2];
-if (!joinJob(jobName)) fail("could not join the process Job Object");
+const probe = process.argv[2] === "--probe";
+const jobName = probe ? process.argv[3] : process.argv[2];
+const joined = joinJob(jobName);
+if (!joined.ok) fail(`could not join the process Job Object: ${joined.reason}`);
+if (probe) process.exit(0);
 
 // No command process exists before job membership is established.
 const configuration = await readConfiguration();

--- a/packages/pi-background-terminals/src/win32-child.mjs
+++ b/packages/pi-background-terminals/src/win32-child.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+/**
+ * Windows pre-shell launcher.
+ *
+ * This file is plain JavaScript because Node deliberately refuses to strip
+ * TypeScript in node_modules. It joins the manager-created Job Object before
+ * starting the requested shell, so every command process is born in the job.
+ */
+
+import { spawn } from "node:child_process";
+import { writeSync } from "node:fs";
+import koffi from "koffi";
+
+const JOB_OBJECT_ASSIGN_PROCESS = 0x0001;
+const PROCESS_TERMINATE = 0x0001;
+const PROCESS_SET_QUOTA = 0x0100;
+
+function fail(message) {
+  writeSync(2, `Windows terminal launcher failed: ${message}\n`);
+  process.exit(1);
+}
+
+function closeHandle(close, handle) {
+  try {
+    close(handle);
+  } catch {
+    // The process may be terminating or the handle may already be invalid.
+  }
+}
+
+function joinJob(name) {
+  if (process.platform !== "win32" || !name) return false;
+  try {
+    const lib = koffi.load("kernel32.dll");
+    const handle = koffi.pointer(koffi.opaque());
+    const openProcess = lib.func("__stdcall", "OpenProcess", handle, [
+      "uint32_t",
+      "int8_t",
+      "uint32_t",
+    ]);
+    const openJobObjectW = lib.func("__stdcall", "OpenJobObjectW", handle, [
+      "uint32_t",
+      "int8_t",
+      "str16",
+    ]);
+    const assignProcessToJobObject = lib.func("__stdcall", "AssignProcessToJobObject", "int32_t", [
+      handle,
+      handle,
+    ]);
+    const close = lib.func("__stdcall", "CloseHandle", "int32_t", [handle]);
+
+    const job = openJobObjectW(JOB_OBJECT_ASSIGN_PROCESS, false, name);
+    if (!job) return false;
+    let currentProcess;
+    try {
+      currentProcess = openProcess(PROCESS_TERMINATE | PROCESS_SET_QUOTA, false, process.pid);
+      return Boolean(currentProcess && assignProcessToJobObject(job, currentProcess));
+    } finally {
+      if (currentProcess) closeHandle(close, currentProcess);
+      closeHandle(close, job);
+    }
+  } catch {
+    return false;
+  }
+}
+
+async function readConfiguration() {
+  let encoded = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) encoded += chunk;
+  try {
+    const value = JSON.parse(encoded);
+    if (
+      typeof value?.shell !== "string" ||
+      value.shell.length === 0 ||
+      !Array.isArray(value.args) ||
+      !value.args.every((arg) => typeof arg === "string") ||
+      (value.commandInput !== undefined && typeof value.commandInput !== "string")
+    ) {
+      fail("invalid launch configuration");
+    }
+    return value;
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
+const jobName = process.argv[2];
+if (!joinJob(jobName)) fail("could not join the process Job Object");
+
+// No command process exists before job membership is established.
+const configuration = await readConfiguration();
+let child;
+try {
+  child = spawn(configuration.shell, configuration.args, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: [configuration.commandInput === undefined ? "ignore" : "pipe", "inherit", "inherit"],
+    windowsHide: true,
+  });
+  if (configuration.commandInput !== undefined) {
+    child.stdin?.on("error", () => {});
+    child.stdin?.end(configuration.commandInput);
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}
+
+let finishing = false;
+const finish = (code) => {
+  if (finishing) return;
+  finishing = true;
+  process.exit(code);
+};
+child.once("error", (error) => {
+  writeSync(2, `Windows terminal shell failed: ${error.message}\n`);
+  finish(1);
+});
+child.once("exit", (code) => {
+  // Exit as soon as the shell exits rather than waiting for inherited stdio.
+  // The manager then closes the job after its bounded natural-exit grace.
+  finish(code ?? 1);
+});

--- a/packages/pi-background-terminals/src/win32-child.mjs
+++ b/packages/pi-background-terminals/src/win32-child.mjs
@@ -53,11 +53,11 @@ function joinJob(name) {
     const close = lib.func("__stdcall", "CloseHandle", "int32_t", [handle]);
     const getLastError = lib.func("__stdcall", "GetLastError", "uint32_t", []);
 
-    const job = openJobObjectW(JOB_OBJECT_ASSIGN_PROCESS, false, name);
+    const job = openJobObjectW(JOB_OBJECT_ASSIGN_PROCESS, 0, name);
     if (!job) return { ok: false, reason: `OpenJobObjectW error ${getLastError()}` };
     let currentProcess;
     try {
-      currentProcess = openProcess(PROCESS_TERMINATE | PROCESS_SET_QUOTA, false, process.pid);
+      currentProcess = openProcess(PROCESS_TERMINATE | PROCESS_SET_QUOTA, 0, process.pid);
       if (!currentProcess) {
         return { ok: false, reason: `OpenProcess error ${getLastError()}` };
       }

--- a/packages/pi-background-terminals/src/win32-job.ts
+++ b/packages/pi-background-terminals/src/win32-job.ts
@@ -1,71 +1,63 @@
+import { randomUUID } from "node:crypto";
+
 /**
- * Per-child Windows Job Objects.
+ * Per-terminal Windows Job Objects.
  *
- * On Windows, PID-based tree kills (`taskkill /T`) walk the parent chain:
- * once the shell exits, its descendants are re-parented and unreachable, so a
- * descendant holding the inherited stdio pipes open survives every cleanup we
- * control (libuv's global KILL_ON_JOB_CLOSE job only closes when the whole Pi
- * process dies).
- *
- * Assigning the spawned shell to a dedicated Job Object with
- * JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE closes that gap: job membership is
- * inherited by every descendant, so closing our job handle makes the kernel
- * terminate all surviving tree members — orphaned or not — which also
- * releases the stdio pipes they hold open.
- *
- * The kernel32 surface is loaded lazily through koffi and only on Windows; on
- * any failure (load error, pre-Windows-8 nested-job restriction, child that
- * exited before assignment) callers silently fall back to the legacy
- * PID-based cleanup.
+ * The manager creates a named KILL_ON_JOB_CLOSE job before it starts the
+ * Windows launcher. The launcher joins itself to that job before it starts the
+ * requested shell, so the shell and every descendant inherit membership with
+ * no post-spawn assignment race. The manager keeps the last job handle and can
+ * therefore reap the complete tree by closing it.
  */
 
 export interface ChildJobHandle {
-  /**
-   * Close the job handle. Idempotent and synchronous, so it is safe to call
-   * from `process.on("exit")`. The kernel terminates any process still in
-   * the job.
-   */
+  /** Name used by the pre-shell launcher to join this job. */
+  readonly name: string;
+  /** Close the last manager-owned handle and terminate every job member. */
   close(): void;
 }
 
 // winnt.h
 const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
 const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
-const PROCESS_TERMINATE = 0x0001;
-const PROCESS_SET_QUOTA = 0x0100;
 
 interface Kernel32 {
-  openProcess(desiredAccess: number, inheritHandle: boolean, pid: number): unknown;
-  createJobObjectW(jobAttributes: null, name: null): unknown;
+  createJobObjectW(jobAttributes: null, name: string): unknown;
   setInformationJobObject(
     job: unknown,
     infoClass: number,
     info: unknown,
     infoLength: number,
   ): boolean;
-  assignProcessToJobObject(job: unknown, process: unknown): boolean;
   closeHandle(object: unknown): boolean;
 }
 
-/** Cached kernel32 surface. `null` once proven unavailable (non-Windows
- * platform or koffi load failure); callers then use the PID-based fallback. */
-let kernel32: Kernel32 | null | undefined;
-/** Zero-initialized extended limits with KILL_ON_JOB_CLOSE set; allocated
- * once and reused for every job. Read-only for the API. */
-let limitInfo: unknown;
-let limitInfoSize = 0;
+interface LoadedKernel32 {
+  readonly api: Kernel32;
+  readonly limitInfo: unknown;
+  readonly limitInfoSize: number;
+}
 
-async function loadKernel32(): Promise<Kernel32 | null> {
-  if (kernel32 !== undefined) return kernel32;
-  if (process.platform !== "win32") {
-    kernel32 = null;
-    return kernel32;
+/** One initialization promise prevents concurrent managers from defining the
+ * same FFI surface twice. All Koffi types are anonymous, so Pi's module-cache-
+ * free /reload can evaluate this module again without duplicate-type errors. */
+let kernel32Load: Promise<LoadedKernel32 | null> | undefined;
+
+function closeHandle(api: Kernel32, handle: unknown) {
+  try {
+    api.closeHandle(handle);
+  } catch {
+    // The process may be terminating or the handle may already be invalid.
   }
+}
+
+async function loadKernel32Once(): Promise<LoadedKernel32 | null> {
+  if (process.platform !== "win32") return null;
   try {
     const koffi = (await import("koffi")).default;
     const lib = koffi.load("kernel32.dll");
-    const handle = koffi.pointer("BT_Handle", koffi.opaque());
-    const ioCounters = koffi.struct("BT_IoCounters", {
+    const handle = koffi.pointer(koffi.opaque());
+    const ioCounters = koffi.struct({
       readOperationCount: "uint64_t",
       writeOperationCount: "uint64_t",
       otherOperationCount: "uint64_t",
@@ -73,9 +65,9 @@ async function loadKernel32(): Promise<Kernel32 | null> {
       writeTransferCount: "uint64_t",
       otherTransferCount: "uint64_t",
     });
-    // Natural (non-packed) alignment: koffi inserts the same padding the
-    // compiler emits for JOBOBJECT_BASIC_LIMIT_INFORMATION on x64/arm64.
-    const basicLimits = koffi.struct("BT_JobBasicLimits", {
+    // Node 26 supports Windows x64/arm64, where SIZE_T and ULONG_PTR are both
+    // 64-bit. Natural Koffi alignment matches the Windows SDK structures.
+    const basicLimits = koffi.struct({
       perProcessUserTimeLimit: "uint64_t",
       perJobUserTimeLimit: "uint64_t",
       limitFlags: "uint32_t",
@@ -86,7 +78,7 @@ async function loadKernel32(): Promise<Kernel32 | null> {
       priorityClass: "uint32_t",
       schedulingClass: "uint32_t",
     });
-    const extendedLimits = koffi.struct("BT_JobExtendedLimits", {
+    const extendedLimits = koffi.struct({
       basicLimitInformation: basicLimits,
       ioInfo: ioCounters,
       processMemoryLimit: "uint64_t",
@@ -94,85 +86,78 @@ async function loadKernel32(): Promise<Kernel32 | null> {
       peakProcessMemoryUsed: "uint64_t",
       peakJobMemoryUsed: "uint64_t",
     });
-    // Input structs accept plain objects: koffi copies fields by name and
-    // zero-fills the rest (same pattern as koffi's own GetCursorPos example).
-    limitInfo = {
-      basicLimitInformation: { limitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE },
-    };
-    limitInfoSize = koffi.sizeof(extendedLimits);
+    const extendedLimitsPointer = koffi.pointer(extendedLimits);
 
-    kernel32 = {
-      openProcess: lib.func(
-        `${handle} __stdcall OpenProcess(uint32_t dwDesiredAccess, int8_t bInheritHandle, uint32_t dwProcessId)`,
-      ),
-      createJobObjectW: lib.func(
-        `${handle} __stdcall CreateJobObjectW(void *lpJobAttributes, const wchar_t *lpName)`,
-      ),
-      setInformationJobObject: lib.func(
-        `int32_t __stdcall SetInformationJobObject(${handle} hJob, int32_t JobObjectInfoClass, BT_JobExtendedLimits *lpJobObjectInfo, uint32_t cbJobObjectInfoLength)`,
-      ),
-      assignProcessToJobObject: lib.func(
-        `int32_t __stdcall AssignProcessToJobObject(${handle} hJob, ${handle} hProcess)`,
-      ),
-      closeHandle: lib.func(`int32_t __stdcall CloseHandle(${handle} hObject)`),
+    const api = {
+      createJobObjectW: lib.func("__stdcall", "CreateJobObjectW", handle, ["void *", "str16"]),
+      setInformationJobObject: lib.func("__stdcall", "SetInformationJobObject", "int32_t", [
+        handle,
+        "int32_t",
+        extendedLimitsPointer,
+        "uint32_t",
+      ]),
+      closeHandle: lib.func("__stdcall", "CloseHandle", "int32_t", [handle]),
     } as Kernel32;
+
+    return {
+      api,
+      // Koffi copies input objects into a zero-initialized native structure.
+      limitInfo: {
+        basicLimitInformation: { limitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE },
+      },
+      limitInfoSize: koffi.sizeof(extendedLimits),
+    };
   } catch {
-    kernel32 = null;
+    return null;
   }
-  return kernel32;
 }
 
-/** Warm the kernel32 surface at manager startup so per-terminal assignment
- * runs its (already synchronous) FFI calls in the same tick as the spawn. */
+function loadKernel32() {
+  kernel32Load ??= loadKernel32Once();
+  return kernel32Load;
+}
+
+/** Warm the native surface before the first terminal starts. */
 export function preloadChildJobSupport(): Promise<void> {
   return loadKernel32().then(() => undefined);
 }
 
 /**
- * Put the freshly spawned child (and, by inheritance, every descendant it is
- * about to create) into a dedicated KILL_ON_JOB_CLOSE job. Resolves
- * `undefined` on any failure or non-Windows platform — cleanup then relies on
- * the legacy PID-based paths exactly as before.
+ * Create and configure an empty named job before any launcher or shell exists.
+ * The returned handle is the manager's kill switch. When unavailable, callers
+ * retain the legacy direct-spawn/taskkill behavior.
  */
-export async function assignChildJob(pid: number): Promise<ChildJobHandle | undefined> {
-  if (!Number.isSafeInteger(pid) || pid <= 0) return undefined;
-  const k = await loadKernel32();
-  if (!k) return undefined;
+export async function createChildJob(): Promise<ChildJobHandle | undefined> {
+  const loaded = await loadKernel32();
+  if (!loaded) return undefined;
+  const { api, limitInfo, limitInfoSize } = loaded;
+  const name = `pi-background-terminal-${process.pid}-${randomUUID()}`;
+  let job: unknown;
   try {
-    const child = k.openProcess(PROCESS_TERMINATE | PROCESS_SET_QUOTA, false, pid);
-    if (!child) return undefined;
-    try {
-      const job = k.createJobObjectW(null, null);
-      if (!job) return undefined;
-      if (
-        !k.setInformationJobObject(
-          job,
-          JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
-          limitInfo,
-          limitInfoSize,
-        ) ||
-        !k.assignProcessToJobObject(job, child)
-      ) {
-        // An empty job is harmless, but close it to release the handle.
-        k.closeHandle(job);
-        return undefined;
-      }
-      let closed = false;
-      return {
-        close() {
-          if (closed) return;
-          closed = true;
-          try {
-            k.closeHandle(job);
-          } catch {
-            // Handle already invalidated; the tree is gone either way.
-          }
-        },
-      };
-    } finally {
-      k.closeHandle(child);
+    job = api.createJobObjectW(null, name);
+    if (!job) return undefined;
+    if (
+      !api.setInformationJobObject(
+        job,
+        JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+        limitInfo,
+        limitInfoSize,
+      )
+    ) {
+      closeHandle(api, job);
+      return undefined;
     }
+    let closed = false;
+    return {
+      name,
+      close() {
+        if (closed) return;
+        closed = true;
+        closeHandle(api, job);
+      },
+    };
   } catch {
+    if (job) closeHandle(api, job);
     return undefined;
   }
 }

--- a/packages/pi-background-terminals/src/win32-job.ts
+++ b/packages/pi-background-terminals/src/win32-job.ts
@@ -1,0 +1,178 @@
+/**
+ * Per-child Windows Job Objects.
+ *
+ * On Windows, PID-based tree kills (`taskkill /T`) walk the parent chain:
+ * once the shell exits, its descendants are re-parented and unreachable, so a
+ * descendant holding the inherited stdio pipes open survives every cleanup we
+ * control (libuv's global KILL_ON_JOB_CLOSE job only closes when the whole Pi
+ * process dies).
+ *
+ * Assigning the spawned shell to a dedicated Job Object with
+ * JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE closes that gap: job membership is
+ * inherited by every descendant, so closing our job handle makes the kernel
+ * terminate all surviving tree members — orphaned or not — which also
+ * releases the stdio pipes they hold open.
+ *
+ * The kernel32 surface is loaded lazily through koffi and only on Windows; on
+ * any failure (load error, pre-Windows-8 nested-job restriction, child that
+ * exited before assignment) callers silently fall back to the legacy
+ * PID-based cleanup.
+ */
+
+export interface ChildJobHandle {
+  /**
+   * Close the job handle. Idempotent and synchronous, so it is safe to call
+   * from `process.on("exit")`. The kernel terminates any process still in
+   * the job.
+   */
+  close(): void;
+}
+
+// winnt.h
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
+const PROCESS_TERMINATE = 0x0001;
+const PROCESS_SET_QUOTA = 0x0100;
+
+interface Kernel32 {
+  openProcess(desiredAccess: number, inheritHandle: boolean, pid: number): unknown;
+  createJobObjectW(jobAttributes: null, name: null): unknown;
+  setInformationJobObject(
+    job: unknown,
+    infoClass: number,
+    info: unknown,
+    infoLength: number,
+  ): boolean;
+  assignProcessToJobObject(job: unknown, process: unknown): boolean;
+  closeHandle(object: unknown): boolean;
+}
+
+/** Cached kernel32 surface. `null` once proven unavailable (non-Windows
+ * platform or koffi load failure); callers then use the PID-based fallback. */
+let kernel32: Kernel32 | null | undefined;
+/** Zero-initialized extended limits with KILL_ON_JOB_CLOSE set; allocated
+ * once and reused for every job. Read-only for the API. */
+let limitInfo: unknown;
+let limitInfoSize = 0;
+
+async function loadKernel32(): Promise<Kernel32 | null> {
+  if (kernel32 !== undefined) return kernel32;
+  if (process.platform !== "win32") {
+    kernel32 = null;
+    return kernel32;
+  }
+  try {
+    const koffi = (await import("koffi")).default;
+    const lib = koffi.load("kernel32.dll");
+    const handle = koffi.pointer("BT_Handle", koffi.opaque());
+    const ioCounters = koffi.struct("BT_IoCounters", {
+      readOperationCount: "uint64_t",
+      writeOperationCount: "uint64_t",
+      otherOperationCount: "uint64_t",
+      readTransferCount: "uint64_t",
+      writeTransferCount: "uint64_t",
+      otherTransferCount: "uint64_t",
+    });
+    // Natural (non-packed) alignment: koffi inserts the same padding the
+    // compiler emits for JOBOBJECT_BASIC_LIMIT_INFORMATION on x64/arm64.
+    const basicLimits = koffi.struct("BT_JobBasicLimits", {
+      perProcessUserTimeLimit: "uint64_t",
+      perJobUserTimeLimit: "uint64_t",
+      limitFlags: "uint32_t",
+      minimumWorkingSetSize: "uint64_t",
+      maximumWorkingSetSize: "uint64_t",
+      activeProcessLimit: "uint32_t",
+      affinity: "uint64_t",
+      priorityClass: "uint32_t",
+      schedulingClass: "uint32_t",
+    });
+    const extendedLimits = koffi.struct("BT_JobExtendedLimits", {
+      basicLimitInformation: basicLimits,
+      ioInfo: ioCounters,
+      processMemoryLimit: "uint64_t",
+      jobMemoryLimit: "uint64_t",
+      peakProcessMemoryUsed: "uint64_t",
+      peakJobMemoryUsed: "uint64_t",
+    });
+    // Input structs accept plain objects: koffi copies fields by name and
+    // zero-fills the rest (same pattern as koffi's own GetCursorPos example).
+    limitInfo = {
+      basicLimitInformation: { limitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE },
+    };
+    limitInfoSize = koffi.sizeof(extendedLimits);
+
+    kernel32 = {
+      openProcess: lib.func(
+        `${handle} __stdcall OpenProcess(uint32_t dwDesiredAccess, int8_t bInheritHandle, uint32_t dwProcessId)`,
+      ),
+      createJobObjectW: lib.func(
+        `${handle} __stdcall CreateJobObjectW(void *lpJobAttributes, const wchar_t *lpName)`,
+      ),
+      setInformationJobObject: lib.func(
+        `int32_t __stdcall SetInformationJobObject(${handle} hJob, int32_t JobObjectInfoClass, BT_JobExtendedLimits *lpJobObjectInfo, uint32_t cbJobObjectInfoLength)`,
+      ),
+      assignProcessToJobObject: lib.func(
+        `int32_t __stdcall AssignProcessToJobObject(${handle} hJob, ${handle} hProcess)`,
+      ),
+      closeHandle: lib.func(`int32_t __stdcall CloseHandle(${handle} hObject)`),
+    } as Kernel32;
+  } catch {
+    kernel32 = null;
+  }
+  return kernel32;
+}
+
+/** Warm the kernel32 surface at manager startup so per-terminal assignment
+ * runs its (already synchronous) FFI calls in the same tick as the spawn. */
+export function preloadChildJobSupport(): Promise<void> {
+  return loadKernel32().then(() => undefined);
+}
+
+/**
+ * Put the freshly spawned child (and, by inheritance, every descendant it is
+ * about to create) into a dedicated KILL_ON_JOB_CLOSE job. Resolves
+ * `undefined` on any failure or non-Windows platform — cleanup then relies on
+ * the legacy PID-based paths exactly as before.
+ */
+export async function assignChildJob(pid: number): Promise<ChildJobHandle | undefined> {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return undefined;
+  const k = await loadKernel32();
+  if (!k) return undefined;
+  try {
+    const child = k.openProcess(PROCESS_TERMINATE | PROCESS_SET_QUOTA, false, pid);
+    if (!child) return undefined;
+    try {
+      const job = k.createJobObjectW(null, null);
+      if (!job) return undefined;
+      if (
+        !k.setInformationJobObject(
+          job,
+          JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+          limitInfo,
+          limitInfoSize,
+        ) ||
+        !k.assignProcessToJobObject(job, child)
+      ) {
+        // An empty job is harmless, but close it to release the handle.
+        k.closeHandle(job);
+        return undefined;
+      }
+      let closed = false;
+      return {
+        close() {
+          if (closed) return;
+          closed = true;
+          try {
+            k.closeHandle(job);
+          } catch {
+            // Handle already invalidated; the tree is gone either way.
+          }
+        },
+      };
+    } finally {
+      k.closeHandle(child);
+    }
+  } catch {
+    return undefined;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.101
         version: 4.0.0-beta.101
+      koffi:
+        specifier: ^3.1.6
+        version: 3.1.6
       typebox:
         specifier: '*'
         version: 1.3.14
@@ -730,6 +733,81 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@koromix/koffi-darwin-arm64@3.1.6':
+    resolution: {integrity: sha512-8FHyXGCZN7/iQf4f7W5BRysmtdlAFvSx6FpmX4u6wmkZiX/2e9hIRdGLiZYlHGudlcA18UmXB/cMiyhJ7fJkzA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@koromix/koffi-darwin-x64@3.1.6':
+    resolution: {integrity: sha512-uzx/jqFQuSHqgg1zaRidTBTCfj8Y9M0SDTO8HeoI9s9fJhiJ1mbB9TTwJO5c2hiMnuWg2m1byczC8BaIH6cG/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@koromix/koffi-freebsd-arm64@3.1.6':
+    resolution: {integrity: sha512-PjpTVrsCK5YTtixOw7VsseYXJOyoY6k0qBt+bf0T9h3wyV06y73rALsorFDDEoYpLUBZO7R6EIMs6CpUrEkNTQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-ia32@3.1.6':
+    resolution: {integrity: sha512-ETYwL820HtFwYoOVzgyvmFmzTHRo9DJtGYTxa5Nb7ajaa5ldCum0jbmUJ3PMECxFTLxD5Q6PYZ8Xbp101bGeSg==}
+    cpu: [ia32]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-x64@3.1.6':
+    resolution: {integrity: sha512-BkqxkNXhAAT9toU2stvLwx1iKHPDx7h08NCICyBbjYEXkCAEr84igTkpE5V3XJ9xZZ2gKll7VvdhxorHtHUqZw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@koromix/koffi-linux-arm64@3.1.6':
+    resolution: {integrity: sha512-cM4XPm9ljbCrcPgXjzFYjDNxDUvvuR7TCYaEoo1AKjwZT/vmWhu2xN3pomfbsHh6aVn80SFA3enufQnaETW1rQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@koromix/koffi-linux-ia32@3.1.6':
+    resolution: {integrity: sha512-l1SVTpO10iaQt8slbowJpzK4fbwQZ7ufj9tmCyAcIwWUpyAbPS83mJMctU72If6N9/gCS2wuRqwnYB2uPLLhLg==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@koromix/koffi-linux-loong64@3.1.6':
+    resolution: {integrity: sha512-KpTJpMSbIdCVFU26ynt0xy4x15h+y6AwPJxj2+iVxJhCzJf4oisCPc0YH2VnutuLV2nVzSrFm7sL/WSOqPgkXw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@koromix/koffi-linux-riscv64@3.1.6':
+    resolution: {integrity: sha512-YdFNpsywnXiYOYQlDAatf7TJLnspbGXdmfwIZhf82kbKSflYUsq4tI6NmoUOzM89oIWDGpYqd4Hz3xL7tsyXsw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@koromix/koffi-linux-x64@3.1.6':
+    resolution: {integrity: sha512-Xx5mpr9VcaMCXfvbqIiLIWIL9Iuu6F4r3iMXg7+zZCqYUFZPFwJgiDQBLxctHv2OYgIfAoaaHMW0GC1cJkHfbA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@koromix/koffi-openbsd-ia32@3.1.6':
+    resolution: {integrity: sha512-39Np4QTxhTlTT6RRveIeP+TnbzrwuDJ0UMyHxEZ+oGtzmb9GqWhl9T1oyehG6v/O+c4BffafG2NwLkCZ7tDKWw==}
+    cpu: [ia32]
+    os: [openbsd]
+
+  '@koromix/koffi-openbsd-x64@3.1.6':
+    resolution: {integrity: sha512-3EynGn3ycQRqaMWGmUJ0tdtuQdStByqSy/tJ0ZGKWizbMGdFAE73YpgLsyd8BDvwnKWytVG/OLNb5nDHpfd9Dg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@koromix/koffi-win32-arm64@3.1.6':
+    resolution: {integrity: sha512-27FdPPRtT4xbO9bsd2OZa95M5YQ7bcJ8QjCRO57UUMI21REfkDegjqKwqo/CFlugxXlJf5IYtG2rq4BEYIrvxg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@koromix/koffi-win32-ia32@3.1.6':
+    resolution: {integrity: sha512-5mVelLKVDup4eoxZOpCzCyMPxoctsg+Qe4J9O5BP4KbBEdqoOEqaNEBBRgNzXcdr2g+GGfmIUo+oVR1NvIdiJw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@koromix/koffi-win32-x64@3.1.6':
+    resolution: {integrity: sha512-lPKjAaHz0aoiZXT/wDVqH+joR5y3lCZj1s9Bk5qx/DGRq+0MK8Ib8VoqiBOrJ69NG5AsJSvn0tQDcSqfRgLmBQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@manypkg/find-root@3.1.0':
     resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
     engines: {node: '>=20.0.0'}
@@ -1320,6 +1398,9 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  koffi@3.1.6:
+    resolution: {integrity: sha512-ln60chEb3o7Du1ayjwl6BFiNN1wZK+3cTM2wWGiHLEzCY/FdTIN1ER5VWDwHq7J/j4tSnnrHaH5ABS1EO6+6ag==}
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
@@ -2128,6 +2209,51 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@koromix/koffi-darwin-arm64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-darwin-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-freebsd-arm64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-freebsd-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-freebsd-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-arm64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-loong64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-riscv64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-openbsd-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-openbsd-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-win32-arm64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-win32-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-win32-x64@3.1.6':
+    optional: true
+
   '@manypkg/find-root@3.1.0':
     dependencies:
       '@manypkg/tools': 2.1.2
@@ -2623,6 +2749,24 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  koffi@3.1.6:
+    optionalDependencies:
+      '@koromix/koffi-darwin-arm64': 3.1.6
+      '@koromix/koffi-darwin-x64': 3.1.6
+      '@koromix/koffi-freebsd-arm64': 3.1.6
+      '@koromix/koffi-freebsd-ia32': 3.1.6
+      '@koromix/koffi-freebsd-x64': 3.1.6
+      '@koromix/koffi-linux-arm64': 3.1.6
+      '@koromix/koffi-linux-ia32': 3.1.6
+      '@koromix/koffi-linux-loong64': 3.1.6
+      '@koromix/koffi-linux-riscv64': 3.1.6
+      '@koromix/koffi-linux-x64': 3.1.6
+      '@koromix/koffi-openbsd-ia32': 3.1.6
+      '@koromix/koffi-openbsd-x64': 3.1.6
+      '@koromix/koffi-win32-arm64': 3.1.6
+      '@koromix/koffi-win32-ia32': 3.1.6
+      '@koromix/koffi-win32-x64': 3.1.6
 
   kubernetes-types@1.30.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ overrides:
 # pnpm 11 denies dependency build scripts unless explicitly allowed here.
 allowBuilds:
   "@google/genai": true
+  koffi: true
   lefthook: true
   msgpackr-extract: true
   protobufjs: true


### PR DESCRIPTION
Closes #5

## Problem

On Windows, PID-based tree kills (`taskkill /T`) walk the parent chain. Once the shell exits — naturally or via a kill — its descendants are re-parented and unreachable: a descendant holding the inherited stdio pipes open survives every cleanup the manager controls. libuv's global `KILL_ON_JOB_CLOSE` job only closes when the whole Pi process dies, so those orphans linger for the entire session and keep the Node event loop alive (observed as a 17-minute test-runner hang in CI — see the evidence comment on #5).

#4 already narrows the race by force-killing the tree (`taskkill /F /T`) on the first attempt, but it cannot help when the shell is already gone — exactly the scenario #5 describes.

## Fix

Assign each spawned shell to a **dedicated Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`** (kernel32 loaded lazily through `koffi`, Windows only):

- Job membership is inherited by every descendant, so closing our job handle makes the kernel terminate all surviving tree members — orphaned or not — which also releases the stdio pipes they hold.
- The close fires at four points: entry settle, the SIGKILL escalation inside `terminateChild`, the entry-scope finalizer backstop, and the synchronous crash sweep in the process-exit tracker.
- Any failure (pre-Windows-8 nested-job restriction, koffi load error, child that exited before assignment) silently degrades to the previous PID-based behavior; `start()` never fails because of job support.

`taskkill` stays as the prompt first attempt; the job close is the kernel-level backstop.

## Tests

- The three tree-reap tests previously skipped on `win32` now run there: whole-tree kill, "shell exit with inherited pipes open settles naturally and reaps descendants" (the #5 scenario), and the natural-exit-vs-kill race.
- #4's Windows-only timeout-orphan test keeps running — now exercised through the job path too.
- Verified locally on macOS (98 pass + 1 platform skip); the `Test (windows-latest)` CI job is the real validation, including the first real koffi load.
