### PR TITLE
test(pi-background-terminals): stabilize Windows timeout coverage

### DIFF
--- a/packages/pi-background-terminals/index.test.ts
+++ b/packages/pi-background-terminals/index.test.ts
@@ -644,7 +644,6 @@ test("a hard timeout is reported as an unsuccessful bash call", async () => {
         {
           command: command("setInterval(() => {}, 1000)"),
           timeout: 0.1,
-          yield_time_ms: 1_000,
         },
         undefined,
         undefined,


### PR DESCRIPTION
## Summary

- let the hard-timeout integration test use the normal 10-second initial wait
- avoid racing Windows process-tree teardown against a test-only 1-second yield window
- keep the assertion that foreground hard timeouts reject the Bash tool call

## Cause

On Windows, terminating and settling the process tree can take longer than one second. The test's explicit `yield_time_ms: 1_000` could therefore return a background terminal before timeout cleanup settled, causing `assert.rejects` to fail even though timeout handling completed correctly.

## Verification

- `pnpm test`
- `pnpm run typecheck`
- `pnpm run check`
- targeted hard-timeout test on a clean branch
