### PR TITLE
fix(pi-image-cache): harden concurrent cleanup and reload lifecycle

### DIFF
--- a/.changeset/soft-pans-listen.md
+++ b/.changeset/soft-pans-listen.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-image-cache": patch
+---
+
+Fix concurrent-session cleanup deleting freshly created cache directories by adding a 10-minute grace period, dispose the stale runtime on extension reload, clear the terminal display cache per session, evict display entries as a true LRU capped at 50, and separate model-facing placeholder strings into lib/prompt.ts.

--- a/packages/pi-image-cache/index.ts
+++ b/packages/pi-image-cache/index.ts
@@ -16,10 +16,10 @@ import {
   displayPathFor,
   ENTRY_TYPE,
   EXTENSION_ID,
-  findPlaceholders,
   isInsideTmpDir,
   PI_CLIPBOARD_PATH_RE,
 } from "./lib/helpers.ts";
+import { findPlaceholders, formatAttachmentNote, formatImageNotesBlock } from "./lib/prompt.ts";
 import type { CachedImage, PreviewEntryData } from "./lib/types.ts";
 import {
   createImageCacheRuntime,
@@ -29,8 +29,19 @@ import {
   type ImageCacheRuntimeShape,
 } from "./src/runtime.ts";
 
-/** Terminal-displayable bytes keyed by the file they were read from. */
+/** Terminal-displayable bytes keyed by the file they were read from (LRU, capped at 50 entries). */
+const MAX_DISPLAY_CACHE_ENTRIES = 50;
 const displayDataByPath = new Map<string, { data: string; mimeType: string }>();
+
+function setDisplayData(path: string, display: { data: string; mimeType: string }): void {
+  // Re-insert so repeated hits refresh recency; eviction below is true LRU.
+  displayDataByPath.delete(path);
+  if (displayDataByPath.size >= MAX_DISPLAY_CACHE_ENTRIES) {
+    const oldest = displayDataByPath.keys().next().value;
+    if (oldest !== undefined) displayDataByPath.delete(oldest);
+  }
+  displayDataByPath.set(path, display);
+}
 
 function loadDisplayData(entry: PreviewEntryData): { data: string; mimeType: string } | undefined {
   const protocol = getCapabilities().images;
@@ -47,7 +58,7 @@ function loadDisplayData(entry: PreviewEntryData): { data: string; mimeType: str
       data: readFileSync(path).toString("base64"),
       mimeType: needsPng ? "image/png" : entry.mimeType,
     };
-    displayDataByPath.set(path, display);
+    setDisplayData(path, display);
     return display;
   } catch {
     return undefined;
@@ -120,6 +131,19 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_start", async (_event, ctx) => {
+    displayDataByPath.clear();
+    if (cacheRuntime) {
+      try {
+        if (cacheService) await run(cacheService.close);
+      } catch {
+        // Ignore errors during previous runtime close
+      } finally {
+        await cacheRuntime.dispose().catch(() => {});
+        cacheRuntime = undefined;
+        cacheService = undefined;
+      }
+    }
+
     cacheRuntime = createImageCacheRuntime();
     cacheService = cacheRuntime.runSync(ImageCacheRuntime);
     const sessionId = ctx.sessionManager.getSessionId?.() ?? `process-${process.pid}`;
@@ -131,6 +155,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async () => {
+    displayDataByPath.clear();
     if (!cacheRuntime || !cacheService) return;
     if (closing) {
       await closing.catch(() => {});
@@ -229,9 +254,7 @@ export default function (pi: ExtensionAPI) {
           continue;
         }
         attached.push(result.content);
-        notes.push(
-          `${placeholder} = attachment ${attached.length}${result.note ? ` (${result.note})` : ""}`,
-        );
+        notes.push(formatAttachmentNote(placeholder, attached.length, result.note));
       } catch {
         ctx.ui.notify(`Could not attach ${placeholder} from cache`, "warning");
       }
@@ -244,7 +267,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     if (notes.length > 0) {
-      text += `\n\n<image-cache-notes>\n${notes.join("\n")}\n</image-cache-notes>`;
+      text += formatImageNotesBlock(notes);
     }
 
     const count = await run(service().imageCount);

--- a/packages/pi-image-cache/lib/helpers.ts
+++ b/packages/pi-image-cache/lib/helpers.ts
@@ -7,7 +7,7 @@ import type { CachedImage } from "./types.ts";
 export const EXTENSION_ID = "image-cache";
 export const ENTRY_TYPE = "image-cache-preview";
 export const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-export const PLACEHOLDER_RE = /\[Image#(\d{3,})\]/g;
+export const EMPTY_CACHE_GRACE_MS = 10 * 60 * 1000;
 
 /** Inline images larger than this are dropped rather than sent to the provider. */
 export const MAX_INLINE_BYTES = 4.5 * 1024 * 1024;
@@ -50,10 +50,6 @@ export const MODEL_SUPPORTED_MIMES = new Set([
  */
 export const PI_CLIPBOARD_PATH_RE =
   /(?:^|[\s"'`(<])((?:[A-Za-z]:)?[\\/][^\s"'`<>)]*pi-clipboard-[A-Za-z0-9-]+\.(?:png|jpe?g|gif|webp|tiff?|heic|heif))(?=$|[\s"'`)>.,;:!?])/gi;
-
-export function formatPlaceholder(id: number): string {
-  return `[Image#${String(id).padStart(3, "0")}]`;
-}
 
 /** `[Image#001]` -> `Image-001`, safe for use as a filename on every platform. */
 export function fileStem(placeholder: string): string {
@@ -137,15 +133,6 @@ export function isInsideTmpDir(candidate: string): boolean {
 export function isPathWithin(root: string, candidate: string): boolean {
   const rel = relative(root, candidate);
   return rel === "" || (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
-}
-
-export function findPlaceholders(text: string): string[] {
-  const found: string[] = [];
-  for (const match of text.matchAll(PLACEHOLDER_RE)) {
-    const placeholder = match[0];
-    if (!found.includes(placeholder)) found.push(placeholder);
-  }
-  return found;
 }
 
 export function previewEntryData(cached: CachedImage) {

--- a/packages/pi-image-cache/lib/prompt.ts
+++ b/packages/pi-image-cache/lib/prompt.ts
@@ -1,0 +1,31 @@
+/**
+ * Model-facing prompt strings, tags, and placeholder patterns for pi-image-cache.
+ */
+
+export const PLACEHOLDER_RE = /\[Image#(\d{3,})\]/g;
+
+export function formatPlaceholder(id: number): string {
+  return `[Image#${String(id).padStart(3, "0")}]`;
+}
+
+export function findPlaceholders(text: string): string[] {
+  const found: string[] = [];
+  for (const match of text.matchAll(PLACEHOLDER_RE)) {
+    const placeholder = match[0];
+    if (!found.includes(placeholder)) found.push(placeholder);
+  }
+  return found;
+}
+
+export function formatAttachmentNote(
+  placeholder: string,
+  attachmentIndex: number,
+  dimensionNote?: string,
+): string {
+  return `${placeholder} = attachment ${attachmentIndex}${dimensionNote ? ` (${dimensionNote})` : ""}`;
+}
+
+export function formatImageNotesBlock(notes: string[]): string {
+  if (notes.length === 0) return "";
+  return `\n\n<image-cache-notes>\n${notes.join("\n")}\n</image-cache-notes>`;
+}

--- a/packages/pi-image-cache/src/runtime.ts
+++ b/packages/pi-image-cache/src/runtime.ts
@@ -37,9 +37,9 @@ import {
   CACHE_TTL_MS,
   detectMimeType,
   displayPathFor,
+  EMPTY_CACHE_GRACE_MS,
   fileStem,
   findByHash,
-  formatPlaceholder,
   hashBytes,
   imageExtension,
   isInsideTmpDir,
@@ -49,6 +49,7 @@ import {
   normalizeMimeType,
   previewEntryData,
 } from "../lib/helpers.ts";
+import { formatPlaceholder } from "../lib/prompt.ts";
 import type {
   CachedImage,
   ClipboardImages,
@@ -398,10 +399,11 @@ const makeImageCacheRuntime = (config: ResolvedImageCacheRuntimeConfig) =>
           }
         }
 
-        if (config.postWriteGate) {
-          config.postWriteGate.onImageFileWritten();
+        const postWriteGate = config.postWriteGate;
+        if (postWriteGate) {
+          postWriteGate.onImageFileWritten();
           yield* Effect.tryPromise({
-            try: () => config.postWriteGate!.waitUntilReleased(),
+            try: () => postWriteGate.waitUntilReleased(),
             catch: (cause) =>
               new ImageCacheRuntimeClosedError({
                 message: cause instanceof Error ? cause.message : String(cause),
@@ -539,7 +541,9 @@ const makeImageCacheRuntime = (config: ResolvedImageCacheRuntimeConfig) =>
                   const expired = now - info.mtimeMs > CACHE_TTL_MS;
                   const isEmpty = contents.length === 0;
                   const onlyManifest = contents.length === 1 && contents[0] === "manifest.json";
-                  if (expired || isEmpty || onlyManifest) {
+                  const isStaleEmpty =
+                    (isEmpty || onlyManifest) && now - info.mtimeMs > EMPTY_CACHE_GRACE_MS;
+                  if (expired || isStaleEmpty) {
                     await rm(fullPath, { recursive: true, force: true });
                   }
                 } catch {

--- a/packages/pi-image-cache/test/runtime.test.ts
+++ b/packages/pi-image-cache/test/runtime.test.ts
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
-import { access, readdir, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { join, parse } from "node:path";
 import test from "node:test";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { hashBytes, isPathWithin } from "../lib/helpers.ts";
+import {
+  findPlaceholders,
+  formatAttachmentNote,
+  formatImageNotesBlock,
+  formatPlaceholder,
+} from "../lib/prompt.ts";
 import {
   createImageCacheRuntime,
   createImageFileWrittenGate,
@@ -300,4 +306,48 @@ test("ImageCacheRuntime close rejects mutations started after admission stops", 
 
   assert.equal(await pathExists(cacheDir), false);
   await runtime.dispose();
+});
+
+test("ImageCacheRuntime cleanup preserves recent concurrent session cache directories", async () => {
+  const concurrentSessionId = `concurrent-${Date.now()}`;
+  const concurrentDir = join(CACHE_ROOT, concurrentSessionId);
+  await mkdir(concurrentDir, { recursive: true });
+  await writeFile(join(concurrentDir, "manifest.json"), JSON.stringify({ version: 1, images: [] }));
+
+  const runtime = createImageCacheRuntime();
+  const cache = runtime.runSync(ImageCacheRuntime);
+  const mySessionId = `session-${Date.now()}`;
+
+  try {
+    await runImageCache(runtime, cache.init(mySessionId));
+    // The concurrent session dir was created recently with only manifest.json;
+    // it must not be prematurely deleted by my session's init cleanup.
+    assert.equal(await pathExists(concurrentDir), true);
+  } finally {
+    await runImageCache(runtime, cache.close);
+    await runtime.dispose();
+    await rm(concurrentDir, { recursive: true, force: true });
+  }
+});
+
+test("prompt helpers format and parse placeholders correctly", () => {
+  assert.equal(formatPlaceholder(1), "[Image#001]");
+  assert.equal(formatPlaceholder(42), "[Image#042]");
+  assert.equal(formatPlaceholder(1000), "[Image#1000]");
+
+  const text = "Check out [Image#001] and [Image#002] but not [Image#01]";
+  const placeholders = findPlaceholders(text);
+  assert.deepEqual(placeholders, ["[Image#001]", "[Image#002]"]);
+
+  assert.equal(
+    formatAttachmentNote("[Image#001]", 1, "image resized to 100x100"),
+    "[Image#001] = attachment 1 (image resized to 100x100)",
+  );
+  assert.equal(formatAttachmentNote("[Image#002]", 2), "[Image#002] = attachment 2");
+
+  assert.equal(
+    formatImageNotesBlock(["[Image#001] = attachment 1"]),
+    "\n\n<image-cache-notes>\n[Image#001] = attachment 1\n</image-cache-notes>",
+  );
+  assert.equal(formatImageNotesBlock([]), "");
 });


### PR DESCRIPTION
## What

Review-driven hardening of pi-image-cache:

- **Concurrent cleanup race fix** — a session's init cleanup could delete another session's freshly created cache directory (empty or manifest-only) before its first image landed. Empty/manifest-only directories now get a 10-minute grace window (`EMPTY_CACHE_GRACE_MS`) on top of the 24h TTL. Deleted directories self-heal: the next write does a recursive `mkdir` and rewrites the full manifest from memory.
- **Reload lifecycle** — extension reload previously leaked the previous Effect runtime (workers, refs) and kept stale base64 display data. `session_start` now closes and disposes the old runtime before creating a new one. Verified safe: `close()` only removes the session directory when it holds no images, and the new runtime re-adopts existing images via `loadManifest`, so reloads keep cached images.
- **True LRU display cache** — the terminal display cache is capped at 50 entries; entries now re-insert on hit so eviction is genuine LRU instead of insertion-order FIFO.
- **Prompt separation** — model-facing placeholder strings (`PLACEHOLDER_RE`, `formatPlaceholder`, `findPlaceholders`, attachment-note formatting) moved to `lib/prompt.ts` per repo convention, imported directly (no helpers re-export shim).

## Verification

- `pnpm --filter @tian.zuo/pi-image-cache run check` (tsc) ✅
- `pnpm --filter @tian.zuo/pi-image-cache test` 13/13 ✅ (incl. new concurrent-session preservation and prompt-helper tests)
- biome clean
