### PR TITLE
feat(pi-antigravity): adopt persistent agy driver

### DIFF
--- a/.changeset/bright-drivers-travel.md
+++ b/.changeset/bright-drivers-travel.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-antigravity": minor
+---
+
+Require agy 1.1.22+, select the newest compatible installed stable binary with automatic cache invalidation, reuse a persistent stream-json driver across ordinary turns, report spawn/recycle counters and causes, recycle safely when model/profile/bridge configuration changes, add binary and model-effort diagnostics, expose custom agent and plan-mode configuration, enrich conversation status, and add safe direct markdown artifact previews.

--- a/packages/pi-antigravity/PLAN.md
+++ b/packages/pi-antigravity/PLAN.md
@@ -1,0 +1,889 @@
+# Plan: improve `pi-antigravity` from the Antigravity VS Code extension
+
+## Status and implementation baseline
+
+This reviewed plan is **implemented on branch
+`feat/pi-antigravity-vscode-improvements`**, based directly on `origin/main` commit
+`59a2c0e11f2c48f8db42cb2a0f8fe7f8a57c1052`.
+
+The implementation started from main at or after `f1ae49c`
+(`feat(pi-antigravity): let agy own native context compaction`). That mainline already
+contains:
+
+- branch-owned native conversation persistence in `lib/conversation-state.ts`;
+- `.db` existence checks and missing-conversation fallback;
+- isolated disposable conversations for Pi compaction/branch summaries;
+- cumulative usage restoration; and
+- heuristic native-context compaction markers in `lib/agy-compaction.ts`.
+
+Do not reimplement or weaken those behaviors. The original checkout had unrelated dirty files, so implementation was isolated in a
+new clean worktree rather than modifying or rebasing that checkout.
+
+## Research performed
+
+Inspected:
+
+- VS Code extension `google.google-antigravity-1.1.0`:
+  - `package.json` and `README.md`;
+  - generated modules in `extension.js`, especially `binary_downloader.ts`,
+    `server_manager.ts`, `artifact_editor_provider.ts`, `editor_state_watcher.ts`,
+    `extension_api_impl.ts`, `agent_edit_manager.ts`, and `hunk_storage.ts`;
+  - the embedded `jetski_cortex.proto` descriptor; and
+  - `bridge.js`/webview integration boundaries.
+- Installed `agy` 1.1.22, its CLI help, models, agents, stream protocol, and local state
+  under `~/.gemini/antigravity-cli/`.
+- `origin/main`'s current `pi-antigravity` runtime, provider, bridge, persistence,
+  compaction, artifact, and test code.
+
+The VS Code extension is not the agent runtime. It downloads and starts `agy --hub`,
+embeds the hub UI in webviews, and adapts VS Code editor state, diffs, and commands to
+that UI. The reusable parts are its **process-management rules, compatibility checks,
+conversation summaries, artifact conventions, and safety checks**. Its hub/Connect RPC
+surface is private and should not be copied.
+
+## Implementation and live-probe record (2026-08-30)
+
+- Baseline: scoped typecheck and 169 tests passed before changes.
+- Full driver argv probe on agy 1.1.22 used the documented stream-json input/output
+  flags, `--add-dir`, normalized model plus valid effort, and no `--print` or
+  `--print-timeout`. Two user events separated by 17 idle seconds stayed on PID 6255,
+  conversation `1aad543c-d701-4372-92f8-7ac0133f53d2`, and returned terminal
+  `SUCCESS` results with `num_turns` 1 then 2.
+- MCP catalog probe registered a unique loopback server, changed its one tool from an
+  `alpha: string` schema to a `beta: integer` schema between driver turns, and removed
+  both registration and manifest cache in `finally`. agy 1.1.22 called `initialize`
+  once and `tools/list` once at process startup; turn 2 did **not** refresh the list and
+  still called the old `alpha` schema. This confirms that catalog-revision process
+  recycling is required rather than merely defensive.
+- Public stream-json captures still expose no exact compaction boundary. Exact
+  `compacted_at_step_indices` remain private hub state, so the mainline conservative
+  token-drop heuristic is intentionally unchanged.
+- The workstreams below were implemented together so persistent process reuse never
+  ships without bridge catalog invalidation. The operational rollback remains
+  `PI_ANTIGRAVITY_DRIVER=0`.
+- Post-review hardening removed PATH-order bias: automatic resolution probes both PATH
+  and the managed install, chooses the newest compatible stable semver, and uses an
+  explicit development build only when no stable candidate is available. Cached
+  successes are invalidated when a resolved path or executable file signature changes.
+- Driver snapshots and `/agy doctor` now expose spawn/respawn, submitted/reused turn,
+  current-process turn, recycle, last-cause, and per-cause counters. This makes an
+  effort/catalog configuration that accidentally defeats persistence observable.
+- The compact parameterized lifecycle suite covers every fingerprint/conversation
+  mismatch plus overall timeout, active-tool stall, abort cleanup, concurrent
+  serialization, and pre-result process death without creating one test fixture per
+  matrix cell.
+
+## Verified findings and decisions
+
+| VS Code/agy finding | What is useful to Pi | Decision |
+| --- | --- | --- |
+| The extension validates `agy --version` with a 5-second timeout and categorizes missing binary, permission, spawn, and timeout failures. | Fail early with actionable diagnostics instead of failing during a model turn. | Add a lazy compatibility preflight and `/agy doctor`. Require the exact driver baseline we test: agy **1.1.22+**. In automatic mode probe PATH and managed candidates, then choose the newest compatible stable build instead of trusting discovery order. |
+| The extension downloads and atomically updates `~/.gemini/bin/agy`, with manifest retries and checksums. | The integrity and atomicity design is sound. | **Do not port auto-download/update.** npm extensions should not silently install executables. Continue to honor `AGY_BINARY` and tell the user how to install/update. |
+| `AntigravityServerManager` has a singleton start promise, bounded readiness wait, line-buffered diagnostics, and graceful-then-force shutdown. | These are good lifecycle rules for a persistent child. | Reuse the lifecycle pattern for the documented stream-json CLI driver, not the hub. |
+| The extension runs `agy --hub --hub-port=…` and serves the UI through internal APIs. | It exposes more state, but only through undocumented, CSRF/auth-gated, version-coupled APIs. | **Reject hub, `agentapi`, LS RPC, and embedded web UI integration.** |
+| `agy --input-format stream-json --output-format stream-json` accepts one NDJSON user event per turn and keeps a process/conversation alive across turns. | Removes one process/auth/workspace/MCP startup per user turn. | Build one lazy persistent driver per Pi runtime. |
+| Live probe: two user events in one process retain the same conversation and increment `num_turns`. | Confirms the core optimization is viable. | Make persistent mode the default, with a temporary `PI_ANTIGRAVITY_DRIVER=0` operational rollback. |
+| Live probe: `--print-timeout 15s` allowed turn 1, but after the budget elapsed the process accepted turn 2 without producing a result. | `--print-timeout` is not a safe per-turn deadline in driver mode. | **Omit `--print-timeout` from persistent-driver argv.** Keep Pi-owned overall/stall timers. One-shot `/usage` and rollback mode keep their existing timeout flag. |
+| Live probe: selecting a normalized model such as `gemini-3.7-flash` without `--effort` returns an error; discovered model rows encode supported effort variants. | Current model normalization loses a required launch constraint. | Preserve supported/default efforts during model discovery and always resolve a valid launch effort for variant-based models. |
+| The VS Code process is configured once at launch (workspace dirs, model-facing host state). | `cwd`, model, effort, agent, and mode cannot safely drift inside one CLI process. | Treat them as a process configuration fingerprint; recycle and resume when any changes. |
+| agy loads MCP servers at process startup. It is not yet proven that a stream driver repeats `tools/list` on later turns. | A persistent process could retain a stale Pi skill/MCP catalog after `/reload` or tool activation changes. | Add a catalog revision to the process fingerprint and conservatively recycle between turns when it changes. Confirm behavior with a live probe before merging. |
+| The extension's workspace state stores only `lastConversationId`; reset clears stale conversation/diff state. | Titles are useful, but that ownership model is weaker than Pi's branch-aware state. | Keep main's Pi branch ownership and `.db` liveness checks. Use metadata only to enrich display. |
+| `cache/conversation_metadata.json` contains `Title`, `Preview`, `NumSteps`, `UpdatedAt`, `WorkspaceURIs`, and `AgentName`. | Better `/agy` status text. | Add a tolerant, read-only metadata parser. Never use this cache as liveness authority. |
+| The custom artifact editor matches `**/.gemini/*/brain/**/*.md` and routes a markdown URI plus conversation ID to the hub artifact page. | Current Pi scanning misses conversation-root markdown/direct artifacts. | Include safe root-level artifacts and add local markdown/checklist preview. Do not embed the hub viewer. |
+| The extension's inline diff receives **both complete original and modified contents**, hashes hunks, records resolutions, detects external edits, and falls back to read-only diff when content diverges. | Its safety invariants are valuable. | **Do not add accept/reject diffs from stream-json.** Pi does not receive authoritative pre/post snapshots; reconstructing them from tool events or Git could overwrite user changes. |
+| The editor watcher debounces active editor, selection, visible ranges, document versions, and recent tabs. | Useful only with direct VS Code APIs. | **Do not port passive IDE context.** Pi is terminal-hosted and already has explicit file/tool context. |
+| The extension's agent status uses `notFullyIdle` and `waitingSteps`; Escape interrupts the agent. | Status and cancellation matter. | Use driver state plus existing streamed tool activities and Pi abort signals. Do not depend on private status RPCs. |
+| Embedded `CompactionInfo` has only `repeated int32 compacted_at_step_indices`, delivered through private `AgentStateUpdate.compaction_info`. | Confirms an exact boundary exists internally, but not its token counts. | Probe stream-json once. Keep main's heuristic unless a public stream event exposes the indices. Never parse private protobuf DBs. |
+| agy supports `--agent`, `agy agents`, and `--mode plan|accept-edits`. | Stable CLI-level access to custom agents and plan mode. | Add validated pass-through configuration and `/agy agents`. |
+
+## Goals
+
+1. Reuse one healthy agy process across ordinary user turns.
+2. Preserve all mainline conversation/branch/summary isolation semantics.
+3. Make binary and process failures diagnosable before they waste a turn.
+4. Prevent stale Pi skills/MCP tools in a persistent process.
+5. Surface useful local Antigravity metadata and markdown artifacts.
+6. Expose supported agent/mode controls without private APIs.
+7. Keep every TUI renderer width-safe and every lifecycle path leak-free.
+
+## Non-goals
+
+- No `agy --hub`, Connect RPC, `agentapi`, webview, or VS Code bridge.
+- No executable downloader or updater.
+- No arbitrary resume/switch to conversations from the global metadata cache.
+- No passive editor-selection/tab context capture.
+- No inline hunk accept/reject until a documented protocol supplies authoritative
+  original and modified contents.
+- No direct `.db`, protobuf, JSONL transcript, or `.system_generated` scraping for
+  conversation semantics.
+- No replacement for agy's native subagents, tools, permissions, or MCP registry.
+
+---
+
+## Workstream 0 — clean baseline and protocol gates
+
+### 0.1 Rebase and establish baseline
+
+Before implementation:
+
+1. Start from a clean worktree.
+2. Rebase onto current `origin/main` so the compaction/persistence work above is present.
+3. Run the package checks and record the clean baseline:
+
+```bash
+pnpm --filter @tian.zuo/pi-antigravity run check
+pnpm --filter @tian.zuo/pi-antigravity test
+```
+
+### 0.2 Complete two bounded live probes
+
+Add a non-published/manual probe script or document exact commands; do not make live
+agy calls part of CI.
+
+1. **Full driver argv probe**
+   - Launch with `--input-format stream-json`, `--output-format stream-json`,
+     `--dangerously-skip-permissions`, `--disable-slash-commands`, `--add-dir`, a
+     discovered model, and a valid discovered effort.
+   - Omit `--print` and `--print-timeout`.
+   - Send two user lines separated by an idle period.
+   - Assert same PID, same non-empty conversation ID, `num_turns` 1 then 2, and two
+     terminal results.
+2. **MCP catalog refresh probe**
+   - Register a uniquely named temporary loopback MCP server and remove it in `finally`.
+   - Count `initialize` and `tools/list` calls.
+   - Change its advertised tool schema between driver turns.
+   - Record whether turn 2 triggers another `tools/list` and whether the model can see
+     the changed tool.
+   - Regardless of the result, retain catalog-revision recycling initially; it is rare
+     and is the fail-safe behavior.
+
+Record the observed agy version and results in this file or a short research note.
+
+### Exit criteria
+
+- The implementation target is a clean mainline baseline.
+- Driver argv and catalog behavior are reproducible and no temporary MCP registration
+  remains.
+
+---
+
+## Workstream 1 — binary compatibility and model launch correctness
+
+### 1.1 Add compatibility diagnostics
+
+Add `lib/agy-diagnostics.ts`:
+
+- `MIN_AGY_VERSION = "1.1.22"`.
+- `resolveAgyBinary()` applies this policy:
+  1. an explicit `AGY_BINARY` override is strict; do not silently fall back if it fails;
+  2. otherwise discover both `agy` from `PATH` and the VS Code extension's existing
+     managed binary at `~/.gemini/bin/agy` (or `agy.exe` on Windows);
+  3. validate all distinct discovered candidates and choose the highest compatible
+     stable semver, regardless of discovery order; and
+  4. if no stable candidate exists, choose the highest compatible prerelease before
+     accepting a `dev`/`HEAD` candidate; development builds are the final fallback.
+- Candidate resolution may reuse an already installed Google-managed binary but must
+  never download or modify one. Use a maintained cross-platform executable resolver.
+- `checkAgyBinary(options)` runs each eligible candidate with `--version` using:
+  - a 5-second timeout;
+  - detached/process-tree cleanup consistent with the existing child tracker;
+  - bounded stdout/stderr capture; and
+  - structured failure categories: `not-found`, `permission-denied`, `timeout`,
+    `spawn-failed`, `invalid-version`, `unsupported-version`.
+- Cache the selected absolute path and successful result by resolution configuration,
+  resolved paths, and executable size/mtime/ctime signatures. Re-resolve and re-stat on
+  access so a newly installed/replaced PATH or managed binary invalidates the cached
+  compatibility result automatically. `/agy doctor` also forces a refresh.
+- Route **all** agy invocations through the selected path: model discovery, MCP
+  registration, usage, agents, one-shot rollback, and persistent driver. Do not let
+  auxiliary commands accidentally run another agy version from `PATH`.
+- Development/HEAD versions may be accepted only when their output explicitly says
+  `dev` or `HEAD`; malformed versions fail closed.
+- Use a maintained semver package rather than a home-grown prerelease comparator.
+
+Run this lazily before the first Antigravity child starts. Merely loading the extension
+or using another provider must not add a new blocking agy call.
+
+### 1.2 Preserve model effort capabilities
+
+Update `lib/models.ts`:
+
+- Extend each normalized model record with discovered `supportedEfforts` and
+  `defaultEffort`.
+- Merge `foo-high`, `foo-medium`, and `foo-low` rows into one Pi model without losing
+  the variants.
+- Use discovery order as agy's default preference; for the current catalog that makes
+  Gemini default to `high` and GPT-OSS to `medium`.
+- Base rows without effort suffixes remain valid with no forced effort unless a live
+  validation probe proves otherwise.
+- Map Pi thinking levels to the closest supported value:
+  - minimal/low → low;
+  - medium → medium;
+  - high/xhigh/max → high;
+  - if unavailable, choose the model's discovered default instead of passing an
+    invalid value.
+- Add effort metadata to the fallback snapshot so offline discovery behaves the same.
+
+### 1.3 Add `/agy doctor`
+
+Extend the existing `/agy` command with `doctor`. It performs no model inference and
+reports, without secrets:
+
+- selected binary, source, version, and selection reason;
+- every discovered candidate and its version/failure category;
+- minimum supported version;
+- model discovery success/count and source;
+- selected model plus resolved effort;
+- bridge enabled/running/registered state and catalog revision;
+- driver mode/state/PID/configuration, spawn/respawn count, submitted/reused turns,
+  current-process turns, recycle count, and per-cause recycle counters, if started;
+- current conversation ID and whether its `.db` is readable; and
+- whether conversation metadata is readable.
+
+The command should aggregate independent failures instead of stopping at the first one.
+Use concise notifications in print/RPC mode and a width-safe overlay only if the existing
+command notification becomes unreadable.
+
+### Tests
+
+Add `test/agy-diagnostics.test.ts`; update `test/models.test.ts` and
+`test/agy-client.test.ts`:
+
+- version extraction from stdout and stderr;
+- explicit override, PATH, managed-binary fallback, Windows suffix, and no-download
+  behavior;
+- exact minimum, newer, older, malformed, dev/HEAD;
+- ENOENT, EACCES, timeout, non-zero exit, bounded diagnostics;
+- every auxiliary command uses the same resolved binary;
+- merging effort variants and choosing fallback effort;
+- full launch argv never sends `--model <variant-base>` without a valid required
+  effort.
+
+### Exit criteria
+
+- Unsupported binaries fail before a turn with an actionable message.
+- Every discovered/fallback model produces an argv combination accepted by agy 1.1.22.
+- No updater/download behavior is introduced.
+
+---
+
+## Workstream 2 — persistent stream-json driver
+
+### 2.1 Keep a full request contract
+
+Do not design the driver as `submitTurn(prompt)`. It must accept the full current
+request because process reuse depends on more than text.
+
+Extend/refine `AgyTurnRequest` in `lib/agy-client.ts` with:
+
+- existing prompt, conversation ID, model, effort, cwd, signal, timeout, inactivity
+  budgets, and callbacks;
+- optional `agent` and `mode`;
+- a non-argv `bridgeRevision` used in the process fingerprint; and
+- test seams for spawn/time where needed.
+
+Split argument construction into explicit functions:
+
+- `buildOneShotAgyArgs(request)` — existing rollback behavior with
+  `--print <prompt>` and `--print-timeout`;
+- `buildDriverAgyArgs(processConfig)` — exactly:
+  - `--input-format stream-json`;
+  - `--output-format stream-json`;
+  - `--dangerously-skip-permissions`;
+  - `--disable-slash-commands`;
+  - `--add-dir <cwd>` when set;
+  - `--conversation <id>` only when launching from a known persisted/resumed
+    conversation;
+  - resolved `--model`/`--effort`;
+  - optional `--agent` and `--mode`; and
+  - **no `--print` and no `--print-timeout`**.
+
+### 2.2 Add `lib/agy-driver.ts`
+
+Implement `AgyDriverSession` with a small explicit state machine:
+
+- `idle` — no process yet;
+- `starting` — one shared start promise prevents duplicate children;
+- `ready` — process alive, no turn active;
+- `running` — exactly one submitted turn owns incoming events;
+- `stopping`/`dead` — no writes accepted; next submission may spawn.
+
+Public contract:
+
+```ts
+interface AgyTurnExecutor {
+  run(request: AgyTurnRequest): Promise<AgyTurnOutcome>;
+  snapshot(): AgyExecutorSnapshot; // includes bounded lifecycle + cumulative counters
+  close(
+    reason: "recycle" | "abort" | "shutdown",
+    cause?: AgyRecycleCause,
+  ): Promise<void>;
+}
+```
+
+Provide two implementations:
+
+- persistent `AgyDriverSession` (default);
+- one-shot executor wrapping current `runAgyTurn` when
+  `PI_ANTIGRAVITY_DRIVER=0`.
+
+`AgyDriverSession.run(request)` must:
+
+1. Serialize calls; never put two user events in flight.
+2. Ensure the binary preflight passed.
+3. Reuse only when process configuration and conversation ownership match.
+4. Write one NDJSON line:
+
+   ```json
+   {"event":"user","message":{"role":"user","content":"…"}}
+   ```
+
+5. Honor stream backpressure (`write()` false → await `drain`) and handle callback
+   errors/EPIPE.
+6. Create a fresh `AgyTurnOutcome` and callback set for each line.
+7. Fold stdout events through existing `parseAgyLine`/`applyEvent` until that turn's
+   next `result`.
+8. Resolve the logical turn immediately on `result`, leaving the process alive.
+9. Mark the process dead on later close so the next turn resumes by conversation ID.
+
+### 2.3 Process configuration and resume rules
+
+The process fingerprint must contain:
+
+- resolved binary path and validated version (so replacing an executable in place
+  recycles the already-running old image on the next turn);
+- cwd/add-dir set;
+- model;
+- resolved effort;
+- agent;
+- mode; and
+- bridge registration/catalog revision.
+
+Conversation ID is handled separately:
+
+- A fresh process starts without `--conversation`; `init`/`result` binds its ID.
+- A reused process is valid only when the request's conversation is the bound ID.
+- A restored session or respawn launches with `--conversation <known-id>`.
+- A request for no conversation while the process is bound means reset/fork and must
+  recycle first.
+- A different conversation ID always recycles; never send a turn to the wrong mutable
+  conversation.
+
+Fingerprint changes are allowed only between logical turns. A Pi provider re-entry
+while the current agy turn is blocked on a bridge tool reuses the existing
+`AgyTurnController`; it must not submit or recycle anything.
+
+### 2.4 Framing, errors, and diagnostics
+
+- Maintain one stdout partial-line buffer across chunks.
+- Accept multiple lines in one chunk and lines fragmented across chunks.
+- On process close, parse a final non-empty unterminated line before deciding failure.
+- Keep only a bounded stderr tail (existing 8 KiB is sufficient) and a small bounded
+  lifecycle log for `/agy doctor`.
+- Unknown JSON events remain non-fatal.
+- Output received while no turn is active may update diagnostics but must never be
+  attached to the next turn.
+- If the child closes before `result`, reject with `AgySpawnError` and mark dead.
+- If it closes after a settled result, do not retroactively fail that turn.
+- Guard all listeners with a child generation so late events from a recycled child
+  cannot settle a newer turn.
+
+### 2.5 Timers and cancellation
+
+Move current watchdog semantics to the active submitted turn, not the process lifetime:
+
+- arm overall and inactivity timers only after a user line is submitted;
+- re-arm inactivity on any stdout/stderr bytes;
+- switch to the longer tool budget between `tool_start` and terminal tool activity;
+- disarm every timer on result/error/abort;
+- keep no idle timer between turns;
+- on stall, kill the active process tree and throw `AgyStallError` so the existing
+  bounded continuation retry can resume the known conversation;
+- on Pi abort, kill the active process tree and return the existing aborted outcome;
+- an abort listener from an old turn must be removed when that turn settles.
+
+Shutdown policy, adapted from the VS Code manager:
+
+- idle recycle: close stdin and allow a short graceful exit, then SIGTERM, then
+  SIGKILL if necessary;
+- active abort/stall: immediate process-tree termination;
+- session shutdown: stop known agy background tasks first (existing behavior), then
+  force the driver tree closed;
+- always integrate with `trackAgyChild`/`untrackAgyChild` and global death hooks.
+
+### 2.6 Runtime integration
+
+Change `src/runtime.ts` to own an executor, not only an injected function:
+
+- normal runtime owns one persistent executor;
+- `reset`, cwd changes, model changes, branch/tree replacement, and close invalidate
+  active work and close/recycle the executor as appropriate;
+- fingerprint-only changes (effort/agent/mode/catalog) recycle the process but preserve
+  the runtime's known conversation ID;
+- existing missing-conversation fallback and stall continuation loops remain the
+  authority for retry behavior;
+- existing usage and conversation callbacks remain unchanged.
+
+Preserve summary isolation from `origin/main`:
+
+- Pi compaction/branch-summary requests use a separate runtime and executor;
+- that executor must never receive the user's conversation ID;
+- close it immediately after the summary turn and dispose its Effect runtime;
+- a summary failure/abort must also close it;
+- no summary prompt may appear in the user's persistent process.
+
+### 2.7 Reuse observability
+
+Keep cumulative counters on the executor rather than the child so a respawn does not
+erase the evidence. Snapshot and `/agy doctor` report:
+
+- total spawns and derived respawns;
+- submitted turns, reused turns, and turns submitted to the current process;
+- recycle total, last cause, and a per-cause map for binary, cwd, model, effort, agent,
+  mode, bridge catalog, conversation mismatch/reset, session tree, restore, and reset;
+- a bounded timestamped lifecycle tail with the cause appended to recycle entries.
+
+Count a recycle only when a live child is actually closed; a reset before the lazy first
+spawn must not look like process churn. Do not persist these counters across Pi runtime
+restarts and do not put them in model-facing prompts.
+
+### Tests
+
+Add `test/agy-driver.test.ts` with a controllable fake child and a fake executable
+integration fixture. Cover:
+
+- two turns, one spawn, same PID/conversation;
+- exact NDJSON input and no `--print`/`--print-timeout`;
+- fragmented lines, coalesced lines, CRLF, and final unterminated line;
+- unknown events and stderr noise;
+- stdout backpressure, `drain`, EPIPE, and child error;
+- process death before result versus after result;
+- no idle watchdog between turns;
+- overall timeout, base stall, active-tool stall, abort, and listener cleanup;
+- serialized concurrent submissions;
+- process fingerprint reuse and recycle for every field;
+- fresh/restored/different conversation matching;
+- late events from an old process generation;
+- graceful close escalation and no tracked-child leak;
+- rollback executor under `PI_ANTIGRAVITY_DRIVER=0`.
+
+Update `test/runtime.test.ts` and `test/provider.test.ts` for:
+
+- reset, cwd, model, session tree, restored state, and shutdown close the driver;
+- stall retry respawns with the continuation prompt and known ID;
+- bridge tool-use provider re-entry does not submit a second user event;
+- isolated summaries use another executor and close it;
+- regular turns after a summary remain in the original process/conversation.
+
+### Exit criteria
+
+- Two ordinary Pi user turns use one agy PID and one conversation.
+- All lifecycle changes route the next turn to the correct conversation/workspace.
+- No driver survives session shutdown.
+- The kill switch restores one-shot behavior without changing provider output.
+
+---
+
+## Workstream 3 — bridge catalog coherence
+
+A persistent agy process must not freeze the Pi skill/MCP catalog captured at startup.
+
+### 3.1 Add a stable catalog revision
+
+Update `lib/bridge.ts`:
+
+- Build a canonical catalog from exposed tool name, description, and input schema.
+- Sort tools by exposed name and recursively sort object keys before hashing/comparing;
+  preserve array order because JSON Schema arrays can be semantic. Pi enumeration or
+  object insertion order must not cause spurious process restarts.
+- Include the dynamic `activate_skill` definition and its enum/description.
+- Increment `catalogRevision` only when canonical content changes.
+- Expose the current revision and whether `refreshTools()` changed it.
+
+Update `lib/bridge-lifecycle.ts`:
+
+- Track a registration generation that changes on successful register/teardown.
+- Expose one combined process revision, e.g.
+  `<registration-generation>:<catalog-revision>`.
+
+### 3.2 Refresh before starting a turn
+
+Reorder non-summary setup in `src/provider.ts`:
+
+1. refresh bridge tools;
+2. resolve pending bridge results from Pi context;
+3. obtain the combined bridge revision;
+4. call `beginStreamTurn` with that revision.
+
+For provider re-entry into an already active controller, a changed catalog waits until
+the next user turn; never kill a process that is waiting for a Pi tool result.
+
+On a changed revision between user turns:
+
+- gracefully recycle the driver;
+- resume the same conversation ID; and
+- let agy perform startup `tools/list` against the new catalog.
+
+Model switch ordering:
+
+- leaving Antigravity: abort/close the driver before deregistering the bridge;
+- entering Antigravity: register/refresh the bridge before the first lazy driver spawn.
+
+Direct fallback mode is unchanged: when bridge registration fails, the skill path
+catalog is appended only when needed, using existing bootstrap-suffix deduplication.
+
+### Tests
+
+Update `test/bridge.test.ts`, `test/runtime.test.ts`, and `test/provider.test.ts`; add
+`test/bridge-lifecycle.test.ts` for the lifecycle generation behavior:
+
+- unchanged/reordered catalogs keep one revision;
+- schema/description/skill changes increment it;
+- registration teardown/re-register changes it;
+- one new process is launched on revision change and resumes the same conversation;
+- no recycle occurs during a pending bridge call;
+- switch-away closes driver before bridge teardown;
+- switch-back registers bridge before spawn;
+- `/reload` skill changes become visible on the next agy user turn.
+
+### Exit criteria
+
+- A persistent process never silently serves a stale Pi skill/MCP catalog.
+- Catalog churn does not contaminate or reset conversation history.
+
+---
+
+## Workstream 4 — conversation metadata as display enrichment
+
+Add `lib/conversation-metadata.ts`.
+
+### Parser and I/O rules
+
+- Default path:
+  `~/.gemini/antigravity-cli/cache/conversation_metadata.json`.
+- Parse only bounded, useful fields:
+  - `ID`;
+  - `Title`;
+  - `Preview`;
+  - `NumSteps`;
+  - `UpdatedAt`;
+  - `WorkspaceURIs`;
+  - `AgentName`.
+- Validate object/array/string/number types and cap string lengths.
+- Refuse an unexpectedly large cache before reading it.
+- Missing file, atomic replacement races, malformed JSON, or malformed records return
+  no enrichment; they never fail a model turn.
+- Do not cache indefinitely. Read on `/agy`/doctor or use a short mtime-aware cache.
+
+### Status behavior
+
+Enhance `/agy` status with:
+
+- title, falling back to a shortened ID;
+- step count and formatted update time when valid;
+- model, turns, native context estimate, process state/PID;
+- configured agent/mode; and
+- metadata absence only as a diagnostic note, not an error.
+
+**Liveness remains unchanged:**
+
+- `agyConversationExists()` checking `conversations/<id>.db` is authoritative at
+  restore time;
+- agy's missing-conversation error remains the runtime fallback;
+- absence from metadata must never discard a valid branch-owned conversation.
+
+Do not add a global conversation switcher. A mutable agy conversation belongs to one Pi
+branch; arbitrary resume would violate main's ownership guarantees.
+
+### Tests
+
+Add `test/conversation-metadata.test.ts` and status formatting tests:
+
+- real-shape fixture with capitalized field names;
+- missing, malformed, oversized, partial, and wrong-type data;
+- Unicode/very long titles;
+- absent metadata does not affect restore;
+- metadata present but `.db` absent still fails liveness;
+- status output remains bounded/readable.
+
+### Exit criteria
+
+- `/agy` identifies the native conversation in human terms.
+- Metadata cannot cause conversation loss or turn failure.
+
+---
+
+## Workstream 5 — markdown and direct artifact experience
+
+The VS Code selector proves that markdown under a conversation's `brain` directory is
+an intended artifact surface. Current Pi code only scans `.tempmediaStorage` and
+`.user_uploaded`, so it misses direct files such as a root-level plan/report/image.
+
+### 5.1 Expand safe discovery
+
+Update `lib/artifacts.ts` to scan only these explicit locations:
+
+1. regular files directly under `brain/<conversation-id>/`;
+2. regular files directly under `.tempmediaStorage/`; and
+3. regular files directly under `.user_uploaded/`.
+
+Rules:
+
+- exclude dotfiles, `*.metadata.json`, directories, sockets, and symlinks;
+- do not recurse into `scratch/` or `.system_generated/` (they contain worktrees,
+  transcripts, logs, and step internals rather than user-facing artifacts);
+- verify the resolved path stays under the selected conversation directory;
+- deduplicate by canonical absolute path;
+- classify source as `conversation`, `generated`, or `uploaded`;
+- add `markdown` to media types;
+- keep newest-first sorting with deterministic path/name tie-breaking.
+
+### 5.2 Add local markdown preview
+
+Update `src/artifacts-ui.ts`:
+
+- Keep `o` for the system default application and `r` to rescan.
+- For markdown, Enter/`v` switches the same dashboard component into a read-only
+  preview state; Esc returns to the list, avoiding nested overlay lifecycle problems.
+- Read a bounded amount (for example 256 KiB) and show an explicit truncation marker.
+- Decode with a fatal UTF-8 `TextDecoder` so corrupt input is distinguishable from valid
+  replacement characters.
+- Compute checklist counts from `- [ ]` and `- [x]` lines. Display exact
+  `completed/total` only when the whole file was read; label counts as partial when the
+  cap truncated the file.
+- Render/wrap/truncate ANSI-aware so every line satisfies `visibleWidth(line) <= width`.
+- Invalid UTF-8/read failures notify and return to the list without closing the
+  dashboard.
+- Do not interpret or execute HTML/scripts from markdown.
+
+Do not claim parity with the hub viewer's clickable links or interactive checklist
+mutation. This is a safe local read-only viewer.
+
+### Tests
+
+Update `test/artifacts.test.ts`; add `test/artifacts-ui.test.ts` if needed:
+
+- root markdown/image discovery;
+- metadata sidecar, scratch, system-generated, directory, and symlink exclusion;
+- path containment and deterministic ordering;
+- markdown media classification and checklist counts;
+- bounded reads/truncation;
+- narrow widths, Unicode, long filenames, and `visibleWidth <= width` on every row.
+
+### Exit criteria
+
+- Plans/reports stored as direct markdown artifacts are visible and readable in Pi.
+- Internal state and unsafe paths are never exposed as artifacts.
+
+---
+
+## Workstream 6 — agent and execution-mode pass-through
+
+### Configuration
+
+Add to `lib/agy-client.ts` or a small runtime config module:
+
+- `PI_ANTIGRAVITY_AGENT=<name>` → `--agent <name>`;
+- `PI_ANTIGRAVITY_MODE=plan|accept-edits` → `--mode <value>`.
+
+Validation:
+
+- mode must be exactly `plan` or `accept-edits`; invalid values fail before spawn with
+  a clear message;
+- agent names are passed as a single spawn argument (never through a shell), trimmed,
+  bounded, and reject NUL/empty values;
+- both fields are shown by `/agy` and `/agy doctor`;
+- both participate in the driver fingerprint, so changing process configuration can
+  never silently reuse an incompatible child.
+
+Add `/agy agents`:
+
+- invoke `agy agents` with the existing bounded command runner;
+- parse/list output tolerantly; an empty successful result means no custom agents;
+- do not spend tokens and do not alter the current conversation.
+
+Plan mode is the supported CLI-level approximation of the VS Code extension's
+implementation-plan workflow. It does not add the extension's private accept/reject
+step RPCs or inline diff controls.
+
+### Tests
+
+- complete one-shot and driver argv with/without agent/mode;
+- invalid mode and unsafe/empty agent input;
+- process recycle when profile changes;
+- empty, normal, malformed, failed, and timed-out `agy agents` output.
+
+### Exit criteria
+
+- Users can select a configured custom agent or plan mode through documented stable
+  CLI flags.
+- No private VS Code workflow API is required.
+
+---
+
+## Workstream 7 — exact compaction boundary probe
+
+Main already implements conservative token-drop inference. The VS Code bundle adds one
+important fact: private `AgentStateUpdate.compaction_info` contains only
+`compacted_at_step_indices`.
+
+### Probe
+
+Capture a real compaction with agy 1.1.22 under stream-json and inspect **documented
+stdout events only**. Do not parse the conversation DB or private protobuf files.
+
+### If stream-json does not expose compaction
+
+- Keep `lib/agy-compaction.ts` unchanged except for any test/document clarification.
+- Record that exact indices exist only on the private hub state stream.
+- Close this workstream without a product code path.
+
+### If stream-json exposes step indices
+
+- Add the smallest tolerant field/event shape to `lib/events.ts`.
+- Emit an exact boundary activity from `lib/reducer.ts`.
+- Track a per-conversation set of observed compacted step indices to deduplicate
+  repeated state snapshots.
+- Append one Pi custom marker per new boundary.
+- Use nearest before/after usage samples only as approximate token labels; do not claim
+  that `CompactionInfo` contains token counts.
+- Keep the current heuristic as fallback for agy versions/events where indices are
+  absent, but suppress a heuristic marker that corresponds to an already observed
+  exact boundary.
+- Reset boundary/dedup state on conversation reset, fallback, model/cwd change, branch
+  move, and session replacement; restore only information already persisted in the Pi
+  branch.
+
+### Tests if positive
+
+Update `test/agy-compaction.test.ts`, `test/reducer.test.ts`, and lifecycle tests:
+
+- exact event parsing;
+- repeated/cumulative index snapshots;
+- multiple compactions;
+- exact-plus-heuristic deduplication;
+- missing adjacent usage;
+- reset/restore lifecycle;
+- width-safe custom marker rendering.
+
+### Exit criteria
+
+- Either exact public events are implemented with deduplication, or the negative result
+  is documented and the conservative mainline heuristic remains.
+
+---
+
+## Workstream 8 — documentation, changesets, and rollout
+
+Update `packages/pi-antigravity/README.md`:
+
+- requirement: agy 1.1.22+;
+- persistent driver architecture and operational rollback;
+- why driver mode omits `--print-timeout`;
+- lifecycle/recycle rules;
+- `/agy doctor`, `/agy agents`, title enrichment, and markdown artifacts;
+- `PI_ANTIGRAVITY_AGENT`, `PI_ANTIGRAVITY_MODE`, and
+  `PI_ANTIGRAVITY_DRIVER=0`;
+- explicit non-support for hub APIs and inline accept/reject;
+- corrected diagrams: one driver spans ordinary user turns, while summaries use
+  disposable isolated processes.
+
+Keep all model-facing text in `lib/prompt.ts`. Diagnostics/UI labels are user-facing,
+not model-facing, but should still be centralized when repeated.
+
+Add a changeset for every independently publishable merged phase. Do not edit package
+versions or changelogs manually.
+
+## Delivery gates and merge sequence
+
+To prevent the eight-workstream plan from becoming all-or-nothing, use these explicit
+scope gates:
+
+- **Required core:** WS0 + WS1, WS2 + WS3 as one atomic persistence/coherence unit,
+  the WS6 process arguments needed by the fingerprint, and the relevant WS8 docs and
+  rollback notes. Do not ship WS2 without WS3.
+- **Optional enrichment:** WS4 metadata and WS5 artifact UX are independently shippable
+  follow-ups and must not block the driver core if schedule or review capacity is tight.
+- **Probe-only unless positive:** WS7 ships no new parser when the public protocol has no
+  exact compaction event; documenting the negative result completes the workstream.
+
+Recommended sequence:
+
+1. **Core gate A — WS0 + WS1:** probes, diagnostics, effort-correct argv, and binary
+   selection/cache invalidation.
+2. **Core gate B — WS2 + WS3:** persistent driver, runtime/summary isolation, bridge
+   catalog coherence, recycle observability, and lifecycle regression suite.
+3. **Core gate C — WS6 + WS8 subset:** agent/mode pass-through, kill switch, operational
+   docs, changeset, and full verification. This is the minimum releasable scope.
+4. **Optional gate D — WS4:** metadata status enrichment.
+5. **Optional gate E — WS5:** direct/markdown artifact discovery and preview.
+6. **Evidence gate F — WS7:** compaction probe; code only on a positive public-protocol
+   result, otherwise retain and document the existing heuristic.
+7. **Final WS8 pass:** reconcile docs and acceptance evidence for whichever optional
+   gates landed.
+
+This branch completed the optional gates too, but their completion is not a precedent
+for coupling them to future driver releases. WS4 and WS5 may be reviewed or reverted
+independently without weakening process persistence or bridge safety.
+
+## Final acceptance matrix
+
+### Continuity and isolation
+
+- Two normal user turns: same driver PID and same agy conversation.
+- Persisted reload: new PID, restored branch-owned conversation ID.
+- Pi summary/compaction: different PID and fresh conversation, closed after use.
+- Reset/fork/tree/cwd/model change: no turn reaches the old mutable conversation.
+- Model switch away and shutdown: no driver process remains.
+
+### Reliability
+
+- Fragmented NDJSON, stderr noise, EPIPE, close races, backpressure, abort, overall
+  timeout, tool stall, and process death are deterministic and covered.
+- Stall retry resumes a known conversation and never duplicates branch bootstrap.
+- No timer or abort listener remains armed while the process is idle.
+
+### Bridge safety
+
+- MCP/skill catalog changes are visible by the next user turn.
+- A pending bridge call is never interrupted by catalog recycling.
+- Bridge teardown occurs only after the driver can no longer call it.
+
+### State safety
+
+- Metadata is display-only.
+- `.db` plus runtime fallback remain liveness authority.
+- Global conversations cannot be arbitrarily attached to a Pi branch.
+- Internal/scratch files and symlinks do not appear as artifacts.
+
+### TUI safety
+
+- Every new status, artifact, preview, and custom-entry renderer passes narrow-width and
+  Unicode tests with `visibleWidth(line) <= width`.
+
+### Verification
+
+Run scoped checks while iterating:
+
+```bash
+pnpm --filter @tian.zuo/pi-antigravity run check
+pnpm --filter @tian.zuo/pi-antigravity test
+```
+
+Before committing/pushing, run the required monorepo verification:
+
+```bash
+pnpm run typecheck
+pnpm run check
+pnpm test
+```
+
+Also run one manual agy 1.1.22 smoke session that records process IDs and covers:
+
+1. two ordinary turns;
+2. one bridged Pi tool call;
+3. one skill/MCP catalog refresh;
+4. `/agy doctor` and `/agy` status;
+5. `/agy reset` followed by a fresh turn;
+6. a Pi compaction/summary request; and
+7. session shutdown with no surviving driver PID.

--- a/packages/pi-antigravity/README.md
+++ b/packages/pi-antigravity/README.md
@@ -6,11 +6,13 @@ Use **Google Antigravity** (`agy`) models inside the [pi coding agent](https://p
 
 ## Highlights
 
-- **Antigravity models in pi's model picker** — `antigravity/gemini-3.7-flash` and friends, with automatic model discovery.
+- **Antigravity models in pi's model picker** — `antigravity/gemini-3.7-flash` and friends, with automatic model discovery and effort-correct launches.
+- **Persistent stream driver** — ordinary user turns reuse one healthy `agy` process; conversation, model, workspace, agent, mode, and bridge changes recycle it safely.
+- **Actionable diagnostics** — `/agy doctor` explains executable selection, checks every candidate and the minimum version, and reports models, driver spawn/recycle counters, bridge revision, conversation database, and display metadata without spending model tokens.
 - **Native rendering, not mimicry** — agy's read-only tools (`view_file`, `grep_search`, `find_by_name`, `list_dir`) are re-executed as real pi builtins (`read` / `grep` / `find` / `ls`), so their cards use pi's own renderers and show live, accurate output. Everything else renders through one display-only `antigravity` wrapper.
 - **Skills & MCP bridge** — your global pi Agent Skills are one `pi__p<pid>__activate_skill` tool (pass `{ name }` from the tool's enum), and pi's MCP servers (via the `pi-mcp-adapter` tools) are reachable from agy with pi's permissions, hooks, and rendering. Per-session tool names keep concurrent pi sessions fully isolated.
 - **Background-task manager** — long-running agy commands are tracked in a dashboard and stoppable with one keystroke (`/agy-tasks`).
-- **Artifact browser** — images and files agy creates are listed and openable via `/agy-artifacts`, with a status-bar hint when new ones appear.
+- **Artifact browser** — direct conversation files, generated media, and uploads are listed via `/agy-artifacts`; markdown plans/reports have a bounded read-only preview with checklist progress.
 - **Model quotas** — `/agy-usage` ports agy's `/usage` into the same Refresh/Close menu as `/usage`: weekly and 5-hour remaining bars per model group, refreshed without spending tokens.
 
 ## How it works
@@ -19,7 +21,7 @@ Use **Google Antigravity** (`agy`) models inside the [pi coding agent](https://p
 flowchart TB
     subgraph pi["pi coding agent (the UI)"]
         UI["You: chat, tool cards,\npermissions, sessions"]
-        Prov["antigravity provider\n(one agy turn per request)"]
+        Prov["antigravity provider\n(persistent stream-json driver)"]
         Native["pi builtins\n(read / grep / find / ls)\nre-execute read-only steps"]
         Bridge["skills & MCP bridge\n(local MCP server on 127.0.0.1)"]
         Skills["pi Agent Skills"]
@@ -27,11 +29,13 @@ flowchart TB
     end
 
     subgraph agy["agy CLI (the agent loop)"]
-        Agent["Antigravity model\nbuilt-in tools"]
+        Agent["Antigravity model\nbuilt-in tools\n(one process across user turns)"]
+        Summary["Disposable agy process\nPi summaries only"]
     end
 
     UI <-- "stream events:\ntext, tool cards, usage" --> Prov
-    Prov -- "spawn / resume:\nagy --print ... --output-format stream-json" --> Agent
+    Prov -- "NDJSON user events:\n--input-format stream-json" --> Agent
+    Prov -. "compaction / branch summary" .-> Summary
     Agent -- "read-only step done:\nemit native toolCall" --> Native
     Prov -- "mutating/specialty step done:\ndisplay-only antigravity card" --> UI
     Agent -- "wants a skill or pi MCP tool:\ncall pi__p<pid>__<name> (MCP)" --> Bridge
@@ -67,7 +71,7 @@ pi --model antigravity/gemini-3.7-flash
 
 Try from a checkout: `pi -e ./packages/pi-antigravity --model antigravity/gemini-3.7-flash`
 
-Requires the `agy` CLI installed and logged in (v1.1.17+). Override the binary with `AGY_BINARY`.
+Requires the `agy` CLI installed and logged in (**v1.1.22+**). `AGY_BINARY` is a strict override. Without it, the extension checks both `agy` on `PATH` and the existing VS Code-managed `~/.gemini/bin/agy`, then selects the newest compatible stable version (or highest prerelease if no stable build exists); a `dev`/`HEAD` build is used only when no compatible versioned candidate exists. Successful checks are cached but automatically invalidated when a candidate path or file signature changes. The extension never downloads or updates executables.
 
 ## Features
 
@@ -114,7 +118,7 @@ Images and files agy creates land in a per-conversation artifact store. A hint a
 ◆ 1 agy artifact • /agy-artifacts to view
 ```
 
-The dashboard shows name, type, size, and origin (`generated` vs `uploaded`). Press `o` to open a file with the system default app. Non-interactive: `/agy-artifacts open <name>`.
+The dashboard shows name, type, size, and origin (`conversation`, `generated`, or `uploaded`). Direct files under the conversation root are included; `.system_generated`, `scratch`, metadata sidecars, directories, and symlinks are excluded. On markdown, press enter/`v` for a bounded (256 KiB), fatal-UTF-8, read-only preview with exact checklist counts when the complete file was read; esc returns to the list. Press `o` to open a file with the system default app. Non-interactive: `/agy-artifacts open <name>`.
 
 ### Model quotas (`/agy-usage`)
 
@@ -138,9 +142,11 @@ Claude and GPT models
 
 | Command | What it does |
 | --- | --- |
-| `/agy` | Conversation status (id, model, turns) |
-| `/agy reset` | Drop the agy conversation; next turn starts fresh |
+| `/agy` | Conversation title/status (id, model, turns, process, native context) |
+| `/agy reset` | Drop the agy conversation and driver; next turn starts fresh |
 | `/agy models` | Re-discover models and re-register the provider |
+| `/agy agents` | List configured custom agy agents without inference |
+| `/agy doctor` | Diagnose all binary candidates/selection, models, driver spawn/recycle counters, bridge, and conversation state |
 | `/agy-tasks` | Background-task dashboard (`stop <task-id> | all` for scripts) |
 | `/agy-artifacts` | Artifact browser (`open <name>` for scripts) |
 | `/agy-usage` | Model quotas (weekly and 5-hour remaining per group) |
@@ -150,8 +156,11 @@ Claude and GPT models
 | Flag | Effect |
 | --- | --- |
 | `PI_ANTIGRAVITY_PI_TOOL_BRIDGE=0` | Turn the bridge off. Skills fall back to a direct path catalog and direct `SKILL.md` reads. |
-| `AGY_BINARY=/path/to/agy` | Use a specific agy binary. |
-| `AGY_TURN_TIMEOUT_MS=600000` | Overall budget per agy turn (also sets agy's `--print-timeout`). |
+| `PI_ANTIGRAVITY_DRIVER=0` | Operational rollback: spawn one `agy --print` process per logical turn. |
+| `PI_ANTIGRAVITY_AGENT=<name>` | Select a custom agy agent. Empty, control-character-containing, and overlong values are rejected before spawn. |
+| `PI_ANTIGRAVITY_MODE=plan\|accept-edits` | Select agy's stable CLI execution mode. Other values fail before spawn. |
+| `AGY_BINARY=/path/to/agy` | Strictly use a specific agy binary; no fallback if it fails. |
+| `AGY_TURN_TIMEOUT_MS=600000` | Pi-owned overall budget per active agy turn. Persistent mode intentionally does not pass `--print-timeout`. |
 | `AGY_STALL_TIMEOUT_MS=120000` | Kill the turn when the stream produces no bytes for this long and retry by resuming the conversation. `0` disables the watchdog. |
 | `AGY_TOOL_STALL_TIMEOUT_MS=300000` | Stall budget while a tool step is ACTIVE — a quiet foreground tool is legitimate, so silence inside a tool gets a longer leash. |
 | `AGY_STALL_RETRY_BACKOFF_MS=3000` | Pause before each stall retry. Stalls retry at most twice, rendered as a collapsed "agy stream stalled … restarting the turn" thinking line. |
@@ -162,13 +171,17 @@ Claude and GPT models
 - **Artifact review:** headless runs cannot show agy's review panel, so image generation would abort after creating the file. Set `"artifactReviewMode": "always-proceed"` in the same `settings.json` to let artifacts through (applies to interactive agy too).
 - **Image generation errors:** `generate_image` can hit Google-side 429 rate limits; agy retries and usually succeeds — failed attempts show on the card with the real reason.
 - **Conversation memory:** lives on agy's side and is reused across turns. The native conversation id and cumulative usage baseline are persisted as branch-local Pi state, so reloading or resuming the same Pi session continues the exact compacted agy conversation. Forks receive a new Pi session id and branch/model/project changes cannot rewind agy's mutable history, so those start fresh from Pi's active summary plus a bounded recent-history tail. A missing persisted agy conversation falls back the same way. `/agy reset` writes a durable reset marker and intentionally starts with no restored history.
-- **Thinking level** maps to `agy --effort`: unset omits the flag, low → `low`, medium → `medium`, high and above → `high`.
+- **Thinking level** maps to `agy --effort`: low/minimal → `low`, medium → `medium`, high and above → `high`. Discovery retains each model's supported variants; an unsupported request falls back to that model's discovered default (for example Gemini `high`, GPT-OSS `medium`) instead of launching an invalid normalized model id.
 - **Context ownership:** agy governs its real context with a ~200k working window and a 185k safety cap, compacting and persisting the native conversation itself. Models advertise a 1M **Pi scheduling window** so Pi does not summarize first at ~168.6k; this value is not a claim about agy's raw capacity. `/agy` reports the latest observed native footprint. agy's terminal counters accumulate over an entire resumed conversation, while the provider reports the latest response step to Pi.
 - **Native compaction display:** agy's documented stream-json protocol does not expose the exact compaction-boundary event used by its TUI. The extension conservatively detects a high-context collapse from response-step input plus cache-read usage and appends a durable `agy compacted context · ~178k → ~36k` divider. Ordinary cache/phase variation is filtered by strict minimum-size, reclaimed-token, and ratio thresholds.
-- **Pi compaction fallback:** manual `/compact`, overflow recovery, branch summaries, or eventual Pi scheduling still run in disposable agy conversations. The active native conversation therefore contains only real user prompts, not Pi's serialized `<conversation>…</conversation>` summary requests. These fallback summaries report zero usage because agy is subscription-billed.
+- **Pi compaction fallback:** manual `/compact`, overflow recovery, branch summaries, or eventual Pi scheduling run in disposable agy processes and conversations. The active persistent driver therefore contains only real user prompts, not Pi's serialized `<conversation>…</conversation>` summary requests. These fallback summaries report zero usage because agy is subscription-billed.
+- **Driver deadlines:** `agy --print-timeout` is deliberately omitted from persistent mode. agy 1.1.22 can remain alive yet stop producing later results after that process-wide budget elapses. Pi arms overall and inactivity watchdogs only while a user event is active and leaves no timer running while the driver is idle.
+- **Driver recycling:** selected binary path/version, workspace, model, resolved effort, custom agent, execution mode, and canonical bridge catalog revision form the process fingerprint. Changes recycle between turns and resume the branch-owned conversation; a pending bridged Pi tool call is never interrupted. `/agy doctor` reports total spawns/respawns, submitted and reused turns, recycle count, current-process turns, and per-cause recycle counters, making accidental per-turn churn visible. Leaving Antigravity closes the driver before bridge teardown.
 - **Thinking display:** substantive agy reasoning keeps one collapsed `Thought for …` row per logical turn rather than repeating before every tool phase. Tiny token-only planner/tool traces that native agy does not render as a thought row are suppressed.
 - **Cost display** uses model-specific public API reference prices for Gemini and Claude (agy is subscription-billed); open or unknown models stay at zero rather than borrowing another model's price. Override per model in `~/.pi/agent/models.json` under `providers.antigravity.modelOverrides`.
 - The print interface is text-only; images in context are replaced by an omission note. Model discovery caches live lists for 24h; fallback snapshots (discovery failed or timed out) expire after 5 minutes so live discovery is retried promptly.
+- Conversation metadata from `~/.gemini/antigravity-cli/cache/conversation_metadata.json` enriches `/agy` with a title/steps/update time only. It is bounded, tolerant, and never controls restore; the readable conversation `.db` plus agy's runtime response remain authoritative.
+- Hub/Connect RPC, `agentapi`, embedded webviews, passive editor context, executable auto-updates, arbitrary global-conversation switching, and inline accept/reject diffs are intentionally unsupported private/unsafe surfaces from the VS Code extension.
 - If an older globally installed copy exists, remove it first: `pi remove npm:@tian.zuo/pi-antigravity`.
 
 ## Development

--- a/packages/pi-antigravity/index.ts
+++ b/packages/pi-antigravity/index.ts
@@ -5,9 +5,11 @@
 // auto-deny tools that would need a permission prompt otherwise).
 //
 // Commands:
-//   /agy            show agy conversation status (id, model, turns)
+//   /agy            show agy conversation and persistent-driver status
 //   /agy reset      drop the current agy conversation (next turn starts fresh)
 //   /agy models     re-discover models from `agy models` and re-register
+//   /agy agents     list configured custom agents
+//   /agy doctor     diagnose binary, models, driver, bridge, and local state
 //   /agy-usage      show Antigravity model quotas (weekly and 5-hour limits)
 
 import type {
@@ -16,20 +18,14 @@ import type {
   ExtensionUIContext,
   ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import { Text, truncateToWidth } from "@earendil-works/pi-tui";
+import { stripTerminalSequences, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { piConfigDir, readJson, writeJson } from "./lib/config.ts";
-import { AGY_BINARY } from "./lib/agy-client.ts";
-import {
-  installAgyDeathHooks,
-  killAgyTree,
-  killAllAgyTrees,
-  trackAgyChild,
-  untrackAgyChild,
-} from "./lib/agy-children.ts";
+import { installAgyDeathHooks, killAllAgyTrees } from "./lib/agy-children.ts";
+import { checkAgyBinary, MIN_AGY_VERSION, runAgyCommand } from "./lib/agy-diagnostics.ts";
+import { parseAgyAgents, readAgyProcessProfile } from "./lib/agy-profile.ts";
 import { pruneBridgeMcpCache, removeMcpCacheEntry } from "./lib/mcp-cache.ts";
 import {
   AgyPiBridge,
@@ -50,10 +46,11 @@ import {
 import {
   capabilitiesForModel,
   FALLBACK_MODELS,
+  mergeAgyModels,
   modelCacheTtlMs,
-  normalizeAgyModelId,
   parseAgyModels,
   pricingForModel,
+  resolveAgyModelEffort,
   type AgyModelInfo,
 } from "./lib/models.ts";
 import type { AgyActivity } from "./lib/reducer.ts";
@@ -71,6 +68,7 @@ import {
   type PersistedAgyConversation,
   type PersistedAgyReset,
 } from "./lib/conversation-state.ts";
+import { readAgyConversationMetadata } from "./lib/conversation-metadata.ts";
 import { AgyReplayStore, type RecordedAgyTool } from "./lib/replay.ts";
 import { findAgyTask, listAgyTasks, stopAgyTask } from "./lib/tasks.ts";
 import { findAgyArtifact, listAgyArtifacts } from "./lib/artifacts.ts";
@@ -81,11 +79,24 @@ import { openAgyTasksPicker } from "./src/tasks-ui.ts";
 import { openArtifact, openAgyArtifactsPicker } from "./src/artifacts-ui.ts";
 import { openAgyUsagePicker } from "./src/usage-ui.ts";
 import { agyToolLabel, formatAgyCall, summarizeAgyResult } from "./lib/render.ts";
-import { streamAntigravity } from "./src/provider.ts";
-import { AntigravityRuntime, createAntigravityRuntime, runAntigravity } from "./src/runtime.ts";
+import { mapThinkingToEffort, streamAntigravity } from "./src/provider.ts";
+import {
+  AntigravityRuntime,
+  createAntigravityRuntime,
+  runAntigravity,
+  type AntigravityStateSnapshot,
+} from "./src/runtime.ts";
 
 const MODEL_CACHE_FILE = path.join(piConfigDir("antigravity"), "model-list.json");
 const DISCOVERY_TIMEOUT_MS = 15_000;
+
+function statusOneLine(value: string, maxLength = 160): string {
+  return stripTerminalSequences(value)
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
 
 // --- Pi-tool bridge ---------------------------------------------------------
 
@@ -94,55 +105,8 @@ const BRIDGE_ENABLED = process.env.PI_ANTIGRAVITY_PI_TOOL_BRIDGE !== "0";
 /** Timeout for shutdown-path agy calls — fast enough not to stall closing pi. */
 const SHUTDOWN_AGY_TIMEOUT_MS = 5_000;
 
-function execAgy(args: string[], timeoutMs = DISCOVERY_TIMEOUT_MS): Promise<string> {
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    let out = "";
-    let errOut = "";
-    const settle = (fn: () => void) => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      fn();
-    };
-    const child = spawn(AGY_BINARY, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      // Own process group so killAgyTree's negative-pid SIGKILL reaps the
-      // whole tree on timeout. Raw spawn because execFile drops `detached`.
-      detached: true,
-    });
-    trackAgyChild(child);
-    child.stdout?.setEncoding("utf8");
-    child.stdout?.on("data", (chunk: string) => {
-      out += chunk;
-    });
-    child.stderr?.setEncoding("utf8");
-    child.stderr?.on("data", (chunk: string) => {
-      errOut += chunk;
-    });
-    child.on("error", (err) => {
-      settle(() => {
-        untrackAgyChild(child);
-        reject(new Error(err.message));
-      });
-    });
-    child.on("close", (code) => {
-      settle(() => {
-        untrackAgyChild(child);
-        if (code === 0) resolve(out);
-        else {
-          reject(new Error(errOut.trim() || `agy ${args[0]} exited with code ${code ?? "signal"}`));
-        }
-      });
-    });
-    timer = setTimeout(() => {
-      settle(() => {
-        killAgyTree(child);
-        reject(new Error(`agy ${args[0]} timed out after ${Math.round(timeoutMs / 1000)}s`));
-      });
-    }, timeoutMs);
-  });
+async function execAgy(args: string[], timeoutMs = DISCOVERY_TIMEOUT_MS): Promise<string> {
+  return (await runAgyCommand(args, { timeoutMs })).stdout;
 }
 
 /**
@@ -217,12 +181,17 @@ function toProviderModel(model: AgyModelInfo): ProviderModelConfig {
 
 /** Collapse effort variants and dedupe (also heals pre-0.2.0 caches). */
 function normalizeModels(models: AgyModelInfo[]): AgyModelInfo[] {
-  const out: AgyModelInfo[] = [];
-  for (const m of models) {
-    const n = normalizeAgyModelId(m.id, m.name);
-    if (!out.some((x) => x.id === n.id)) out.push(n);
-  }
-  return out;
+  return mergeAgyModels(models).map((model) => {
+    if (model.supportedEfforts.length > 0) return model;
+    const fallback = FALLBACK_MODELS.find((candidate) => candidate.id === model.id);
+    return fallback?.supportedEfforts.length
+      ? {
+          ...model,
+          supportedEfforts: [...fallback.supportedEfforts],
+          defaultEffort: fallback.defaultEffort,
+        }
+      : model;
+  });
 }
 
 async function listAgyModels(): Promise<AgyModelInfo[]> {
@@ -680,25 +649,26 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
         getBootstrapSuffix,
         isActiveTool,
         handleAgyActivity,
+        createAntigravityRuntime,
+        (modelId) => currentCache.models.find((candidate) => candidate.id === modelId),
+        readAgyProcessProfile,
+        bridgeManager.processRevision,
       ),
     });
   };
 
   registerAntigravityProvider(currentCache.models);
 
-  // Refresh model catalog non-blockingly in the background when stale or on fallback
-  if (
-    !currentCache.fetchedAt ||
-    Date.now() - currentCache.fetchedAt >= modelCacheTtlMs(currentCache.source)
-  ) {
-    void discoverModels(true)
-      .then((fresh) => {
-        currentCache = fresh;
-        registerAntigravityProvider(fresh.models);
-      })
-      .catch(() => {
-        // Cache is best-effort
-      });
+  async function refreshStaleModelsWhenSelected(): Promise<void> {
+    if (
+      currentCache.fetchedAt &&
+      Date.now() - currentCache.fetchedAt < modelCacheTtlMs(currentCache.source)
+    ) {
+      return;
+    }
+    const fresh = await discoverModels(true);
+    currentCache = fresh;
+    registerAntigravityProvider(fresh.models);
   }
 
   pi.on("before_agent_start", (event) => {
@@ -784,6 +754,7 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
     // model_select; non-agy sessions never touch agy at all.
     if (ctx.model?.provider === "antigravity") {
       await ensureBridgeRegistered(ctx.ui);
+      await refreshStaleModelsWhenSelected();
     }
   });
 
@@ -802,6 +773,7 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
     // The bridge exists only while an Antigravity model is selected.
     if (event.model?.provider === "antigravity") {
       await ensureBridgeRegistered(ctx?.ui);
+      await refreshStaleModelsWhenSelected();
     } else {
       await teardownBridge();
     }
@@ -878,7 +850,7 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
   });
 
   pi.registerCommand("agy", {
-    description: "Manage the agy backend: status | reset | models",
+    description: "Manage the agy backend: status | reset | models | agents | doctor",
     handler: async (args, ctx) => {
       const sub = args.trim().toLowerCase();
       if (sub === "reset") {
@@ -897,18 +869,169 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
         );
         return;
       }
+      if (sub === "agents") {
+        try {
+          const agents = parseAgyAgents(await execAgy(["agents"]));
+          ctx.ui.notify(
+            agents.length > 0
+              ? `antigravity custom agents:\n${agents.map((agent) => `• ${agent}`).join("\n")}`
+              : "antigravity: no custom agents configured.",
+            "info",
+          );
+        } catch (error) {
+          ctx.ui.notify(
+            `antigravity: failed to list agents (${error instanceof Error ? error.message : String(error)}).`,
+            "error",
+          );
+        }
+        return;
+      }
+      if (sub === "doctor") {
+        const lines = ["antigravity doctor"];
+        const binary = await checkAgyBinary({ refresh: true });
+        if (binary.ok) {
+          lines.push(
+            `binary: ${binary.binary} (${binary.version}, ${binary.source})`,
+            `binary selection: ${binary.selectionReason ?? "compatible candidate"}`,
+            `minimum: ${MIN_AGY_VERSION}`,
+          );
+        } else {
+          lines.push(
+            `binary: ERROR [${binary.category}] ${binary.message}`,
+            `minimum: ${MIN_AGY_VERSION}`,
+          );
+        }
+        for (const candidate of binary.candidates ?? []) {
+          const selected =
+            binary.ok && candidate.binary === binary.binary ? "selected" : "candidate";
+          lines.push(
+            `binary ${selected}: ${candidate.source} ${candidate.binary} · ${
+              candidate.ok
+                ? candidate.development
+                  ? (candidate.version ?? "development")
+                  : (candidate.version ?? "unknown")
+                : `ERROR [${candidate.category ?? "unknown"}]`
+            }`,
+          );
+        }
+
+        try {
+          const discovered = parseAgyModels((await runAgyCommand(["models"])).stdout);
+          if (discovered.length === 0) throw new Error("no valid model rows returned");
+          currentCache = { fetchedAt: Date.now(), source: "live", models: discovered };
+          registerAntigravityProvider(discovered);
+          lines.push(`models: ${discovered.length} (live)`);
+        } catch (error) {
+          lines.push(
+            `models: ERROR ${error instanceof Error ? error.message : String(error)}; ${currentCache.models.length} cached (${currentCache.source})`,
+          );
+        }
+
+        let snapshot: AntigravityStateSnapshot | undefined;
+        try {
+          snapshot = await runAntigravity(runtime, service.snapshot);
+          const executor = snapshot.executor;
+          const config = executor.config;
+          lines.push(
+            `driver: ${executor.mode} · ${executor.state}${executor.pid ? ` · pid ${executor.pid}` : ""}`,
+            `driver binary: ${config?.binary ?? "none"}${config?.binaryVersion ? ` · ${config.binaryVersion}` : ""}`,
+            `driver config: model=${config?.model ?? "none"} effort=${config?.effort ?? "none"} agent=${config?.agent ?? "none"} mode=${config?.mode ?? "default"}`,
+          );
+          if (executor.stats) {
+            const stats = executor.stats;
+            const reasons = Object.entries(stats.recycleReasons)
+              .map(([reason, count]) => `${reason}=${count}`)
+              .join(", ");
+            lines.push(
+              executor.mode === "persistent"
+                ? `driver stats: spawns=${stats.spawnCount} respawns=${Math.max(0, stats.spawnCount - 1)} turns=${stats.submittedTurns} reused=${stats.reusedTurns} recycles=${stats.recycleCount} current=${stats.currentProcessTurns}`
+                : `driver stats: one-shot launches=${stats.spawnCount} turns=${stats.submittedTurns}`,
+              `driver recycle reasons: ${reasons || "none"}`,
+            );
+          }
+        } catch (error) {
+          lines.push(`driver: ERROR ${error instanceof Error ? error.message : String(error)}`);
+        }
+
+        const selected = currentCache.models.find((model) => model.id === ctx.model?.id);
+        let profile = "agent=none mode=default";
+        try {
+          const configured = readAgyProcessProfile();
+          profile = `agent=${configured.agent ?? "none"} mode=${configured.mode ?? "default"}`;
+          lines.push(
+            `selection: ${ctx.model?.id ?? "none"} · effort ${
+              resolveAgyModelEffort(
+                selected,
+                ctx.thinkingLevel === "off"
+                  ? undefined
+                  : mapThinkingToEffort(
+                      ctx.thinkingLevel as Exclude<typeof ctx.thinkingLevel, "off">,
+                    ),
+              ) ?? "none"
+            }`,
+          );
+        } catch (error) {
+          lines.push(`profile: ERROR ${error instanceof Error ? error.message : String(error)}`);
+        }
+        lines.push(`profile: ${profile}`);
+        lines.push(
+          `bridge: enabled=${BRIDGE_ENABLED} running=${bridgeManager.isRunning()} registered=${bridgeManager.isRegistered()} revision=${bridgeManager.processRevision()}`,
+        );
+
+        const conversationId = snapshot?.conversationId;
+        if (conversationId) {
+          const [exists, metadata] = await Promise.all([
+            agyConversationExists(conversationId),
+            readAgyConversationMetadata(conversationId),
+          ]);
+          lines.push(
+            `conversation: ${conversationId} · db ${exists ? "readable" : "missing/unreadable"}`,
+            `metadata: ${metadata.status}`,
+          );
+        } else {
+          lines.push("conversation: none", "metadata: not applicable");
+        }
+        ctx.ui.notify(lines.join("\n"), binary.ok ? "info" : "error");
+        return;
+      }
       if (sub) {
-        ctx.ui.notify(`antigravity: unknown argument "${sub}". Use reset | models.`, "error");
+        ctx.ui.notify(
+          `antigravity: unknown argument "${sub}". Use reset | models | agents | doctor.`,
+          "error",
+        );
         return;
       }
       const snapshot = await runAntigravity(runtime, service.snapshot);
-      const id = snapshot.conversationId ?? "(none — next turn starts fresh)";
-      const context =
+      const id = snapshot.conversationId;
+      const metadata = id ? await readAgyConversationMetadata(id) : undefined;
+      const metadataTitle = metadata?.metadata?.title
+        ? statusOneLine(metadata.metadata.title)
+        : undefined;
+      const title = metadataTitle || (id ? id.slice(0, 12) : "none — next turn starts fresh");
+      const updated = metadata?.metadata?.updatedAt
+        ? new Date(metadata.metadata.updatedAt).toLocaleString()
+        : undefined;
+      const details = [
+        `model: ${snapshot.model ?? "unselected"}`,
+        `turns: ${snapshot.turns}`,
+        `driver: ${snapshot.executor.mode}/${snapshot.executor.state}${snapshot.executor.pid ? ` pid=${snapshot.executor.pid}` : ""}`,
         observedContextTokens === undefined
-          ? ""
-          : ` · native context: ~${formatAgyContextTokens(observedContextTokens)}/185k`;
+          ? undefined
+          : `native context: ~${formatAgyContextTokens(observedContextTokens)}/185k`,
+        metadata?.metadata?.numSteps === undefined
+          ? undefined
+          : `native steps: ${metadata.metadata.numSteps}`,
+        updated ? `updated: ${updated}` : undefined,
+      ].filter((part): part is string => part !== undefined);
+      let profile = "agent: none · mode: default";
+      try {
+        const configured = readAgyProcessProfile();
+        profile = `agent: ${configured.agent ?? "none"} · mode: ${configured.mode ?? "default"}`;
+      } catch (error) {
+        profile = `profile error: ${error instanceof Error ? error.message : String(error)}`;
+      }
       ctx.ui.notify(
-        `antigravity: conversation ${id}\nmodel: ${snapshot.model ?? "unselected"} · turns: ${snapshot.turns}${context} · models: ${currentCache.models.length} (${currentCache.source})`,
+        `antigravity: ${title}\nconversation: ${id ?? "none"}\n${details.join(" · ")}\n${profile}`,
         "info",
       );
     },

--- a/packages/pi-antigravity/lib/agy-children.ts
+++ b/packages/pi-antigravity/lib/agy-children.ts
@@ -75,6 +75,26 @@ export function untrackAgyChild(child: TrackableChild): void {
   getAgyChildrenRegistry().live.delete(child.pid);
 }
 
+/** Send a signal to a detached process tree without removing it from tracking. */
+export function signalAgyTree(child: TrackableChild, signal: NodeJS.Signals): void {
+  if (child.pid === undefined) return;
+  if (process.platform === "win32") {
+    // Windows has no process-group SIGTERM equivalent; callers escalate with taskkill.
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+    return;
+  } catch {
+    // Process group may already be gone; try the leader.
+  }
+  try {
+    process.kill(child.pid, signal);
+  } catch {
+    // Already exited.
+  }
+}
+
 /** Synchronously terminate a child's whole process tree. */
 export function killAgyTree(child: TrackableChild): void {
   if (child.pid === undefined) return;

--- a/packages/pi-antigravity/lib/agy-client.ts
+++ b/packages/pi-antigravity/lib/agy-client.ts
@@ -1,7 +1,7 @@
 /**
- * Imperative agy CLI client — spawns `agy --print` turns with stream-json
- * output, parses NDJSON, and folds events into an AgyTurnOutcome. The Effect
- * service in src/runtime.ts wraps this for typed lifecycle and abort handling.
+ * agy CLI request contract plus the one-shot `agy --print` rollback client.
+ * The default persistent implementation lives in agy-driver.ts; both paths
+ * parse NDJSON into the same AgyTurnOutcome contract.
  *
  * Every invocation hard-codes --dangerously-skip-permissions: headless agy
  * turns auto-deny any tool that needs a permission prompt, so skipping is
@@ -10,10 +10,10 @@
 
 import { spawn } from "node:child_process";
 import { killAgyTree, trackAgyChild, untrackAgyChild } from "./agy-children.ts";
+import { getAgyBinary } from "./agy-diagnostics.ts";
+import type { AgyExecutionMode } from "./agy-profile.ts";
 import { parseAgyLine } from "./events.ts";
 import { applyEvent, newTurnOutcome, type AgyActivity, type AgyTurnOutcome } from "./reducer.ts";
-
-export const AGY_BINARY = process.env.AGY_BINARY ?? "agy";
 
 /** agy reasoning effort, as accepted by `agy --effort`. */
 export type AgyEffort = "low" | "medium" | "high";
@@ -28,7 +28,7 @@ export interface AgyTurnRequest {
   effort?: AgyEffort;
   /** Working directory for the agy process. */
   cwd?: string;
-  /** Overall turn timeout; agy's own --print-timeout is set from this. */
+  /** Overall turn timeout owned by Pi. One-shot mode also passes --print-timeout. */
   timeoutMs?: number;
   /**
    * Kill the turn when the stream produces no bytes for this long (stall
@@ -42,6 +42,14 @@ export interface AgyTurnRequest {
    */
   toolInactivityTimeoutMs?: number;
   signal?: AbortSignal;
+  /** Optional custom agy agent selected for this process. */
+  agent?: string;
+  /** Stable agy execution mode. */
+  mode?: AgyExecutionMode;
+  /** Non-argv bridge/catalog fingerprint used by persistent executors. */
+  bridgeRevision?: string;
+  /** Preflight-selected absolute binary. Normally resolved lazily. */
+  binary?: string;
   /** Called with each structured activity event as tool steps stream in. */
   onActivity?: (activity: AgyActivity) => void;
   /**
@@ -85,36 +93,58 @@ export class AgyStallError extends Error {
   }
 }
 
-export function buildAgyArgs(request: AgyTurnRequest): string[] {
-  const timeout = Math.ceil((request.timeoutMs ?? 600_000) / 1000);
-  // NOTE: agy's --print consumes the NEXT token as the prompt value (it is
-  // not a boolean flag). The prompt MUST come immediately after --print,
-  // otherwise the first following flag string becomes the prompt.
-  const args = [
-    "--print",
-    request.prompt,
-    "--dangerously-skip-permissions",
-    "--disable-slash-commands",
-    "--output-format",
-    "stream-json",
-    // agy's print mode does not treat the process cwd as the workspace; the
-    // working directory must be registered explicitly via --add-dir.
-    ...(request.cwd ? ["--add-dir", request.cwd] : []),
-    "--print-timeout",
-    `${timeout}s`,
-  ];
+function appendProcessArgs(args: string[], request: AgyTurnRequest): string[] {
+  if (request.cwd) args.push("--add-dir", request.cwd);
   if (request.conversationId) args.push("--conversation", request.conversationId);
   if (request.model) args.push("--model", request.model);
   if (request.effort) args.push("--effort", request.effort);
+  if (request.agent) args.push("--agent", request.agent);
+  if (request.mode) args.push("--mode", request.mode);
   return args;
 }
+
+export function buildOneShotAgyArgs(request: AgyTurnRequest): string[] {
+  const timeout = Math.ceil((request.timeoutMs ?? 600_000) / 1000);
+  // --print consumes the next token, so the prompt must remain adjacent.
+  return appendProcessArgs(
+    [
+      "--print",
+      request.prompt,
+      "--dangerously-skip-permissions",
+      "--disable-slash-commands",
+      "--output-format",
+      "stream-json",
+      "--print-timeout",
+      `${timeout}s`,
+    ],
+    request,
+  );
+}
+
+export function buildDriverAgyArgs(request: Omit<AgyTurnRequest, "prompt">): string[] {
+  return appendProcessArgs(
+    [
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json",
+      "--dangerously-skip-permissions",
+      "--disable-slash-commands",
+    ],
+    { ...request, prompt: "" },
+  );
+}
+
+/** Kept as the public one-shot argument builder used by existing callers. */
+export const buildAgyArgs = buildOneShotAgyArgs;
 
 /**
  * Run one agy turn. Resolves with the reduced outcome once the process exits
  * or the result event arrives. Rejects with AgySpawnError when the process
  * fails before producing any result event (missing binary, auth failure, …).
  */
-export function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
+export async function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
+  const binary = request.binary ?? (request.spawnOverride ? "agy" : await getAgyBinary());
   return new Promise((resolve, reject) => {
     if (request.signal?.aborted) {
       const outcome = newTurnOutcome();
@@ -125,7 +155,7 @@ export function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
       return;
     }
     const doSpawn = request.spawnOverride ?? spawn;
-    const child = doSpawn(AGY_BINARY, buildAgyArgs(request), {
+    const child = doSpawn(binary, buildOneShotAgyArgs(request), {
       cwd: request.cwd,
       stdio: ["ignore", "pipe", "pipe"],
       // Own process group so one negative-pid SIGKILL reaps agy's whole
@@ -149,6 +179,7 @@ export function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
       untrackAgyChild(child);
     };
 
+    let abortHandler: (() => void) | undefined;
     const finishLogical = (fn: () => void) => {
       if (settled) return;
       settled = true;
@@ -157,6 +188,7 @@ export function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
         clearTimeout(stallTimer);
         stallTimer = undefined;
       }
+      if (abortHandler) request.signal?.removeEventListener("abort", abortHandler);
       fn();
     };
 
@@ -198,20 +230,17 @@ export function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
       child.stderr?.on("data", armStall);
     }
 
-    request.signal?.addEventListener(
-      "abort",
-      () => {
-        killAgyTree(child);
-        untrack();
-        finishLogical(() => {
-          outcome.status = "ERROR";
-          outcome.error = "agy turn was aborted.";
-          outcome.finished = true;
-          resolve(outcome);
-        });
-      },
-      { once: true },
-    );
+    abortHandler = () => {
+      killAgyTree(child);
+      untrack();
+      finishLogical(() => {
+        outcome.status = "ERROR";
+        outcome.error = "agy turn was aborted.";
+        outcome.finished = true;
+        resolve(outcome);
+      });
+    };
+    request.signal?.addEventListener("abort", abortHandler, { once: true });
 
     let conversationReported = false;
     const handleParsed = (parsed: ReturnType<typeof parseAgyLine>) => {
@@ -281,7 +310,7 @@ export function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
       finishLogical(() =>
         reject(
           new AgySpawnError(
-            `failed to start agy (${err.message}). Install it or set AGY_BINARY.`,
+            `failed to start agy (${err.message}). Install agy 1.1.22+ or set AGY_BINARY.`,
             stderrBuf,
           ),
         ),

--- a/packages/pi-antigravity/lib/agy-diagnostics.ts
+++ b/packages/pi-antigravity/lib/agy-diagnostics.ts
@@ -1,0 +1,557 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { gte, prerelease, rcompare, valid } from "semver";
+import which from "which";
+import { killAgyTree, trackAgyChild, untrackAgyChild } from "./agy-children.ts";
+
+export const MIN_AGY_VERSION = "1.1.22";
+export const AGY_VERSION_TIMEOUT_MS = 5_000;
+const DIAGNOSTIC_LIMIT = 8_192;
+const COMMAND_OUTPUT_LIMIT = 1024 * 1024;
+
+export type AgyBinarySource = "override" | "path" | "managed";
+export type AgyBinaryFailureCategory =
+  | "not-found"
+  | "permission-denied"
+  | "timeout"
+  | "spawn-failed"
+  | "invalid-version"
+  | "unsupported-version";
+
+export interface AgyBinaryCandidateReport {
+  binary: string;
+  source: AgyBinarySource;
+  ok: boolean;
+  version?: string;
+  development?: boolean;
+  category?: AgyBinaryFailureCategory;
+  message?: string;
+}
+
+export interface AgyBinarySuccess {
+  ok: true;
+  configured: string;
+  binary: string;
+  source: AgyBinarySource;
+  version: string;
+  development: boolean;
+  stdout: string;
+  stderr: string;
+  candidates?: AgyBinaryCandidateReport[];
+  selectionReason?: string;
+  revision?: string;
+}
+
+export interface AgyBinaryFailure {
+  ok: false;
+  configured: string;
+  binary?: string;
+  source?: AgyBinarySource;
+  category: AgyBinaryFailureCategory;
+  message: string;
+  stdout: string;
+  stderr: string;
+  candidates?: AgyBinaryCandidateReport[];
+}
+
+export type AgyBinaryCheck = AgyBinarySuccess | AgyBinaryFailure;
+
+export class AgyCompatibilityError extends Error {
+  readonly diagnostic: AgyBinaryFailure;
+
+  constructor(diagnostic: AgyBinaryFailure) {
+    super(diagnostic.message);
+    this.name = "AgyCompatibilityError";
+    this.diagnostic = diagnostic;
+  }
+}
+
+interface BinaryCandidate {
+  configured: string;
+  binary: string;
+  source: AgyBinarySource;
+}
+
+interface SpawnLikeError extends Error {
+  code?: string;
+}
+
+export interface CheckAgyBinaryOptions {
+  refresh?: boolean;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+  timeoutMs?: number;
+  spawnOverride?: typeof spawn;
+  statOverride?: (file: string) => Promise<{ mtimeMs: number; ctimeMs?: number; size: number }>;
+  whichOverride?: (
+    command: string,
+    options?: { path?: string; pathExt?: string },
+  ) => Promise<string>;
+}
+
+let cachedSuccess: { key: string; result: AgyBinarySuccess } | undefined;
+
+export function resetAgyBinaryCache(): void {
+  cachedSuccess = undefined;
+}
+
+async function binaryCacheIdentity(
+  options: CheckAgyBinaryOptions,
+  resolved: Awaited<ReturnType<typeof resolveAgyBinary>>,
+): Promise<{ key: string; candidateRevisions: Map<string, string> }> {
+  const env = options.env ?? process.env;
+  const stat = options.statOverride ?? fs.stat;
+  const signatures = await Promise.all(
+    resolved.candidates.map(async (candidate) => {
+      let signature: string;
+      try {
+        const info = await stat(candidate.binary);
+        signature = `${candidate.binary}:${info.size}:${info.mtimeMs}:${info.ctimeMs ?? ""}`;
+      } catch {
+        signature = `${candidate.binary}:missing`;
+      }
+      return {
+        cache: `${candidate.source}:${signature}`,
+        binary: candidate.binary,
+        revision: createHash("sha256").update(signature).digest("hex"),
+      };
+    }),
+  );
+  const material = [
+    env.AGY_BINARY === undefined ? "auto" : `override:${env.AGY_BINARY}`,
+    env.PATH ?? "",
+    env.PATHEXT ?? "",
+    options.homeDir ?? os.homedir(),
+    options.platform ?? process.platform,
+    ...signatures.map(({ cache }) => cache),
+  ].join("\0");
+  return {
+    key: createHash("sha256").update(material).digest("hex"),
+    candidateRevisions: new Map(
+      signatures.map(({ binary, revision }) => [binary, revision] as const),
+    ),
+  };
+}
+
+function boundedAppend(current: string, chunk: string, limit = DIAGNOSTIC_LIMIT): string {
+  const next = current + chunk;
+  return next.length <= limit ? next : next.slice(-limit);
+}
+
+export function extractAgyVersion(
+  stdout: string,
+  stderr = "",
+):
+  | { version: string; development: false }
+  | { version: "dev" | "HEAD"; development: true }
+  | undefined {
+  const text = `${stdout}\n${stderr}`;
+  if (/\bHEAD\b/.test(text)) return { version: "HEAD", development: true };
+  if (/\bdev(?:elopment)?\b/i.test(text)) return { version: "dev", development: true };
+  const match = text.match(/(?:^|\s)v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?=\s|$)/m);
+  if (!match || !valid(match[1])) return undefined;
+  return { version: match[1], development: false };
+}
+
+async function resolveCandidate(
+  configured: string,
+  source: AgyBinarySource,
+  resolveWhich: NonNullable<CheckAgyBinaryOptions["whichOverride"]>,
+  env: NodeJS.ProcessEnv,
+): Promise<BinaryCandidate | undefined> {
+  if (!configured.trim()) return undefined;
+  try {
+    const resolved = await resolveWhich(configured, {
+      path: env.PATH,
+      pathExt: env.PATHEXT,
+    });
+    return { configured, binary: path.resolve(resolved), source };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function resolveAgyBinary(
+  options: CheckAgyBinaryOptions = {},
+): Promise<{ candidates: BinaryCandidate[]; configured: string; strict: boolean }> {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const homeDir = options.homeDir ?? os.homedir();
+  const resolveWhich =
+    options.whichOverride ?? ((command, opts) => which(command, opts) as Promise<string>);
+  const explicit = env.AGY_BINARY;
+  if (explicit !== undefined) {
+    const candidate = await resolveCandidate(explicit, "override", resolveWhich, env);
+    return {
+      candidates: candidate ? [candidate] : [],
+      configured: explicit,
+      strict: true,
+    };
+  }
+
+  const candidates: BinaryCandidate[] = [];
+  const fromPath = await resolveCandidate("agy", "path", resolveWhich, env);
+  if (fromPath) candidates.push(fromPath);
+  const managed = path.join(homeDir, ".gemini", "bin", platform === "win32" ? "agy.exe" : "agy");
+  const managedCandidate = await resolveCandidate(managed, "managed", resolveWhich, env);
+  if (
+    managedCandidate &&
+    !candidates.some((candidate) => candidate.binary === managedCandidate.binary)
+  ) {
+    candidates.push(managedCandidate);
+  }
+  return { candidates, configured: "agy", strict: false };
+}
+
+function classifySpawnError(error: SpawnLikeError): AgyBinaryFailureCategory {
+  if (error.code === "ENOENT") return "not-found";
+  if (error.code === "EACCES" || error.code === "EPERM") return "permission-denied";
+  return "spawn-failed";
+}
+
+function checkCandidate(
+  candidate: BinaryCandidate,
+  configured: string,
+  options: CheckAgyBinaryOptions,
+): Promise<AgyBinaryCheck> {
+  return new Promise((resolve) => {
+    const doSpawn = options.spawnOverride ?? spawn;
+    let stdout = "";
+    let stderr = "";
+    let versionHint: ReturnType<typeof extractAgyVersion>;
+    let settled = false;
+    const child = doSpawn(candidate.binary, ["--version"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+      windowsHide: true,
+    });
+    trackAgyChild(child);
+
+    const settle = (result: AgyBinaryCheck) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      untrackAgyChild(child);
+      resolve(result);
+    };
+
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      versionHint ??= extractAgyVersion(chunk);
+      stdout = boundedAppend(stdout, chunk);
+    });
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      versionHint ??= extractAgyVersion("", chunk);
+      stderr = boundedAppend(stderr, chunk);
+    });
+    child.on("error", (error: SpawnLikeError) => {
+      const category = classifySpawnError(error);
+      settle({
+        ok: false,
+        configured,
+        binary: candidate.binary,
+        source: candidate.source,
+        category,
+        message: `antigravity: cannot run agy at ${candidate.binary} (${error.message}).`,
+        stdout,
+        stderr,
+      });
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      if (code !== 0) {
+        settle({
+          ok: false,
+          configured,
+          binary: candidate.binary,
+          source: candidate.source,
+          category: "spawn-failed",
+          message: `antigravity: agy --version exited with code ${code ?? "signal"}.`,
+          stdout,
+          stderr,
+        });
+        return;
+      }
+      const parsed = versionHint ?? extractAgyVersion(stdout, stderr);
+      if (!parsed) {
+        settle({
+          ok: false,
+          configured,
+          binary: candidate.binary,
+          source: candidate.source,
+          category: "invalid-version",
+          message: `antigravity: agy at ${candidate.binary} returned an unrecognized version.`,
+          stdout,
+          stderr,
+        });
+        return;
+      }
+      if (!parsed.development && !gte(parsed.version, MIN_AGY_VERSION)) {
+        settle({
+          ok: false,
+          configured,
+          binary: candidate.binary,
+          source: candidate.source,
+          category: "unsupported-version",
+          message: `antigravity: agy ${parsed.version} is unsupported; install ${MIN_AGY_VERSION} or newer.`,
+          stdout,
+          stderr,
+        });
+        return;
+      }
+      settle({
+        ok: true,
+        configured,
+        binary: candidate.binary,
+        source: candidate.source,
+        version: parsed.version,
+        development: parsed.development,
+        stdout,
+        stderr,
+      });
+    });
+
+    const timer = setTimeout(() => {
+      killAgyTree(child);
+      settle({
+        ok: false,
+        configured,
+        binary: candidate.binary,
+        source: candidate.source,
+        category: "timeout",
+        message: `antigravity: agy --version timed out after ${Math.round((options.timeoutMs ?? AGY_VERSION_TIMEOUT_MS) / 1000)}s.`,
+        stdout,
+        stderr,
+      });
+    }, options.timeoutMs ?? AGY_VERSION_TIMEOUT_MS);
+  });
+}
+
+function candidateReport(checked: AgyBinaryCheck): AgyBinaryCandidateReport | undefined {
+  if (!checked.binary || !checked.source) return undefined;
+  return checked.ok
+    ? {
+        binary: checked.binary,
+        source: checked.source,
+        ok: true,
+        version: checked.version,
+        development: checked.development,
+      }
+    : {
+        binary: checked.binary,
+        source: checked.source,
+        ok: false,
+        category: checked.category,
+        message: checked.message,
+      };
+}
+
+function selectAgyCandidate(successes: AgyBinarySuccess[]): AgyBinarySuccess | undefined {
+  const versioned = successes.filter((candidate) => !candidate.development);
+  const stable = versioned.filter((candidate) => prerelease(candidate.version) === null);
+  if (stable.length > 0) {
+    return [...stable].sort((left, right) => rcompare(left.version, right.version))[0];
+  }
+  if (versioned.length > 0) {
+    return [...versioned].sort((left, right) => rcompare(left.version, right.version))[0];
+  }
+  return successes[0];
+}
+
+export async function checkAgyBinary(options: CheckAgyBinaryOptions = {}): Promise<AgyBinaryCheck> {
+  if (options.refresh) cachedSuccess = undefined;
+  const resolved = await resolveAgyBinary(options);
+  const cacheIdentity = await binaryCacheIdentity(options, resolved);
+  if (cachedSuccess?.key === cacheIdentity.key) return cachedSuccess.result;
+  if (resolved.candidates.length === 0) {
+    return {
+      ok: false,
+      configured: resolved.configured,
+      category: "not-found",
+      message: resolved.strict
+        ? `antigravity: AGY_BINARY=${JSON.stringify(resolved.configured)} is not executable.`
+        : "antigravity: agy was not found on PATH or at ~/.gemini/bin/agy. Install agy 1.1.22+ or set AGY_BINARY.",
+      stdout: "",
+      stderr: "",
+      candidates: [],
+    };
+  }
+
+  const checks = await Promise.all(
+    resolved.candidates.map(async (candidate): Promise<AgyBinaryCheck> => {
+      try {
+        return await checkCandidate(candidate, resolved.configured, options);
+      } catch (error) {
+        return {
+          ok: false,
+          configured: resolved.configured,
+          binary: candidate.binary,
+          source: candidate.source,
+          category: "spawn-failed",
+          message: `antigravity: cannot run agy at ${candidate.binary} (${error instanceof Error ? error.message : String(error)}).`,
+          stdout: "",
+          stderr: "",
+        };
+      }
+    }),
+  );
+  const reports = checks
+    .map(candidateReport)
+    .filter((report): report is AgyBinaryCandidateReport => report !== undefined);
+  const selected = selectAgyCandidate(
+    checks.filter((checked): checked is AgyBinarySuccess => checked.ok),
+  );
+  if (selected) {
+    const result: AgyBinarySuccess = {
+      ...selected,
+      candidates: reports,
+      revision: cacheIdentity.candidateRevisions.get(selected.binary),
+      selectionReason: resolved.strict
+        ? "explicit AGY_BINARY override"
+        : selected.development
+          ? "development fallback; no compatible versioned candidate was available"
+          : prerelease(selected.version) !== null
+            ? "highest compatible prerelease; no stable candidate was available"
+            : `highest compatible stable version among ${checks.length} candidate${checks.length === 1 ? "" : "s"}`,
+    };
+    cachedSuccess = { key: cacheIdentity.key, result };
+    return result;
+  }
+
+  const lastFailure = [...checks]
+    .reverse()
+    .find((checked): checked is AgyBinaryFailure => !checked.ok);
+  return lastFailure
+    ? { ...lastFailure, candidates: reports }
+    : {
+        ok: false,
+        configured: resolved.configured,
+        category: "spawn-failed",
+        message: "antigravity: no agy candidate could be checked.",
+        stdout: "",
+        stderr: "",
+        candidates: reports,
+      };
+}
+
+export async function getAgyBinary(options: CheckAgyBinaryOptions = {}): Promise<string> {
+  const checked = await checkAgyBinary(options);
+  if (!checked.ok) throw new AgyCompatibilityError(checked);
+  return checked.binary;
+}
+
+export interface RunAgyCommandOptions {
+  binary?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  maxOutputBytes?: number;
+  cwd?: string;
+  spawnOverride?: typeof spawn;
+}
+
+export interface AgyCommandResult {
+  binary: string;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run one bounded auxiliary agy command through the selected compatible binary. */
+export async function runAgyCommand(
+  args: readonly string[],
+  options: RunAgyCommandOptions = {},
+): Promise<AgyCommandResult> {
+  const binary = options.binary ?? (await getAgyBinary());
+  if (options.signal?.aborted) {
+    const error = new Error("agy command was aborted.");
+    error.name = "AbortError";
+    throw error;
+  }
+  return new Promise((resolve, reject) => {
+    const doSpawn = options.spawnOverride ?? spawn;
+    const limit = options.maxOutputBytes ?? COMMAND_OUTPUT_LIMIT;
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const child = doSpawn(binary, [...args], {
+      cwd: options.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+      windowsHide: true,
+    });
+    trackAgyChild(child);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", onAbort);
+      untrackAgyChild(child);
+    };
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+    const fail = (message: string) => settle(() => reject(new Error(message)));
+    const append = (current: string, chunk: string, streamName: string): string => {
+      const next = current + chunk;
+      if (Buffer.byteLength(next, "utf8") > limit) {
+        killAgyTree(child);
+        fail(`agy ${args[0] ?? "command"} ${streamName} exceeded ${limit} bytes.`);
+        return current;
+      }
+      return next;
+    };
+
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      if (!settled) stdout = append(stdout, chunk, "stdout");
+    });
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      if (!settled) stderr = append(stderr, chunk, "stderr");
+    });
+    child.on("error", (error: SpawnLikeError) => {
+      fail(`failed to run ${binary} (${error.message}).`);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      if (code === 0) {
+        settle(() => resolve({ binary, stdout, stderr }));
+      } else {
+        fail(stderr.trim() || `agy ${args[0] ?? "command"} exited with code ${code ?? "signal"}`);
+      }
+    });
+
+    const onAbort = () => {
+      killAgyTree(child);
+      settle(() => {
+        const error = new Error("agy command was aborted.");
+        error.name = "AbortError";
+        reject(error);
+      });
+    };
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    const timer = setTimeout(() => {
+      killAgyTree(child);
+      fail(
+        `agy ${args[0] ?? "command"} timed out after ${Math.round((options.timeoutMs ?? 15_000) / 1000)}s.`,
+      );
+    }, options.timeoutMs ?? 15_000);
+  });
+}
+
+/** True when the selected conversation database exists and is readable. */
+export async function isReadableFile(file: string): Promise<boolean> {
+  try {
+    await fs.access(file);
+    const stat = await fs.stat(file);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}

--- a/packages/pi-antigravity/lib/agy-driver.ts
+++ b/packages/pi-antigravity/lib/agy-driver.ts
@@ -1,0 +1,645 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  AgySpawnError,
+  AgyStallError,
+  buildDriverAgyArgs,
+  runAgyTurn,
+  type AgyTurnRequest,
+} from "./agy-client.ts";
+import { killAgyTree, signalAgyTree, trackAgyChild, untrackAgyChild } from "./agy-children.ts";
+import { AgyCompatibilityError, checkAgyBinary } from "./agy-diagnostics.ts";
+import { parseAgyLine } from "./events.ts";
+import { applyEvent, newTurnOutcome, type AgyTurnOutcome } from "./reducer.ts";
+
+export type AgyDriverState = "idle" | "starting" | "ready" | "running" | "stopping" | "dead";
+export type AgyExecutorCloseReason = "recycle" | "abort" | "shutdown";
+export type AgyRecycleCause =
+  | "binary"
+  | "cwd"
+  | "model"
+  | "effort"
+  | "agent"
+  | "mode"
+  | "bridge-catalog"
+  | "conversation"
+  | "conversation-reset"
+  | "session-tree"
+  | "restore"
+  | "reset"
+  | "unspecified";
+
+export interface AgyProcessConfigSnapshot {
+  binary: string;
+  binaryVersion?: string;
+  binaryRevision?: string;
+  cwd?: string;
+  model?: string;
+  effort?: string;
+  agent?: string;
+  mode?: string;
+  bridgeRevision?: string;
+}
+
+export interface AgyExecutorStats {
+  spawnCount: number;
+  submittedTurns: number;
+  reusedTurns: number;
+  recycleCount: number;
+  currentProcessTurns: number;
+  recycleReasons: Record<string, number>;
+  lastRecycleReason?: AgyRecycleCause;
+}
+
+export interface AgyExecutorSnapshot {
+  mode: "persistent" | "one-shot";
+  state: AgyDriverState;
+  pid?: number;
+  conversationId?: string;
+  config?: AgyProcessConfigSnapshot;
+  lifecycle: string[];
+  stats?: AgyExecutorStats;
+}
+
+export interface AgyTurnExecutor {
+  run(request: AgyTurnRequest): Promise<AgyTurnOutcome>;
+  snapshot(): AgyExecutorSnapshot;
+  close(reason: AgyExecutorCloseReason, cause?: AgyRecycleCause): Promise<void>;
+}
+
+interface ActiveTurn {
+  generation: number;
+  request: AgyTurnRequest;
+  outcome: AgyTurnOutcome;
+  toolActive: boolean;
+  conversationReported: boolean;
+  overallTimer?: NodeJS.Timeout;
+  stallTimer?: NodeJS.Timeout;
+  abortHandler?: () => void;
+  resolve: (outcome: AgyTurnOutcome) => void;
+  reject: (error: unknown) => void;
+}
+
+type DriverChild = ChildProcess & {
+  stdin: NonNullable<ChildProcess["stdin"]>;
+  stdout: NonNullable<ChildProcess["stdout"]>;
+  stderr: NonNullable<ChildProcess["stderr"]>;
+};
+
+const STDERR_LIMIT = 8_192;
+const STDOUT_LINE_LIMIT = 8 * 1024 * 1024;
+const LIFECYCLE_LIMIT = 24;
+const GRACEFUL_CLOSE_MS = 250;
+const TERM_CLOSE_MS = 500;
+
+function processConfig(
+  request: AgyTurnRequest,
+  binary: string,
+  binaryVersion?: string,
+  binaryRevision?: string,
+): AgyProcessConfigSnapshot {
+  return {
+    binary,
+    binaryVersion,
+    binaryRevision,
+    cwd: request.cwd,
+    model: request.model,
+    effort: request.effort,
+    agent: request.agent,
+    mode: request.mode,
+    bridgeRevision: request.bridgeRevision,
+  };
+}
+
+function recycleCause(
+  request: AgyTurnRequest,
+  current: AgyProcessConfigSnapshot | undefined,
+  next: AgyProcessConfigSnapshot,
+  boundConversationId: string | undefined,
+): AgyRecycleCause | undefined {
+  if (!current) return "unspecified";
+  if (
+    current.binary !== next.binary ||
+    current.binaryVersion !== next.binaryVersion ||
+    current.binaryRevision !== next.binaryRevision
+  )
+    return "binary";
+  if (current.cwd !== next.cwd) return "cwd";
+  if (current.model !== next.model) return "model";
+  if (current.effort !== next.effort) return "effort";
+  if (current.agent !== next.agent) return "agent";
+  if (current.mode !== next.mode) return "mode";
+  if (current.bridgeRevision !== next.bridgeRevision) return "bridge-catalog";
+  if (request.conversationId === undefined) {
+    return boundConversationId === undefined ? undefined : "conversation-reset";
+  }
+  return request.conversationId === boundConversationId ? undefined : "conversation";
+}
+
+function abortOutcome(): AgyTurnOutcome {
+  const outcome = newTurnOutcome();
+  outcome.status = "ERROR";
+  outcome.error = "agy turn was aborted.";
+  outcome.finished = true;
+  return outcome;
+}
+
+/** One long-lived stream-json agy process, serialized to one logical turn at a time. */
+export class AgyDriverSession implements AgyTurnExecutor {
+  #state: AgyDriverState = "idle";
+  #child: DriverChild | undefined;
+  #generation = 0;
+  #stdoutBuffer = "";
+  #stderrTail = "";
+  #boundConversationId: string | undefined;
+  #config: AgyProcessConfigSnapshot | undefined;
+  #active: ActiveTurn | undefined;
+  #queueTail: Promise<void> = Promise.resolve();
+  #lifecycle: string[] = [];
+  #spawnCount = 0;
+  #submittedTurns = 0;
+  #reusedTurns = 0;
+  #recycleCount = 0;
+  #currentProcessTurns = 0;
+  #recycleReasons = new Map<AgyRecycleCause, number>();
+  #lastRecycleReason: AgyRecycleCause | undefined;
+  #shutdown = false;
+
+  snapshot(): AgyExecutorSnapshot {
+    return {
+      mode: "persistent",
+      state: this.#state,
+      pid: this.#child?.pid,
+      conversationId: this.#boundConversationId,
+      config: this.#config ? { ...this.#config } : undefined,
+      lifecycle: [...this.#lifecycle],
+      stats: {
+        spawnCount: this.#spawnCount,
+        submittedTurns: this.#submittedTurns,
+        reusedTurns: this.#reusedTurns,
+        recycleCount: this.#recycleCount,
+        currentProcessTurns: this.#currentProcessTurns,
+        recycleReasons: Object.fromEntries(
+          [...this.#recycleReasons.entries()].sort(([left], [right]) => left.localeCompare(right)),
+        ),
+        lastRecycleReason: this.#lastRecycleReason,
+      },
+    };
+  }
+
+  async run(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
+    let release!: () => void;
+    const previous = this.#queueTail;
+    this.#queueTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      if (this.#shutdown) throw new AgySpawnError("agy driver is shut down.", this.#stderrTail);
+      if (request.signal?.aborted) return abortOutcome();
+      return await this.#runExclusive(request);
+    } finally {
+      release();
+    }
+  }
+
+  async close(reason: AgyExecutorCloseReason, cause?: AgyRecycleCause): Promise<void> {
+    if (reason === "shutdown") this.#shutdown = true;
+    const child = this.#child;
+    if (!child) {
+      this.#state = reason === "shutdown" ? "dead" : "idle";
+      return;
+    }
+
+    if (reason === "recycle") this.#recordRecycle(cause ?? "unspecified");
+    this.#log(`close:${reason}${cause ? `:${cause}` : ""}`);
+    if (this.#active || reason === "abort") {
+      const active = this.#active;
+      this.#detachChild(child, "dead");
+      killAgyTree(child);
+      if (active) this.#settleTurn(active, { outcome: abortOutcome() });
+      return;
+    }
+
+    this.#state = "stopping";
+    try {
+      child.stdin.end();
+    } catch {
+      // Already closed.
+    }
+    if (await this.#waitUntilChildChanges(child, GRACEFUL_CLOSE_MS)) return;
+    signalAgyTree(child, "SIGTERM");
+    if (await this.#waitUntilChildChanges(child, TERM_CLOSE_MS)) return;
+    this.#detachChild(child, "dead");
+    killAgyTree(child);
+  }
+
+  async #runExclusive(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
+    const checked = request.binary ? undefined : await checkAgyBinary();
+    if (checked && !checked.ok) throw new AgyCompatibilityError(checked);
+    const binary = request.binary ?? checked?.binary;
+    if (!binary) throw new AgySpawnError("agy binary resolution returned no executable.", "");
+    const nextConfig = processConfig(request, binary, checked?.version, checked?.revision);
+    if (this.#child) {
+      const cause = recycleCause(request, this.#config, nextConfig, this.#boundConversationId);
+      if (cause) await this.close("recycle", cause);
+      else this.#reusedTurns += 1;
+    }
+    if (!this.#child) await this.#start(request, nextConfig);
+    const child = this.#child;
+    if (!child) throw new AgySpawnError("agy driver failed to start.", this.#stderrTail);
+
+    const turn = this.#createTurn(request);
+    const outcomePromise = new Promise<AgyTurnOutcome>((resolve, reject) => {
+      turn.resolve = resolve;
+      turn.reject = reject;
+    });
+    this.#active = turn;
+    this.#state = "running";
+    this.#submittedTurns += 1;
+    this.#currentProcessTurns += 1;
+    this.#armTurnTimers(turn);
+    try {
+      await this.#writeUserEvent(child, request.prompt);
+    } catch (error) {
+      this.#detachChild(child, "dead");
+      killAgyTree(child);
+      this.#settleTurn(turn, {
+        error: new AgySpawnError(
+          `failed to write to agy driver (${error instanceof Error ? error.message : String(error)}).`,
+          this.#stderrTail,
+        ),
+      });
+    }
+    return outcomePromise;
+  }
+
+  async #start(request: AgyTurnRequest, config: AgyProcessConfigSnapshot): Promise<void> {
+    this.#state = "starting";
+    this.#generation += 1;
+    const generation = this.#generation;
+    this.#stdoutBuffer = "";
+    this.#stderrTail = "";
+    this.#boundConversationId = request.conversationId;
+    this.#config = config;
+    const doSpawn = request.spawnOverride ?? spawn;
+    let child: DriverChild;
+    try {
+      child = doSpawn(
+        config.binary,
+        buildDriverAgyArgs({
+          conversationId: request.conversationId,
+          model: request.model,
+          effort: request.effort,
+          cwd: request.cwd,
+          timeoutMs: request.timeoutMs,
+          inactivityTimeoutMs: request.inactivityTimeoutMs,
+          toolInactivityTimeoutMs: request.toolInactivityTimeoutMs,
+          signal: request.signal,
+          agent: request.agent,
+          mode: request.mode,
+          bridgeRevision: request.bridgeRevision,
+          binary: config.binary,
+          onActivity: request.onActivity,
+          onConversation: request.onConversation,
+          spawnOverride: request.spawnOverride,
+        }),
+        {
+          cwd: request.cwd,
+          stdio: ["pipe", "pipe", "pipe"],
+          detached: true,
+          windowsHide: true,
+        },
+      ) as DriverChild;
+    } catch (error) {
+      this.#state = "dead";
+      this.#config = undefined;
+      this.#boundConversationId = undefined;
+      throw new AgySpawnError(
+        `failed to start agy driver (${error instanceof Error ? error.message : String(error)}).`,
+        this.#stderrTail,
+      );
+    }
+    this.#child = child;
+    this.#spawnCount += 1;
+    this.#currentProcessTurns = 0;
+    trackAgyChild(child);
+    this.#log(`spawn:${child.pid ?? "unknown"}`);
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => this.#onStdout(generation, chunk));
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => this.#onStderr(generation, chunk));
+    child.on("error", (error: Error) => this.#onChildError(generation, error));
+    child.on("close", (code, signal) => this.#onChildClose(generation, code, signal));
+    this.#state = "ready";
+  }
+
+  #createTurn(request: AgyTurnRequest): ActiveTurn {
+    return {
+      generation: this.#generation,
+      request,
+      outcome: newTurnOutcome(),
+      toolActive: false,
+      conversationReported: false,
+      resolve: () => {},
+      reject: () => {},
+    };
+  }
+
+  #writeUserEvent(child: DriverChild, prompt: string): Promise<void> {
+    const line = `${JSON.stringify({ event: "user", message: { role: "user", content: prompt } })}\n`;
+    return new Promise((resolve, reject) => {
+      let callbackDone = false;
+      let writeReturned = false;
+      let drainDone = true;
+      let settled = false;
+      const cleanup = () => {
+        child.stdin.off("error", onError);
+        child.stdin.off("close", onClose);
+        child.stdin.off("drain", onDrain);
+      };
+      const finish = () => {
+        if (!settled && writeReturned && callbackDone && drainDone) {
+          settled = true;
+          cleanup();
+          resolve();
+        }
+      };
+      const onError = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+      const onClose = () =>
+        onError(new Error("agy driver stdin closed before the user event was written."));
+      const onDrain = () => {
+        drainDone = true;
+        finish();
+      };
+      child.stdin.once("error", onError);
+      child.stdin.once("close", onClose);
+      try {
+        const accepted = child.stdin.write(line, (error?: Error | null) => {
+          if (error) {
+            onError(error);
+            return;
+          }
+          callbackDone = true;
+          finish();
+        });
+        writeReturned = true;
+        if (!accepted) {
+          drainDone = false;
+          child.stdin.once("drain", onDrain);
+        }
+        finish();
+      } catch (error) {
+        onError(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  #armTurnTimers(turn: ActiveTurn): void {
+    const overallMs = turn.request.timeoutMs ?? 600_000;
+    turn.overallTimer = setTimeout(() => {
+      const child = this.#child;
+      if (this.#active !== turn || !child) return;
+      this.#detachChild(child, "dead");
+      killAgyTree(child);
+      this.#settleTurn(turn, {
+        error: new AgySpawnError(
+          `agy turn timed out after ${Math.round(overallMs / 1000)}s`,
+          this.#stderrTail,
+        ),
+      });
+    }, overallMs);
+
+    const onAbort = () => {
+      const child = this.#child;
+      if (this.#active !== turn) return;
+      if (child) {
+        this.#detachChild(child, "dead");
+        killAgyTree(child);
+      }
+      this.#settleTurn(turn, { outcome: abortOutcome() });
+    };
+    turn.abortHandler = onAbort;
+    turn.request.signal?.addEventListener("abort", onAbort, { once: true });
+    this.#rearmStall(turn);
+  }
+
+  #rearmStall(turn: ActiveTurn): void {
+    if (this.#active !== turn) return;
+    if (turn.stallTimer) clearTimeout(turn.stallTimer);
+    const baseMs = turn.request.inactivityTimeoutMs ?? 120_000;
+    if (baseMs <= 0) return;
+    const toolMs = turn.request.toolInactivityTimeoutMs ?? Math.max(baseMs, 300_000);
+    const budgetMs = turn.toolActive ? toolMs : baseMs;
+    turn.stallTimer = setTimeout(() => {
+      const child = this.#child;
+      if (this.#active !== turn || !child) return;
+      this.#detachChild(child, "dead");
+      killAgyTree(child);
+      this.#settleTurn(turn, { error: new AgyStallError(budgetMs, turn.toolActive) });
+    }, budgetMs);
+  }
+
+  #onStdout(generation: number, chunk: string): void {
+    if (generation !== this.#generation) return;
+    if (this.#active) this.#rearmStall(this.#active);
+    this.#stdoutBuffer += chunk;
+    for (;;) {
+      const newline = this.#stdoutBuffer.indexOf("\n");
+      if (newline < 0) break;
+      const line = this.#stdoutBuffer.slice(0, newline).replace(/\r$/, "");
+      this.#stdoutBuffer = this.#stdoutBuffer.slice(newline + 1);
+      this.#handleLine(generation, line);
+    }
+    if (Buffer.byteLength(this.#stdoutBuffer, "utf8") > STDOUT_LINE_LIMIT) {
+      const child = this.#child;
+      const turn = this.#active;
+      if (!child || !turn) {
+        this.#stdoutBuffer = this.#stdoutBuffer.slice(-STDOUT_LINE_LIMIT);
+        return;
+      }
+      this.#detachChild(child, "dead");
+      killAgyTree(child);
+      this.#stdoutBuffer = "";
+      this.#settleTurn(turn, {
+        error: new AgySpawnError(
+          `agy driver emitted an unterminated stdout line larger than ${STDOUT_LINE_LIMIT} bytes.`,
+          this.#stderrTail,
+        ),
+      });
+    }
+  }
+
+  #onStderr(generation: number, chunk: string): void {
+    if (generation !== this.#generation) return;
+    this.#stderrTail = (this.#stderrTail + chunk).slice(-STDERR_LIMIT);
+    if (this.#active) this.#rearmStall(this.#active);
+  }
+
+  #handleLine(generation: number, line: string): void {
+    const turn = this.#active;
+    if (!turn || turn.generation !== generation) {
+      if (line.trim()) this.#log("stdout:idle");
+      return;
+    }
+    const parsed = parseAgyLine(line);
+    if (!turn.conversationReported) {
+      const id =
+        parsed.kind === "init"
+          ? parsed.conversationId
+          : parsed.kind === "step"
+            ? parsed.step.conversation_id
+            : parsed.kind === "result"
+              ? parsed.result.conversation_id
+              : undefined;
+      if (id) {
+        turn.conversationReported = true;
+        this.#boundConversationId = id;
+        turn.request.onConversation?.(id);
+      }
+    }
+    for (const activity of applyEvent(turn.outcome, parsed)) {
+      if (activity.type === "tool_start") turn.toolActive = true;
+      else if (activity.type === "tool_done" || activity.type === "tool_error") {
+        turn.toolActive = false;
+      }
+      turn.request.onActivity?.(activity);
+    }
+    if (turn.outcome.conversationId) this.#boundConversationId = turn.outcome.conversationId;
+    if (turn.outcome.finished) {
+      this.#settleTurn(turn, { outcome: turn.outcome });
+    } else {
+      this.#rearmStall(turn);
+    }
+  }
+
+  #onChildError(generation: number, error: Error): void {
+    if (generation !== this.#generation) return;
+    const child = this.#child;
+    if (child) this.#detachChild(child, "dead");
+    const turn = this.#active;
+    if (turn) {
+      this.#settleTurn(turn, {
+        error: new AgySpawnError(`agy driver failed (${error.message}).`, this.#stderrTail),
+      });
+    }
+  }
+
+  #onChildClose(generation: number, code: number | null, signal: NodeJS.Signals | null): void {
+    if (generation !== this.#generation) return;
+    if (this.#stdoutBuffer.trim() && this.#active) {
+      this.#handleLine(generation, this.#stdoutBuffer.replace(/\r$/, ""));
+    }
+    this.#stdoutBuffer = "";
+    const child = this.#child;
+    if (child) this.#detachChild(child, "dead");
+    this.#log(`close:${code ?? signal ?? "unknown"}`);
+    const turn = this.#active;
+    if (turn) {
+      const tail = this.#stderrTail.trim().split("\n").slice(-3).join("\n");
+      this.#settleTurn(turn, {
+        error: new AgySpawnError(
+          `agy exited with code ${code ?? signal ?? "signal"} before producing a result${tail ? `: ${tail}` : ""}`,
+          this.#stderrTail,
+        ),
+      });
+    }
+  }
+
+  #settleTurn(turn: ActiveTurn, result: { outcome: AgyTurnOutcome } | { error: unknown }): void {
+    if (this.#active !== turn) return;
+    if (turn.overallTimer) clearTimeout(turn.overallTimer);
+    if (turn.stallTimer) clearTimeout(turn.stallTimer);
+    if (turn.abortHandler) turn.request.signal?.removeEventListener("abort", turn.abortHandler);
+    this.#active = undefined;
+    if (this.#child) this.#state = "ready";
+    if ("error" in result) turn.reject(result.error);
+    else turn.resolve(result.outcome);
+  }
+
+  #detachChild(child: DriverChild, nextState: AgyDriverState): void {
+    if (this.#child !== child) return;
+    untrackAgyChild(child);
+    this.#child = undefined;
+    this.#currentProcessTurns = 0;
+    this.#state = nextState;
+    this.#generation += 1;
+  }
+
+  #recordRecycle(cause: AgyRecycleCause): void {
+    this.#recycleCount += 1;
+    this.#lastRecycleReason = cause;
+    this.#recycleReasons.set(cause, (this.#recycleReasons.get(cause) ?? 0) + 1);
+  }
+
+  #waitUntilChildChanges(child: DriverChild, timeoutMs: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const deadline = setTimeout(() => resolve(this.#child !== child), timeoutMs);
+      child.once("close", () => {
+        clearTimeout(deadline);
+        resolve(true);
+      });
+    });
+  }
+
+  #log(message: string): void {
+    this.#lifecycle.push(`${new Date().toISOString()} ${message}`);
+    if (this.#lifecycle.length > LIFECYCLE_LIMIT) this.#lifecycle.shift();
+  }
+}
+
+export class AgyOneShotExecutor implements AgyTurnExecutor {
+  #state: AgyDriverState = "idle";
+  #activeAbort: AbortController | undefined;
+  #lifecycle: string[] = [];
+  #submittedTurns = 0;
+
+  async run(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
+    const activeAbort = new AbortController();
+    this.#submittedTurns += 1;
+    this.#activeAbort = activeAbort;
+    this.#state = "running";
+    const signal = request.signal
+      ? AbortSignal.any([request.signal, activeAbort.signal])
+      : activeAbort.signal;
+    try {
+      return await runAgyTurn({ ...request, signal });
+    } finally {
+      if (this.#activeAbort === activeAbort) this.#activeAbort = undefined;
+      this.#state = "idle";
+    }
+  }
+
+  snapshot(): AgyExecutorSnapshot {
+    return {
+      mode: "one-shot",
+      state: this.#state,
+      lifecycle: [...this.#lifecycle],
+      stats: {
+        spawnCount: this.#submittedTurns,
+        submittedTurns: this.#submittedTurns,
+        reusedTurns: 0,
+        recycleCount: 0,
+        currentProcessTurns: this.#state === "running" ? 1 : 0,
+        recycleReasons: {},
+      },
+    };
+  }
+
+  async close(reason: AgyExecutorCloseReason, cause?: AgyRecycleCause): Promise<void> {
+    this.#lifecycle.push(`${new Date().toISOString()} close:${reason}${cause ? `:${cause}` : ""}`);
+    if (this.#lifecycle.length > LIFECYCLE_LIMIT) this.#lifecycle.shift();
+    this.#activeAbort?.abort();
+    this.#activeAbort = undefined;
+    this.#state = reason === "shutdown" ? "dead" : "idle";
+  }
+}
+
+export function createAgyTurnExecutor(env: NodeJS.ProcessEnv = process.env): AgyTurnExecutor {
+  return env.PI_ANTIGRAVITY_DRIVER === "0" ? new AgyOneShotExecutor() : new AgyDriverSession();
+}

--- a/packages/pi-antigravity/lib/agy-profile.ts
+++ b/packages/pi-antigravity/lib/agy-profile.ts
@@ -1,0 +1,56 @@
+export type AgyExecutionMode = "plan" | "accept-edits";
+
+export interface AgyProcessProfile {
+  agent?: string;
+  mode?: AgyExecutionMode;
+}
+
+const MAX_AGENT_NAME_LENGTH = 128;
+
+export function readAgyProcessProfile(env: NodeJS.ProcessEnv = process.env): AgyProcessProfile {
+  let agent: string | undefined;
+  if (env.PI_ANTIGRAVITY_AGENT !== undefined) {
+    agent = env.PI_ANTIGRAVITY_AGENT.trim();
+    if (!agent) {
+      throw new Error("PI_ANTIGRAVITY_AGENT must not be empty.");
+    }
+    if (agent.includes("\0")) {
+      throw new Error("PI_ANTIGRAVITY_AGENT must not contain NUL bytes.");
+    }
+    if (/[\x01-\x1f\x7f]/.test(agent)) {
+      throw new Error("PI_ANTIGRAVITY_AGENT must not contain control characters.");
+    }
+    if (agent.length > MAX_AGENT_NAME_LENGTH) {
+      throw new Error(`PI_ANTIGRAVITY_AGENT must be at most ${MAX_AGENT_NAME_LENGTH} characters.`);
+    }
+  }
+
+  let mode: AgyExecutionMode | undefined;
+  if (env.PI_ANTIGRAVITY_MODE !== undefined) {
+    const configured = env.PI_ANTIGRAVITY_MODE.trim();
+    if (configured !== "plan" && configured !== "accept-edits") {
+      throw new Error('PI_ANTIGRAVITY_MODE must be exactly "plan" or "accept-edits".');
+    }
+    mode = configured;
+  }
+  return {
+    ...(agent ? { agent } : {}),
+    ...(mode ? { mode } : {}),
+  };
+}
+
+/** Parse the intentionally simple line-oriented output of `agy agents`. */
+export function parseAgyAgents(text: string): string[] {
+  const agents: string[] = [];
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || /^available\s+agents:?$/i.test(line) || /^name\s+/i.test(line)) continue;
+    const name = line
+      .split(/\t|\s{2,}/, 1)[0]
+      ?.replace(/^[-*]\s*/, "")
+      .trim();
+    if (!name || name.length > MAX_AGENT_NAME_LENGTH || /[\x00-\x1f\x7f]/.test(name)) continue;
+    if (!agents.includes(name)) agents.push(name);
+  }
+  return agents;
+}

--- a/packages/pi-antigravity/lib/artifacts.ts
+++ b/packages/pi-antigravity/lib/artifacts.ts
@@ -1,28 +1,14 @@
-/**
- * Discovery of agy conversation artifacts.
- *
- * agy stores per-conversation files under
- * `~/.gemini/antigravity-cli/brain/<conversation-id>/`:
- *   - `.tempmediaStorage/` — media/files the agent created (artifacts);
- *   - `.user_uploaded/`    — files the user uploaded into the conversation.
- *
- * The stream-json RPC never reports these, so — like background tasks —
- * this module reads them from the filesystem. Transcripts reference them
- * as `[ARTIFACT: <name>]` markers with `file://` paths.
- */
+/** Safe discovery of user-facing files in an agy conversation brain directory. */
 
-import { promises as fs } from "node:fs";
+import { promises as fs, type Dirent } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
 export interface AgyArtifact {
-  /** File name, e.g. "media_1786774158854.png". */
   name: string;
   absolutePath: string;
-  /** created-by-agent vs uploaded-by-user. */
-  kind: "generated" | "uploaded";
-  /** Rough media type from the extension. */
-  mediaType: "image" | "audio" | "video" | "pdf" | "other";
+  kind: "conversation" | "generated" | "uploaded";
+  mediaType: "image" | "audio" | "video" | "pdf" | "markdown" | "other";
   bytes: number;
   modifiedMs: number;
 }
@@ -45,48 +31,94 @@ const MEDIA_TYPES: Record<string, AgyArtifact["mediaType"]> = {
   webm: "video",
   mov: "video",
   pdf: "pdf",
+  md: "markdown",
+  markdown: "markdown",
 };
 
 function mediaTypeFor(name: string): AgyArtifact["mediaType"] {
   return MEDIA_TYPES[name.split(".").pop()?.toLowerCase() ?? ""] ?? "other";
 }
 
-async function listDir(dir: string, kind: AgyArtifact["kind"]): Promise<AgyArtifact[]> {
-  let entries: string[];
-  try {
-    entries = await fs.readdir(dir);
-  } catch {
-    return []; // Directory absent — the conversation created no artifacts.
-  }
-  return Promise.all(
-    entries
-      .filter((name) => !name.startsWith("."))
-      .map(async (name): Promise<AgyArtifact> => {
-        const absolutePath = path.join(dir, name);
-        const stat = await fs.stat(absolutePath).catch(() => undefined);
-        return {
-          name,
-          absolutePath,
-          kind,
-          mediaType: mediaTypeFor(name),
-          bytes: stat?.size ?? 0,
-          modifiedMs: stat?.mtimeMs ?? 0,
-        };
-      }),
+function isContained(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
   );
 }
 
-/** List every artifact recorded for an agy conversation, newest first. */
+function isVisibleArtifactName(name: string): boolean {
+  return !name.startsWith(".") && !name.toLowerCase().endsWith(".metadata.json");
+}
+
+async function listDirectFiles(
+  dir: string,
+  conversationRoot: string,
+  kind: AgyArtifact["kind"],
+): Promise<AgyArtifact[]> {
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const artifacts: AgyArtifact[] = [];
+  for (const entry of entries) {
+    if (!isVisibleArtifactName(entry.name) || !entry.isFile() || entry.isSymbolicLink()) continue;
+    const candidate = path.resolve(dir, entry.name);
+    if (!isContained(conversationRoot, candidate)) continue;
+    try {
+      const [stat, canonical] = await Promise.all([fs.lstat(candidate), fs.realpath(candidate)]);
+      if (!stat.isFile() || stat.isSymbolicLink() || !isContained(conversationRoot, canonical))
+        continue;
+      artifacts.push({
+        name: entry.name,
+        absolutePath: canonical,
+        kind,
+        mediaType: mediaTypeFor(entry.name),
+        bytes: stat.size,
+        modifiedMs: stat.mtimeMs,
+      });
+    } catch {
+      // Atomic replacement or unreadable entry: omit it from this scan.
+    }
+  }
+  return artifacts;
+}
+
+/** List safe direct artifacts for one agy conversation, newest first. */
 export async function listAgyArtifacts(
   conversationId: string,
   options: { brainDir?: string } = {},
 ): Promise<AgyArtifact[]> {
-  const base = path.join(options.brainDir ?? agyBrainDir(), conversationId);
-  const [generated, uploaded] = await Promise.all([
-    listDir(path.join(base, ".tempmediaStorage"), "generated"),
-    listDir(path.join(base, ".user_uploaded"), "uploaded"),
+  const brain = path.resolve(options.brainDir ?? agyBrainDir());
+  const base = path.resolve(brain, conversationId);
+  if (!isContained(brain, base) || base === brain) return [];
+
+  let canonicalBrain: string;
+  let canonicalBase: string;
+  try {
+    [canonicalBrain, canonicalBase] = await Promise.all([fs.realpath(brain), fs.realpath(base)]);
+  } catch {
+    return [];
+  }
+  if (!isContained(canonicalBrain, canonicalBase) || canonicalBase === canonicalBrain) return [];
+
+  const [conversation, generated, uploaded] = await Promise.all([
+    listDirectFiles(canonicalBase, canonicalBase, "conversation"),
+    listDirectFiles(path.join(canonicalBase, ".tempmediaStorage"), canonicalBase, "generated"),
+    listDirectFiles(path.join(canonicalBase, ".user_uploaded"), canonicalBase, "uploaded"),
   ]);
-  return [...generated, ...uploaded].sort((a, b) => b.modifiedMs - a.modifiedMs);
+  const deduped = new Map<string, AgyArtifact>();
+  for (const artifact of [...conversation, ...generated, ...uploaded]) {
+    if (!deduped.has(artifact.absolutePath)) deduped.set(artifact.absolutePath, artifact);
+  }
+  return [...deduped.values()].sort(
+    (a, b) =>
+      b.modifiedMs - a.modifiedMs ||
+      a.name.localeCompare(b.name) ||
+      a.absolutePath.localeCompare(b.absolutePath),
+  );
 }
 
 /** Resolve an artifact reference by exact name or unique prefix. */

--- a/packages/pi-antigravity/lib/bridge-lifecycle.ts
+++ b/packages/pi-antigravity/lib/bridge-lifecycle.ts
@@ -17,16 +17,21 @@ export interface BridgeLifecycleManager {
   readonly isRunning: () => boolean;
   readonly ensureRegistered: (notify?: (message: string) => void) => Promise<boolean>;
   readonly teardown: () => Promise<void>;
+  readonly registrationGeneration: () => number;
+  readonly processRevision: () => string;
   readonly getBootstrapSuffix: (skills: SkillLite[]) => string | undefined;
 }
 
 export function createBridgeLifecycleManager(deps: BridgeLifecycleDeps): BridgeLifecycleManager {
   const enabled = deps.enabled ?? true;
   let registered = false;
+  let generation = 0;
 
   return {
     isRegistered: () => registered,
     isRunning: () => deps.bridge.running,
+    registrationGeneration: () => generation,
+    processRevision: () => `${generation}:${deps.bridge.catalogRevision}`,
 
     ensureRegistered: async (notify?: (message: string) => void) => {
       if (!enabled) return false;
@@ -44,6 +49,7 @@ export function createBridgeLifecycleManager(deps: BridgeLifecycleDeps): BridgeL
         await deps.addMcpServer(deps.bridge.serverName, url, deps.bridgeToken);
         deps.bridge.refreshTools();
         registered = true;
+        generation += 1;
         return true;
       } catch (error) {
         registered = false;
@@ -60,6 +66,7 @@ export function createBridgeLifecycleManager(deps: BridgeLifecycleDeps): BridgeL
 
     teardown: async () => {
       if (!registered && !deps.bridge.running) return;
+      const changed = registered || deps.bridge.running;
       registered = false;
       try {
         await deps.removeMcpServer(deps.bridge.serverName);
@@ -74,6 +81,7 @@ export function createBridgeLifecycleManager(deps: BridgeLifecycleDeps): BridgeL
       if (deps.bridge.running) {
         await deps.bridge.close();
       }
+      if (changed) generation += 1;
     },
 
     getBootstrapSuffix: (skills: SkillLite[]) =>

--- a/packages/pi-antigravity/lib/bridge.ts
+++ b/packages/pi-antigravity/lib/bridge.ts
@@ -18,7 +18,7 @@
  * the provider hands back the executed result, or times out (fail closed).
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { WRAPPER_TOOL_NAME } from "./prompt.ts";
 
@@ -107,6 +107,21 @@ interface JsonRpcRequest {
   };
 }
 
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (typeof value !== "object" || value === null) return value;
+  const object = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(object)
+      .sort()
+      .map((key) => [key, canonicalValue(object[key])]),
+  );
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalValue(value));
+}
+
 export class AgyPiBridge {
   #tools: BridgeToolDef[] = [];
   #server: Server | undefined;
@@ -131,6 +146,8 @@ export class AgyPiBridge {
   #toolSource: (() => BridgeToolDef[]) | undefined;
   /** Replaced wholesale on every skills refresh (activate_skill, or empty). */
   #dynamic = new Map<string, DynamicTool>();
+  #catalogDigest = createHash("sha256").update("[]").digest("hex");
+  #catalogRevision = 0;
 
   constructor(serverName: string = BRIDGE_SERVER_NAME) {
     this.serverName = serverName;
@@ -144,6 +161,7 @@ export class AgyPiBridge {
   /** Set the per-session tool-name prefix (e.g. `pi__p1234__`). */
   setToolPrefix(prefix: string): void {
     this.#toolPrefix = prefix;
+    this.#updateCatalogRevision();
   }
 
   setOnCall(onCall: (call: BridgeCall) => boolean): void {
@@ -154,9 +172,14 @@ export class AgyPiBridge {
     this.#toolSource = toolSource;
   }
 
-  /** Refresh the exposed-tool snapshot from the configured source. */
-  refreshTools(): void {
+  /** Refresh the exposed-tool snapshot and report whether canonical content changed. */
+  refreshTools(): boolean {
     this.#tools = this.#toolSource?.() ?? [];
+    return this.#updateCatalogRevision();
+  }
+
+  get catalogRevision(): number {
+    return this.#catalogRevision;
   }
 
   /**
@@ -173,6 +196,30 @@ export class AgyPiBridge {
     }>,
   ): void {
     this.#dynamic = new Map(tools.map((tool) => [tool.name, { ...tool }]));
+    this.#updateCatalogRevision();
+  }
+
+  #updateCatalogRevision(): boolean {
+    const catalog = [
+      ...this.#tools
+        .filter((tool) => !this.#dynamic.has(tool.name))
+        .map((tool) => ({
+          name: `${this.#toolPrefix}${tool.name}`,
+          description:
+            tool.description || `pi tool "${tool.name}" bridged into agy by ${BRIDGE_SERVER_NAME}.`,
+          inputSchema: tool.parameters,
+        })),
+      ...[...this.#dynamic].map(([name, definition]) => ({
+        name: `${this.#toolPrefix}${name}`,
+        description: definition.description,
+        inputSchema: definition.parameters,
+      })),
+    ].sort((a, b) => a.name.localeCompare(b.name));
+    const digest = createHash("sha256").update(canonicalJson(catalog)).digest("hex");
+    if (digest === this.#catalogDigest) return false;
+    this.#catalogDigest = digest;
+    this.#catalogRevision += 1;
+    return true;
   }
 
   get url(): string | undefined {

--- a/packages/pi-antigravity/lib/conversation-metadata.ts
+++ b/packages/pi-antigravity/lib/conversation-metadata.ts
@@ -1,0 +1,125 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const AGY_METADATA_MAX_BYTES = 5 * 1024 * 1024;
+
+export interface AgyConversationMetadata {
+  id: string;
+  title?: string;
+  preview?: string;
+  numSteps?: number;
+  updatedAt?: string;
+  workspaceUris: string[];
+  agentName?: string;
+}
+
+export type AgyMetadataStatus = "ok" | "missing" | "oversized" | "invalid" | "unreadable";
+
+export interface AgyMetadataResult {
+  status: AgyMetadataStatus;
+  metadata?: AgyConversationMetadata;
+}
+
+export function agyConversationMetadataPath(homeDirectory = os.homedir()): string {
+  return path.join(
+    homeDirectory,
+    ".gemini",
+    "antigravity-cli",
+    "cache",
+    "conversation_metadata.json",
+  );
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function boundedString(value: unknown, max: number): string | undefined {
+  return typeof value === "string" && value.length > 0 && value.length <= max ? value : undefined;
+}
+
+function validTimestamp(value: unknown): string | undefined {
+  const timestamp = boundedString(value, 128);
+  return timestamp && Number.isFinite(Date.parse(timestamp)) ? timestamp : undefined;
+}
+
+export function parseAgyConversationMetadata(
+  value: unknown,
+  conversationId: string,
+): AgyConversationMetadata | undefined {
+  const root = record(value);
+  const conversations = record(root?.conversations);
+  const raw = record(conversations?.[conversationId]);
+  const summary = record(raw?.summary) ?? raw;
+  if (!summary) return undefined;
+  const id = boundedString(summary.ID, 256) ?? boundedString(summary.id, 256);
+  if (!id || id !== conversationId) return undefined;
+
+  const numSteps = summary.NumSteps;
+  const workspaceUris = Array.isArray(summary.WorkspaceURIs)
+    ? summary.WorkspaceURIs.slice(0, 32)
+        .map((uri) => boundedString(uri, 4_096))
+        .filter((uri): uri is string => uri !== undefined)
+    : [];
+  return {
+    id,
+    title: boundedString(summary.Title, 512),
+    preview: boundedString(summary.Preview, 2_048),
+    numSteps:
+      Number.isSafeInteger(numSteps) && (numSteps as number) >= 0
+        ? (numSteps as number)
+        : undefined,
+    updatedAt: validTimestamp(summary.UpdatedAt),
+    workspaceUris,
+    agentName: boundedString(summary.AgentName, 256),
+  };
+}
+
+export async function readAgyConversationMetadata(
+  conversationId: string,
+  options: { file?: string; maxBytes?: number } = {},
+): Promise<AgyMetadataResult> {
+  const file = options.file ?? agyConversationMetadataPath();
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(file);
+  } catch (error) {
+    return {
+      status: (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "unreadable",
+    };
+  }
+  if (!stat.isFile()) return { status: "unreadable" };
+  if (stat.size > (options.maxBytes ?? AGY_METADATA_MAX_BYTES)) return { status: "oversized" };
+
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  try {
+    handle = await fs.open(file, "r");
+    const limit = options.maxBytes ?? AGY_METADATA_MAX_BYTES;
+    const buffer = Buffer.alloc(limit + 1);
+    let total = 0;
+    while (total < buffer.length) {
+      const { bytesRead } = await handle.read(buffer, total, buffer.length - total, total);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+    }
+    if (total > limit) return { status: "oversized" };
+    let text: string;
+    try {
+      text = new TextDecoder("utf-8", { fatal: true }).decode(buffer.subarray(0, total));
+    } catch {
+      return { status: "invalid" };
+    }
+    const parsed = JSON.parse(text) as unknown;
+    const metadata = parseAgyConversationMetadata(parsed, conversationId);
+    return metadata ? { status: "ok", metadata } : { status: "invalid" };
+  } catch (error) {
+    return {
+      status: error instanceof SyntaxError ? "invalid" : "unreadable",
+    };
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}

--- a/packages/pi-antigravity/lib/models.ts
+++ b/packages/pi-antigravity/lib/models.ts
@@ -1,30 +1,71 @@
 /**
- * agy model discovery — parses `agy models` tab-separated output and maps it
- * to pi provider model configs. Effort variants (`-low`/`-medium`/`-high`
- * suffixes) are collapsed into one base model per family; reasoning effort is
- * controlled at turn time from pi's thinking level via `agy --effort`.
- * A bundled fallback snapshot (captured from agy 1.1.19) registers when
- * discovery cannot run, so /model stays usable.
+ * agy model discovery. Effort variants are presented as one Pi model while
+ * retaining the launch constraints agy requires for the normalized base id.
  */
+
+import type { AgyEffort } from "./agy-client.ts";
 
 export interface AgyModelInfo {
   id: string;
   name: string;
+  supportedEfforts: AgyEffort[];
+  defaultEffort?: AgyEffort;
 }
 
 const EFFORT_SUFFIX = /-(low|medium|high)$/i;
 const EFFORT_NAME_SUFFIX = /\s*\((?:low|medium|high)\)$/i;
 
-/** Collapse an effort variant (`gemini-3.7-flash-high`) to its base model. */
+function effortFromId(id: string): AgyEffort | undefined {
+  const match = id.match(EFFORT_SUFFIX);
+  const effort = match?.[1]?.toLowerCase();
+  return effort === "low" || effort === "medium" || effort === "high" ? effort : undefined;
+}
+
+/** Collapse one effort variant while retaining its discovered effort. */
 export function normalizeAgyModelId(id: string, name: string): AgyModelInfo {
-  const baseId = id.replace(EFFORT_SUFFIX, "");
-  const baseName = name.replace(EFFORT_NAME_SUFFIX, "").trim();
-  return { id: baseId || id, name: baseName || name };
+  const effort = effortFromId(id);
+  const baseId = effort ? id.replace(EFFORT_SUFFIX, "") : id;
+  const baseName = effort ? name.replace(EFFORT_NAME_SUFFIX, "").trim() : name.trim();
+  return {
+    id: baseId || id,
+    name: baseName || name,
+    supportedEfforts: effort ? [effort] : [],
+    defaultEffort: effort,
+  };
+}
+
+/** Merge normalized/cache records without losing effort variants or discovery order. */
+export function mergeAgyModels(models: readonly AgyModelInfo[]): AgyModelInfo[] {
+  const merged: AgyModelInfo[] = [];
+  for (const raw of models) {
+    const normalized = normalizeAgyModelId(raw.id, raw.name);
+    const efforts = raw.supportedEfforts?.length
+      ? raw.supportedEfforts.filter(
+          (effort): effort is AgyEffort =>
+            effort === "low" || effort === "medium" || effort === "high",
+        )
+      : normalized.supportedEfforts;
+    const existing = merged.find((model) => model.id === normalized.id);
+    if (!existing) {
+      merged.push({
+        id: normalized.id,
+        name: normalized.name,
+        supportedEfforts: [...new Set(efforts)],
+        defaultEffort: raw.defaultEffort ?? normalized.defaultEffort ?? efforts[0],
+      });
+      continue;
+    }
+    for (const effort of efforts) {
+      if (!existing.supportedEfforts.includes(effort)) existing.supportedEfforts.push(effort);
+    }
+    existing.defaultEffort ??= raw.defaultEffort ?? normalized.defaultEffort ?? efforts[0];
+  }
+  return merged;
 }
 
 /** Parse `agy models` output: header/noise lines without a tab are ignored. */
 export function parseAgyModels(text: string): AgyModelInfo[] {
-  const models: AgyModelInfo[] = [];
+  const rows: AgyModelInfo[] = [];
   for (const line of text.split("\n")) {
     const tab = line.indexOf("\t");
     if (tab <= 0) continue;
@@ -32,22 +73,63 @@ export function parseAgyModels(text: string): AgyModelInfo[] {
     const rawName = line.slice(tab + 1).trim();
     if (!rawId || !rawName) continue;
     if (!/^[a-z0-9][a-z0-9.-]*$/i.test(rawId)) continue;
-    const model = normalizeAgyModelId(rawId, rawName);
-    if (models.some((m) => m.id === model.id)) continue;
-    models.push(model);
+    rows.push(normalizeAgyModelId(rawId, rawName));
   }
-  return models;
+  return mergeAgyModels(rows);
 }
 
-/** Fallback snapshot from agy 1.1.19 `agy models` (2026-08-24), base models only. */
+/** Resolve a valid effort for a normalized agy model. */
+export function resolveAgyModelEffort(
+  model: AgyModelInfo | undefined,
+  requested: AgyEffort | undefined,
+): AgyEffort | undefined {
+  if (!model || model.supportedEfforts.length === 0) return undefined;
+  if (requested && model.supportedEfforts.includes(requested)) return requested;
+  return model.defaultEffort ?? model.supportedEfforts[0];
+}
+
+/** Fallback snapshot from agy 1.1.22 `agy models`, including effort constraints. */
 export const FALLBACK_MODELS: AgyModelInfo[] = [
-  { id: "gemini-3.7-flash", name: "Gemini 3.7 Flash" },
-  { id: "gemini-3.6-flash", name: "Gemini 3.6 Flash" },
-  { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash" },
-  { id: "gemini-3.1-pro", name: "Gemini 3.1 Pro" },
-  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (Thinking)" },
-  { id: "claude-opus-4-6-thinking", name: "Claude Opus 4.6 (Thinking)" },
-  { id: "gpt-oss-120b", name: "GPT-OSS 120B" },
+  {
+    id: "gemini-3.7-flash",
+    name: "Gemini 3.7 Flash",
+    supportedEfforts: ["high", "medium", "low"],
+    defaultEffort: "high",
+  },
+  {
+    id: "gemini-3.6-flash",
+    name: "Gemini 3.6 Flash",
+    supportedEfforts: ["high", "medium", "low"],
+    defaultEffort: "high",
+  },
+  {
+    id: "gemini-3.5-flash",
+    name: "Gemini 3.5 Flash",
+    supportedEfforts: ["high", "medium", "low"],
+    defaultEffort: "high",
+  },
+  {
+    id: "gemini-3.1-pro",
+    name: "Gemini 3.1 Pro",
+    supportedEfforts: ["high", "low"],
+    defaultEffort: "high",
+  },
+  {
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6 (Thinking)",
+    supportedEfforts: [],
+  },
+  {
+    id: "claude-opus-4-6-thinking",
+    name: "Claude Opus 4.6 (Thinking)",
+    supportedEfforts: [],
+  },
+  {
+    id: "gpt-oss-120b",
+    name: "GPT-OSS 120B",
+    supportedEfforts: ["medium"],
+    defaultEffort: "medium",
+  },
 ];
 
 export interface ModelCapabilities {
@@ -83,7 +165,6 @@ export function pricingForModel(modelId: string): ModelPricing {
     return { input: 1.5, output: 9, cacheRead: 0.15, cacheWrite: 1.5 };
   }
   if (/^gemini-3\.1-pro/i.test(modelId)) {
-    // The <=200k standard tier; pi's cost shape cannot express tiered rates.
     return { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 2 };
   }
   if (/^claude-sonnet-4-6/i.test(modelId)) {
@@ -97,14 +178,10 @@ export function pricingForModel(modelId: string): ModelPricing {
 
 /**
  * Pi scheduling window, deliberately larger than agy's private ~185k working
- * window. agy owns and persists its native context compaction; advertising the
- * smaller working cap made Pi summarize the same conversation first. This is
- * not a claim about raw model capacity — `/agy` reports the observed native
- * footprint while Pi uses this value only for its compaction scheduler.
+ * window. agy owns and persists its native context compaction.
  */
 export const AGY_PI_SCHEDULING_CONTEXT_WINDOW = 1_000_000;
 
-/** Vendor-specific limits for models present in agy's current catalog. */
 export function capabilitiesForModel(modelId: string): ModelCapabilities {
   let maxTokens: number;
   if (/^gpt-oss-120b/i.test(modelId)) {
@@ -121,16 +198,9 @@ export function capabilitiesForModel(modelId: string): ModelCapabilities {
   return { contextWindow: AGY_PI_SCHEDULING_CONTEXT_WINDOW, maxTokens };
 }
 
-/** Cache lifetime for a discovery result: live catalogs hold a day. */
 export const LIVE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-/**
- * Fallback snapshots hold minutes only: live discovery can lose a race
- * (observed: `agy models` taking 12s against a 15s timeout) and must be
- * retried soon instead of sticking for the full day.
- */
 export const FALLBACK_CACHE_TTL_MS = 5 * 60 * 1000;
 
-/** TTL that applies to a cached model list with the given source. */
 export function modelCacheTtlMs(source: "live" | "fallback" | undefined): number {
   return source === "fallback" ? FALLBACK_CACHE_TTL_MS : LIVE_CACHE_TTL_MS;
 }

--- a/packages/pi-antigravity/lib/usage.ts
+++ b/packages/pi-antigravity/lib/usage.ts
@@ -8,7 +8,7 @@
 
 import { spawn } from "node:child_process";
 import { killAgyTree, trackAgyChild, untrackAgyChild } from "./agy-children.ts";
-import { AGY_BINARY } from "./agy-client.ts";
+import { getAgyBinary } from "./agy-diagnostics.ts";
 
 export const USAGE_TIMEOUT_MS = 30_000;
 
@@ -208,12 +208,14 @@ function defaultExec(
 ): void {
   let settled = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let abortHandler: (() => void) | undefined;
   let out = "";
   let errOut = "";
   const settle = (fn: () => void) => {
     if (settled) return;
     settled = true;
     if (timer) clearTimeout(timer);
+    if (abortHandler) options.signal?.removeEventListener("abort", abortHandler);
     fn();
   };
   // Raw spawn (execFile drops `detached`): own process group + tracked, so
@@ -236,7 +238,7 @@ function defaultExec(
   });
   child.stderr?.setEncoding("utf8");
   child.stderr?.on("data", (chunk: string) => {
-    errOut += chunk;
+    errOut = (errOut + chunk).slice(-8_192);
   });
   child.on("error", (error) => {
     settle(() => {
@@ -256,16 +258,13 @@ function defaultExec(
       );
     });
   });
-  options.signal?.addEventListener(
-    "abort",
-    () => {
-      settle(() => {
-        killAgyTree(child);
-        callback(new Error("aborted"), "", "");
-      });
-    },
-    { once: true },
-  );
+  abortHandler = () => {
+    settle(() => {
+      killAgyTree(child);
+      callback(new Error("aborted"), "", "");
+    });
+  };
+  options.signal?.addEventListener("abort", abortHandler, { once: true });
   if (options.timeout !== undefined) {
     timer = setTimeout(() => {
       settle(() => {
@@ -277,8 +276,8 @@ function defaultExec(
 }
 
 /** Run `agy --print /usage` and parse the structured quota payload. */
-export function fetchAgyUsage(options: FetchAgyUsageOptions = {}): Promise<AgyUsageReport> {
-  const binary = options.binary ?? AGY_BINARY;
+export async function fetchAgyUsage(options: FetchAgyUsageOptions = {}): Promise<AgyUsageReport> {
+  const binary = options.binary ?? (options.execFileOverride ? "agy" : await getAgyBinary());
   const timeoutMs = options.timeoutMs ?? USAGE_TIMEOUT_MS;
   const run = options.execFileOverride ?? defaultExec;
   return new Promise((resolve, reject) => {

--- a/packages/pi-antigravity/package.json
+++ b/packages/pi-antigravity/package.json
@@ -39,7 +39,9 @@
     "test": "node --test --experimental-strip-types test/*.test.ts"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.101"
+    "effect": "4.0.0-beta.101",
+    "semver": "^7.8.5",
+    "which": "^7.0.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
@@ -47,6 +49,8 @@
   },
   "devDependencies": {
     "@effect/language-service": "^0.87.2",
+    "@types/semver": "^7.8.0",
+    "@types/which": "^3.0.4",
     "typescript": "^7.0.2"
   },
   "publishConfig": {

--- a/packages/pi-antigravity/src/artifacts-ui.ts
+++ b/packages/pi-antigravity/src/artifacts-ui.ts
@@ -7,13 +7,19 @@
  */
 
 import { execFile } from "node:child_process";
+import { open as openFile } from "node:fs/promises";
 import type {
   ExtensionCommandContext,
   KeybindingsManager,
   Theme,
 } from "@earendil-works/pi-coding-agent";
 import type { Component, TUI } from "@earendil-works/pi-tui";
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import {
+  stripTerminalSequences,
+  truncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 import type { AgyArtifact } from "../lib/artifacts.ts";
 
 function oneLine(text: string) {
@@ -51,6 +57,54 @@ export interface AgyArtifactsModel {
   refresh(): Promise<void>;
 }
 
+export const MARKDOWN_PREVIEW_MAX_BYTES = 256 * 1024;
+
+export interface AgyMarkdownPreview {
+  text: string;
+  truncated: boolean;
+  completed: number;
+  total: number;
+}
+
+export async function readMarkdownPreview(
+  absolutePath: string,
+  maxBytes = MARKDOWN_PREVIEW_MAX_BYTES,
+): Promise<AgyMarkdownPreview> {
+  const handle = await openFile(absolutePath, "r");
+  try {
+    const buffer = Buffer.alloc(maxBytes + 1);
+    let bytesReadTotal = 0;
+    while (bytesReadTotal < buffer.length) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        bytesReadTotal,
+        buffer.length - bytesReadTotal,
+        bytesReadTotal,
+      );
+      if (bytesRead === 0) break;
+      bytesReadTotal += bytesRead;
+    }
+    const truncated = bytesReadTotal > maxBytes;
+    const bytes = buffer.subarray(0, Math.min(bytesReadTotal, maxBytes));
+    // Streaming decode on a truncated prefix drops only an incomplete final
+    // code point; malformed UTF-8 anywhere else still fails closed.
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes, {
+      stream: truncated,
+    });
+    let completed = 0;
+    let total = 0;
+    for (const line of text.split(/\r?\n/)) {
+      const match = line.match(/^\s*-\s+\[([ xX])\]\s+/);
+      if (!match) continue;
+      total += 1;
+      if (match[1]?.toLowerCase() === "x") completed += 1;
+    }
+    return { text, truncated, completed, total };
+  } finally {
+    await handle.close();
+  }
+}
+
 /** Open a file with the OS default handler. Resolves after launch. */
 export function openArtifact(absolutePath: string): Promise<void> {
   const command = process.platform === "darwin" ? "open" : "xdg-open";
@@ -80,7 +134,9 @@ export async function openAgyArtifactsPicker(
   };
   await ctx.ui.custom<null>(
     (tui, theme, keybindings, done) =>
-      new AgyArtifactsDashboard(tui, theme, keybindings, model, selection, done),
+      new AgyArtifactsDashboard(tui, theme, keybindings, model, selection, done, (message) =>
+        ctx.ui.notify(message, "error"),
+      ),
     {
       overlay: true,
       overlayOptions: { anchor: "center", width: "100%", maxHeight: "100%" },
@@ -97,6 +153,10 @@ export class AgyArtifactsDashboard implements Component {
   private done: (value: null) => void;
   private closed = false;
   private busy = false;
+  private preview:
+    | { artifact: AgyArtifact; content: AgyMarkdownPreview; scroll: number }
+    | undefined;
+  private notifyError: (message: string) => void;
 
   constructor(
     tui: TUI,
@@ -105,6 +165,7 @@ export class AgyArtifactsDashboard implements Component {
     model: AgyArtifactsModel,
     selection: AgyArtifactsSelection,
     done: (value: null) => void,
+    notifyError: (message: string) => void = () => {},
   ) {
     this.tui = tui;
     this.theme = theme;
@@ -112,6 +173,7 @@ export class AgyArtifactsDashboard implements Component {
     this.model = model;
     this.selection = selection;
     this.done = done;
+    this.notifyError = notifyError;
   }
 
   private close() {
@@ -132,6 +194,26 @@ export class AgyArtifactsDashboard implements Component {
     if (this.busy) return;
     const artifacts = this.model.getArtifacts();
     reconcileAgyArtifactsSelection(this.selection, artifacts);
+
+    if (this.preview) {
+      if (this.keybindings.matches(data, "tui.select.cancel")) {
+        this.preview = undefined;
+        this.tui.requestRender();
+        return;
+      }
+      if (this.keybindings.matches(data, "tui.select.up") || data === "k") {
+        this.preview.scroll = Math.max(0, this.preview.scroll - 1);
+        this.tui.requestRender();
+        return;
+      }
+      if (this.keybindings.matches(data, "tui.select.down") || data === "j") {
+        this.preview.scroll += 1;
+        this.tui.requestRender();
+        return;
+      }
+      if (data === "o") void this.open(this.preview.artifact.absolutePath);
+      return;
+    }
 
     if (this.keybindings.matches(data, "tui.select.cancel")) {
       this.close();
@@ -162,12 +244,34 @@ export class AgyArtifactsDashboard implements Component {
       if (artifact) void this.open(artifact.absolutePath);
       return;
     }
+    if (data === "v" || this.keybindings.matches(data, "tui.select.confirm")) {
+      const artifact = artifacts[this.selection.index];
+      if (artifact?.mediaType === "markdown") void this.loadPreview(artifact);
+      return;
+    }
   }
 
   private async rescan(): Promise<void> {
     this.busy = true;
     try {
       await this.model.refresh();
+    } finally {
+      this.busy = false;
+      this.tui.requestRender();
+    }
+  }
+
+  private async loadPreview(artifact: AgyArtifact): Promise<void> {
+    this.busy = true;
+    this.tui.requestRender();
+    try {
+      const content = await readMarkdownPreview(artifact.absolutePath);
+      this.preview = { artifact, content, scroll: 0 };
+    } catch (error) {
+      this.notifyError(
+        `agy-artifacts: cannot preview ${artifact.name} (${error instanceof Error ? error.message : String(error)}).`,
+      );
+      this.preview = undefined;
     } finally {
       this.busy = false;
       this.tui.requestRender();
@@ -214,22 +318,32 @@ export class AgyArtifactsDashboard implements Component {
 
     const lines: string[] = [];
 
-    const headerLeft = theme.fg("accent", theme.bold("agy artifacts"));
-    const headerRight = theme.fg("muted", `${artifacts.length}`);
+    const headerLeft = theme.fg(
+      "accent",
+      theme.bold(
+        this.preview ? `agy artifact · ${oneLine(this.preview.artifact.name)}` : "agy artifacts",
+      ),
+    );
+    const headerRight = theme.fg("muted", this.preview ? "markdown" : `${artifacts.length}`);
     const headerPad = Math.max(1, width - visibleWidth(headerLeft) - visibleWidth(headerRight) - 4);
     lines.push(truncateToWidth(`  ${headerLeft}${" ".repeat(headerPad)}${headerRight}  `, width));
 
     lines.push(
       truncateToWidth(
         theme.fg("border", "╭") +
-          this.borderSegment(innerWidth, this.busy ? "working…" : "artifacts") +
+          this.borderSegment(
+            innerWidth,
+            this.busy ? "working…" : this.preview ? this.previewChecklistLabel() : "artifacts",
+          ) +
           theme.fg("border", "╮"),
         width,
       ),
     );
 
     const divider = theme.fg("border", "│");
-    const rowLines = this.renderRows(artifacts, innerWidth, bodyHeight);
+    const rowLines = this.preview
+      ? this.renderPreview(innerWidth, bodyHeight)
+      : this.renderRows(artifacts, innerWidth, bodyHeight);
     for (let i = 0; i < bodyHeight; i++) {
       lines.push(
         truncateToWidth(divider + this.pad(rowLines[i] ?? "", innerWidth) + divider, width),
@@ -249,13 +363,43 @@ export class AgyArtifactsDashboard implements Component {
       truncateToWidth(
         theme.fg(
           "dim",
-          `  ${configuredKeys(this.keybindings, "tui.select.up")}/${configuredKeys(this.keybindings, "tui.select.down")}/jk select · o open · r rescan · ${configuredKeys(this.keybindings, "tui.select.cancel")} close`,
+          this.preview
+            ? `  ${configuredKeys(this.keybindings, "tui.select.up")}/${configuredKeys(this.keybindings, "tui.select.down")}/jk scroll · o open · ${configuredKeys(this.keybindings, "tui.select.cancel")} back`
+            : `  ${configuredKeys(this.keybindings, "tui.select.up")}/${configuredKeys(this.keybindings, "tui.select.down")}/jk select · enter/v preview markdown · o open · r rescan · ${configuredKeys(this.keybindings, "tui.select.cancel")} close`,
         ),
         width,
       ),
     );
 
     return lines;
+  }
+
+  private previewChecklistLabel(): string {
+    if (!this.preview) return "preview";
+    const { completed, total, truncated } = this.preview.content;
+    if (total === 0) return truncated ? "preview · truncated" : "preview";
+    return truncated
+      ? `preview · checklist ${completed}/${total} partial · truncated`
+      : `preview · checklist ${completed}/${total}`;
+  }
+
+  private renderPreview(width: number, height: number): string[] {
+    if (!this.preview) return [];
+    const marker = this.preview.content.truncated
+      ? "\n\n[Preview truncated at 256 KiB; checklist counts are partial.]"
+      : "";
+    const source = stripTerminalSequences(`${this.preview.content.text}${marker}`)
+      .replace(/\r\n?/g, "\n")
+      .replace(/\t/g, "    ")
+      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
+    const wrapped = source
+      .split("\n")
+      .flatMap((line) => (line ? wrapTextWithAnsi(line, Math.max(1, width - 2)) : [""]));
+    const maxScroll = Math.max(0, wrapped.length - height);
+    this.preview.scroll = Math.min(this.preview.scroll, maxScroll);
+    return wrapped
+      .slice(this.preview.scroll, this.preview.scroll + height)
+      .map((line) => truncateToWidth(` ${line}`, width, ""));
   }
 
   private renderRows(
@@ -282,7 +426,11 @@ export class AgyArtifactsDashboard implements Component {
 
       const marker = isSelected ? theme.fg("accent", "❯") : " ";
       const glyph =
-        artifact.kind === "generated" ? theme.fg("success", "◆") : theme.fg("muted", "◇");
+        artifact.kind === "generated"
+          ? theme.fg("success", "◆")
+          : artifact.kind === "conversation"
+            ? theme.fg("accent", "◆")
+            : theme.fg("muted", "◇");
       const title = isSelected
         ? theme.fg("accent", oneLine(artifact.name))
         : theme.fg("text", oneLine(artifact.name));
@@ -292,7 +440,7 @@ export class AgyArtifactsDashboard implements Component {
       const rightParts = [
         theme.fg("muted", artifact.mediaType),
         theme.fg("muted", formatBytes(artifact.bytes)),
-        theme.fg("muted", artifact.kind === "generated" ? "generated" : "uploaded"),
+        theme.fg("muted", artifact.kind),
       ];
       const right = `${rightParts.join(dot)} `;
 

--- a/packages/pi-antigravity/src/provider.ts
+++ b/packages/pi-antigravity/src/provider.ts
@@ -28,6 +28,8 @@ import {
 } from "@earendil-works/pi-ai";
 import type { AgyEffort } from "../lib/agy-client.ts";
 import { type AgyPiBridge, resolveBridgeResultsFromContext } from "../lib/bridge.ts";
+import { resolveAgyModelEffort, type AgyModelInfo } from "../lib/models.ts";
+import { readAgyProcessProfile, type AgyProcessProfile } from "../lib/agy-profile.ts";
 import type { AgyActivity, AgyUsage } from "../lib/reducer.ts";
 import type { AgyReplayStore } from "../lib/replay.ts";
 import { mapAgyToolToNative } from "../lib/native-tools.ts";
@@ -233,6 +235,12 @@ export function streamAntigravity(
   onActivity?: (activity: AgyActivity) => void,
   /** Test seam for disposable compaction/branch-summary conversations. */
   createIsolatedRuntime: () => AntigravityRuntimeInstance = createAntigravityRuntime,
+  /** Current discovery metadata used to resolve a valid required effort. */
+  getModelInfo: (modelId: string) => AgyModelInfo | undefined = () => undefined,
+  /** Validated process profile; read per turn so env changes recycle safely. */
+  getProcessProfile: () => AgyProcessProfile = readAgyProcessProfile,
+  /** Combined bridge registration/catalog revision. */
+  getBridgeRevision: () => string | undefined = () => undefined,
 ) {
   return (
     model: Model<string>,
@@ -309,23 +317,33 @@ export function streamAntigravity(
           );
         }
 
+        let bridgeRevision: string | undefined;
+        let processProfile: AgyProcessProfile = {};
+        if (!summaryRequest) {
+          // Refresh and resolve before the driver fingerprint is evaluated.
+          // Re-entry into a pending bridge turn returns the existing controller,
+          // so a changed revision is deferred safely to the next user turn.
+          bridge.refreshTools();
+          resolveBridgeResultsFromContext(bridge, context.messages);
+          bridgeRevision = getBridgeRevision();
+          processProfile = getProcessProfile();
+        }
+        const requestedEffort = mapThinkingToEffort(options?.reasoning);
+        const effort = resolveAgyModelEffort(getModelInfo(model.id), requestedEffort);
+
         const controller = await turnRuntime.runPromise(
           turnService.beginStreamTurn({
             prompt,
             historyBootstrap: summaryRequest ? undefined : piHistoryBootstrap(context),
             bootstrapSuffix: summaryRequest ? undefined : getBootstrapSuffix?.(),
             modelId: model.id,
-            effort: mapThinkingToEffort(options?.reasoning),
+            effort,
+            agent: processProfile.agent,
+            mode: processProfile.mode,
+            bridgeRevision,
             signal: options?.signal,
           }),
         );
-
-        if (!summaryRequest) {
-          // Refresh the exposed-tool snapshot per request and hand back the
-          // results of bridged tools pi executed since the previous request.
-          bridge.refreshTools();
-          resolveBridgeResultsFromContext(bridge, context.messages);
-        }
 
         let usage: AgyUsage | undefined;
         let textIndex: number | null = null;

--- a/packages/pi-antigravity/src/runtime.ts
+++ b/packages/pi-antigravity/src/runtime.ts
@@ -9,12 +9,14 @@
  */
 
 import { Context, Data, Effect, Layer, ManagedRuntime, Exit, Cause, Result } from "effect";
+import { AgySpawnError, AgyStallError, type AgyTurnRequest } from "../lib/agy-client.ts";
 import {
-  AgySpawnError,
-  AgyStallError,
-  runAgyTurn,
-  type AgyTurnRequest,
-} from "../lib/agy-client.ts";
+  createAgyTurnExecutor,
+  type AgyExecutorSnapshot,
+  type AgyRecycleCause,
+  type AgyTurnExecutor,
+} from "../lib/agy-driver.ts";
+import type { AgyExecutionMode } from "../lib/agy-profile.ts";
 import type { AgyTurnOutcome, AgyUsage } from "../lib/reducer.ts";
 import { stallContinuationPrompt } from "../lib/prompt.ts";
 import { AgyTurnController } from "../lib/turn.ts";
@@ -84,6 +86,7 @@ export interface AntigravityStateSnapshot {
   cwd: string | undefined;
   turns: number;
   conversationUsage: AgyUsage;
+  executor: AgyExecutorSnapshot;
 }
 
 export interface AntigravityRuntimeShape {
@@ -115,6 +118,9 @@ export interface AntigravityRuntimeShape {
     readonly bootstrapSuffix?: string;
     readonly modelId: string;
     readonly effort?: "low" | "medium" | "high";
+    readonly agent?: string;
+    readonly mode?: AgyExecutionMode;
+    readonly bridgeRevision?: string;
     readonly signal?: AbortSignal;
   }) => Effect.Effect<AgyTurnController, AntigravityRuntimeClosedError>;
   /** Clear the active controller once a provider turn reached a terminal state. */
@@ -141,7 +147,15 @@ export class AntigravityRuntime extends Context.Service<
 
 export type AgyTurnRunner = (request: AgyTurnRequest) => Promise<AgyTurnOutcome>;
 
-const makeRuntime = (turnRunner: AgyTurnRunner) =>
+function runnerExecutor(turnRunner: AgyTurnRunner): AgyTurnExecutor {
+  return {
+    run: turnRunner,
+    snapshot: () => ({ mode: "one-shot", state: "idle", lifecycle: [] }),
+    close: async () => {},
+  };
+}
+
+const makeRuntime = (executor: AgyTurnExecutor) =>
   Effect.gen(function* () {
     let conversationId: string | undefined;
     /** Terminal usage counters from the last turn; agy reports them cumulatively on resume. */
@@ -169,6 +183,14 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
       active = undefined;
     };
 
+    const recycle = async (
+      reason: "recycle" | "abort" | "shutdown" = "recycle",
+      cause?: AgyRecycleCause,
+    ) => {
+      invalidateActiveTurn();
+      await executor.close(reason, cause);
+    };
+
     const ensureOpen: Effect.Effect<void, AntigravityRuntimeClosedError> = Effect.suspend(() =>
       closed
         ? Effect.fail(
@@ -183,11 +205,19 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
       setSession: (sessionCwd, modelId, restoreFromPiContext = false) =>
         ensureOpen.pipe(
           Effect.andThen(
-            Effect.sync(() => {
+            Effect.promise(async () => {
+              const cwdChanged = cwd !== sessionCwd;
+              const modelChanged =
+                modelId !== undefined && model !== undefined && model !== modelId;
               cwd = sessionCwd;
               if (modelId !== undefined) model = modelId;
+              if (restoreFromPiContext || cwdChanged || modelChanged) {
+                await recycle(
+                  "recycle",
+                  restoreFromPiContext ? "session-tree" : cwdChanged ? "cwd" : "model",
+                );
+              }
               if (restoreFromPiContext) {
-                invalidateActiveTurn();
                 conversationId = undefined;
                 conversationUsage = {};
                 conversationCwd = undefined;
@@ -203,8 +233,8 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
       restoreConversation: (state) =>
         ensureOpen.pipe(
           Effect.andThen(
-            Effect.sync(() => {
-              invalidateActiveTurn();
+            Effect.promise(async () => {
+              await recycle("recycle", "restore");
               conversationId = state.conversationId;
               conversationUsage = { ...state.usage };
               conversationCwd = state.cwd;
@@ -259,10 +289,13 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
               const turnAbort = new AbortController();
               activeTurnAbort = turnAbort;
               const turnGeneration = generation;
+              let requestAbortHandler: (() => void) | undefined;
               if (request.signal) {
                 if (request.signal.aborted) turnAbort.abort();
-                else
-                  request.signal.addEventListener("abort", () => turnAbort.abort(), { once: true });
+                else {
+                  requestAbortHandler = () => turnAbort.abort();
+                  request.signal.addEventListener("abort", requestAbortHandler, { once: true });
+                }
               }
               const resumingPersistedConversation =
                 restoredConversationPending && conversationId !== undefined;
@@ -293,6 +326,9 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
                 conversationId,
                 model: request.modelId,
                 effort: request.effort,
+                agent: request.agent,
+                mode: request.mode,
+                bridgeRevision: request.bridgeRevision,
                 cwd,
                 timeoutMs: envInt("AGY_TURN_TIMEOUT_MS", 600_000),
                 inactivityTimeoutMs: envInt("AGY_STALL_TIMEOUT_MS", 120_000),
@@ -358,7 +394,7 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
                             conversationId: resumableConversationId,
                           };
                   try {
-                    const outcome = await turnRunner(attempt);
+                    const outcome = await executor.run(attempt);
                     if (resumingPersistedConversation && !freshFallback && restoredResultMissing) {
                       restoredAttemptActive = false;
                       controller.push({ type: "conversation_fallback" });
@@ -427,6 +463,12 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
                     return;
                   }
                   controller.fail(cause instanceof Error ? cause : new Error(String(cause)));
+                })
+                .finally(() => {
+                  if (requestAbortHandler) {
+                    request.signal?.removeEventListener("abort", requestAbortHandler);
+                  }
+                  if (activeTurnAbort === turnAbort) activeTurnAbort = undefined;
                 });
               return controller;
             }),
@@ -445,8 +487,8 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
 
       reset: ensureOpen.pipe(
         Effect.andThen(
-          Effect.sync(() => {
-            invalidateActiveTurn();
+          Effect.promise(async () => {
+            await recycle("recycle", "reset");
             conversationId = undefined;
             conversationUsage = {};
             conversationCwd = undefined;
@@ -466,6 +508,7 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
             cwd,
             turns,
             conversationUsage: { ...conversationUsage },
+            executor: executor.snapshot(),
           })),
         ),
       ),
@@ -473,15 +516,14 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
       close: Effect.suspend(() =>
         ensureOpen.pipe(
           Effect.andThen(
-            Effect.sync(() => {
+            Effect.promise(async () => {
               closed = true;
               conversationId = undefined;
               conversationUsage = {};
               conversationCwd = undefined;
               restoredConversationPending = false;
               lastBootstrappedSkillsSuffix = undefined;
-              // Kill any in-flight agy child process immediately.
-              invalidateActiveTurn();
+              await recycle("shutdown");
             }),
           ),
         ),
@@ -489,13 +531,19 @@ const makeRuntime = (turnRunner: AgyTurnRunner) =>
     });
   });
 
-const runtimeLayer = (turnRunner: AgyTurnRunner): Layer.Layer<AntigravityRuntime> =>
-  Layer.effect(AntigravityRuntime, makeRuntime(turnRunner));
+const runtimeLayer = (executor: AgyTurnExecutor): Layer.Layer<AntigravityRuntime> =>
+  Layer.effect(AntigravityRuntime, makeRuntime(executor));
 
-export const AntigravityRuntimeLive: Layer.Layer<AntigravityRuntime> = runtimeLayer(runAgyTurn);
+export const AntigravityRuntimeLive: Layer.Layer<AntigravityRuntime> = runtimeLayer(
+  createAgyTurnExecutor(),
+);
 
-export function createAntigravityRuntime(turnRunner: AgyTurnRunner = runAgyTurn) {
-  return ManagedRuntime.make(runtimeLayer(turnRunner));
+export function createAntigravityRuntime(
+  executorOrRunner: AgyTurnExecutor | AgyTurnRunner = createAgyTurnExecutor(),
+) {
+  const executor =
+    typeof executorOrRunner === "function" ? runnerExecutor(executorOrRunner) : executorOrRunner;
+  return ManagedRuntime.make(runtimeLayer(executor));
 }
 
 export type AntigravityRuntimeInstance = ReturnType<typeof createAntigravityRuntime>;

--- a/packages/pi-antigravity/test/agy-client.test.ts
+++ b/packages/pi-antigravity/test/agy-client.test.ts
@@ -67,12 +67,16 @@ test("buildAgyArgs always skips permissions and puts the prompt directly after -
     effort: "medium",
     cwd: "/tmp/w",
     timeoutMs: 90_000,
+    agent: "reviewer",
+    mode: "plan",
   });
   assert.equal(full[full.indexOf("--conversation") + 1], "c1");
   assert.equal(full[full.indexOf("--model") + 1], "m1");
   assert.equal(full[full.indexOf("--effort") + 1], "medium");
   assert.equal(full[full.indexOf("--add-dir") + 1], "/tmp/w");
   assert.equal(full[full.indexOf("--print-timeout") + 1], "90s");
+  assert.equal(full[full.indexOf("--agent") + 1], "reviewer");
+  assert.equal(full[full.indexOf("--mode") + 1], "plan");
 });
 
 test("runAgyTurn reduces a successful stream", async () => {

--- a/packages/pi-antigravity/test/agy-diagnostics.test.ts
+++ b/packages/pi-antigravity/test/agy-diagnostics.test.ts
@@ -81,7 +81,10 @@ test("explicit AGY_BINARY is strict and PATH then managed fallback are ordered",
       return command;
     },
   });
-  assert.deepEqual(calls, ["agy", "/home/test/.gemini/bin/agy"]);
+  assert.deepEqual(calls, [
+    "agy",
+    path.join("/home/test", ".gemini", "bin", process.platform === "win32" ? "agy.exe" : "agy"),
+  ]);
   assert.equal(fallback.candidates[0]?.source, "managed");
 
   const windows = await resolveAgyBinary({

--- a/packages/pi-antigravity/test/agy-diagnostics.test.ts
+++ b/packages/pi-antigravity/test/agy-diagnostics.test.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { test } from "node:test";
+import {
+  checkAgyBinary,
+  extractAgyVersion,
+  resetAgyBinaryCache,
+  resolveAgyBinary,
+  runAgyCommand,
+} from "../lib/agy-diagnostics.ts";
+
+interface FakeProcessOptions {
+  stdout?: string;
+  stderr?: string;
+  code?: number;
+  error?: NodeJS.ErrnoException;
+  hang?: boolean;
+}
+
+function fakeSpawn(options: FakeProcessOptions) {
+  return (() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+      pid?: number;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    queueMicrotask(() => {
+      if (options.error) {
+        child.emit("error", options.error);
+        return;
+      }
+      if (options.hang) return;
+      if (options.stdout) child.stdout.write(options.stdout);
+      if (options.stderr) child.stderr.write(options.stderr);
+      child.emit("close", options.code ?? 0);
+    });
+    return child;
+  }) as never;
+}
+
+const found = async (command: string) => `/resolved/${command.replaceAll("/", "_")}`;
+
+test("extractAgyVersion recognizes stdout, stderr, dev, and HEAD", () => {
+  assert.deepEqual(extractAgyVersion("1.1.22\n"), { version: "1.1.22", development: false });
+  assert.deepEqual(extractAgyVersion("", "agy v1.4.0\n"), {
+    version: "1.4.0",
+    development: false,
+  });
+  assert.deepEqual(extractAgyVersion("agy dev build"), { version: "dev", development: true });
+  assert.deepEqual(extractAgyVersion("agy HEAD"), { version: "HEAD", development: true });
+  assert.equal(extractAgyVersion("version unknown"), undefined);
+});
+
+test("explicit AGY_BINARY is strict and PATH then managed fallback are ordered", async () => {
+  const explicitCalls: string[] = [];
+  const explicit = await resolveAgyBinary({
+    env: { AGY_BINARY: "/custom/agy", PATH: "/bin" },
+    whichOverride: async (command) => {
+      explicitCalls.push(command);
+      throw new Error("missing");
+    },
+  });
+  assert.equal(explicit.strict, true);
+  assert.deepEqual(explicit.candidates, []);
+  assert.deepEqual(explicitCalls, ["/custom/agy"]);
+
+  const calls: string[] = [];
+  const fallback = await resolveAgyBinary({
+    env: { PATH: "/bin" },
+    homeDir: "/home/test",
+    whichOverride: async (command) => {
+      calls.push(command);
+      if (command === "agy") throw new Error("missing");
+      return command;
+    },
+  });
+  assert.deepEqual(calls, ["agy", "/home/test/.gemini/bin/agy"]);
+  assert.equal(fallback.candidates[0]?.source, "managed");
+
+  const windows = await resolveAgyBinary({
+    env: { PATH: "C:\\bin" },
+    homeDir: "C:\\Users\\test",
+    platform: "win32",
+    whichOverride: async (command) => command,
+  });
+  assert.ok(windows.candidates.some((candidate) => candidate.configured.endsWith("agy.exe")));
+});
+
+test("checkAgyBinary accepts the minimum, newer, and development builds", async () => {
+  for (const output of ["1.1.22", "1.9.0", "agy dev", "agy HEAD"]) {
+    resetAgyBinaryCache();
+    const checked = await checkAgyBinary({
+      env: { AGY_BINARY: "/fake/agy" },
+      whichOverride: found,
+      spawnOverride: fakeSpawn({ stdout: output }),
+    });
+    assert.equal(checked.ok, true, output);
+  }
+});
+
+test("checkAgyBinary categorizes unsupported, malformed, spawn, permission, and timeout failures", async () => {
+  const cases: Array<{
+    expected: string;
+    spawn: ReturnType<typeof fakeSpawn>;
+    timeoutMs?: number;
+  }> = [
+    { expected: "unsupported-version", spawn: fakeSpawn({ stdout: "1.1.21" }) },
+    { expected: "invalid-version", spawn: fakeSpawn({ stdout: "banana" }) },
+    { expected: "spawn-failed", spawn: fakeSpawn({ code: 2, stderr: "bad" }) },
+    {
+      expected: "permission-denied",
+      spawn: fakeSpawn({ error: Object.assign(new Error("denied"), { code: "EACCES" }) }),
+    },
+    {
+      expected: "not-found",
+      spawn: fakeSpawn({ error: Object.assign(new Error("gone"), { code: "ENOENT" }) }),
+    },
+    { expected: "timeout", spawn: fakeSpawn({ hang: true }), timeoutMs: 5 },
+  ];
+  for (const entry of cases) {
+    resetAgyBinaryCache();
+    const checked = await checkAgyBinary({
+      env: { AGY_BINARY: "/fake/agy" },
+      whichOverride: found,
+      spawnOverride: entry.spawn,
+      timeoutMs: entry.timeoutMs,
+    });
+    assert.equal(checked.ok, false);
+    if (!checked.ok) assert.equal(checked.category, entry.expected);
+  }
+});
+
+test("automatic selection chooses the newest compatible stable candidate", async () => {
+  resetAgyBinaryCache();
+  const checked = await checkAgyBinary({
+    env: { PATH: "/bin" },
+    homeDir: "/home/test",
+    whichOverride: async (command) =>
+      command === "agy" ? "/path/agy" : "/home/test/.gemini/bin/agy",
+    spawnOverride: ((file: string) =>
+      (
+        fakeSpawn({ stdout: file === "/path/agy" ? "1.1.22" : "1.4.0" }) as () => unknown
+      )()) as never,
+  });
+  assert.equal(checked.ok, true);
+  if (!checked.ok) return;
+  assert.equal(checked.binary, "/home/test/.gemini/bin/agy");
+  assert.equal(checked.version, "1.4.0");
+  assert.match(checked.selectionReason ?? "", /highest compatible stable/);
+  assert.deepEqual(
+    checked.candidates?.map(({ source, version, ok }) => ({ source, version, ok })),
+    [
+      { source: "path", version: "1.1.22", ok: true },
+      { source: "managed", version: "1.4.0", ok: true },
+    ],
+  );
+});
+
+test("automatic selection prefers stable over a newer prerelease", async () => {
+  resetAgyBinaryCache();
+  const checked = await checkAgyBinary({
+    env: { PATH: "/bin" },
+    homeDir: "/home/test",
+    whichOverride: async (command) =>
+      command === "agy" ? "/path/agy" : "/home/test/.gemini/bin/agy",
+    spawnOverride: ((file: string) =>
+      (
+        fakeSpawn({ stdout: file === "/path/agy" ? "1.4.0" : "2.0.0-beta.1" }) as () => unknown
+      )()) as never,
+  });
+  assert.equal(checked.ok && checked.binary, "/path/agy");
+  assert.match((checked.ok && checked.selectionReason) || "", /stable/);
+});
+
+test("automatic selection bypasses an incompatible PATH binary", async () => {
+  resetAgyBinaryCache();
+  const checked = await checkAgyBinary({
+    env: { PATH: "/bin" },
+    homeDir: "/home/test",
+    whichOverride: async (command) =>
+      command === "agy" ? "/path/agy" : "/home/test/.gemini/bin/agy",
+    spawnOverride: ((file: string) =>
+      (
+        fakeSpawn({ stdout: file === "/path/agy" ? "1.1.21" : "1.2.0" }) as () => unknown
+      )()) as never,
+  });
+  assert.equal(checked.ok && checked.binary, "/home/test/.gemini/bin/agy");
+  assert.equal(checked.candidates?.[0]?.category, "unsupported-version");
+});
+
+test("automatic selection prefers a compatible stable build over development", async () => {
+  resetAgyBinaryCache();
+  const checked = await checkAgyBinary({
+    env: { PATH: "/bin" },
+    homeDir: "/home/test",
+    whichOverride: async (command) =>
+      command === "agy" ? "/path/agy" : "/home/test/.gemini/bin/agy",
+    spawnOverride: ((file: string) =>
+      (
+        fakeSpawn({ stdout: file === "/path/agy" ? "agy HEAD" : "1.2.0" }) as () => unknown
+      )()) as never,
+  });
+  assert.equal(checked.ok && checked.binary, "/home/test/.gemini/bin/agy");
+});
+
+test("auxiliary commands use the exact preflight-selected binary", async () => {
+  resetAgyBinaryCache();
+  const checked = await checkAgyBinary({
+    env: { AGY_BINARY: "/configured/agy" },
+    whichOverride: async () => "/selected/agy",
+    spawnOverride: fakeSpawn({ stdout: "1.1.22" }),
+  });
+  assert.equal(checked.ok, true);
+  if (!checked.ok) return;
+  let invoked = "";
+  await runAgyCommand(["models"], {
+    binary: checked.binary,
+    spawnOverride: ((file: string) => {
+      invoked = file;
+      const commandSpawn = fakeSpawn({ stdout: "model\tModel\n" }) as unknown as () => unknown;
+      return commandSpawn();
+    }) as never,
+  });
+  assert.equal(invoked, "/selected/agy");
+});
+
+test("candidate file changes invalidate a cached compatibility result", async () => {
+  resetAgyBinaryCache();
+  let signature = 1;
+  let version = "1.1.22";
+  let spawns = 0;
+  const options = {
+    env: { AGY_BINARY: "/fake/agy" },
+    whichOverride: found,
+    statOverride: async () => ({ mtimeMs: signature, ctimeMs: signature, size: signature }),
+    spawnOverride: (() => {
+      spawns += 1;
+      return (fakeSpawn({ stdout: version }) as unknown as () => unknown)();
+    }) as never,
+  };
+  const first = await checkAgyBinary(options);
+  version = "1.2.0";
+  const cached = await checkAgyBinary(options);
+  signature += 1;
+  const refreshed = await checkAgyBinary(options);
+  assert.equal(first.ok && first.version, "1.1.22");
+  assert.equal(cached.ok && cached.version, "1.1.22");
+  assert.equal(refreshed.ok && refreshed.version, "1.2.0");
+  assert.equal(first.ok && cached.ok && first.revision, cached.ok && cached.revision);
+  assert.notEqual(first.ok && first.revision, refreshed.ok && refreshed.revision);
+  assert.equal(spawns, 2);
+});
+
+test("forced refresh drops a stale success and cache keys follow binary configuration", async () => {
+  resetAgyBinaryCache();
+  const env = { AGY_BINARY: "/fake/agy" };
+  const first = await checkAgyBinary({
+    env,
+    whichOverride: found,
+    spawnOverride: fakeSpawn({ stdout: "1.1.22" }),
+  });
+  assert.equal(first.ok && first.version, "1.1.22");
+
+  const failed = await checkAgyBinary({
+    env,
+    refresh: true,
+    whichOverride: found,
+    spawnOverride: fakeSpawn({ code: 2 }),
+  });
+  assert.equal(failed.ok, false);
+  const retried = await checkAgyBinary({
+    env,
+    whichOverride: found,
+    spawnOverride: fakeSpawn({ stdout: "1.2.0" }),
+  });
+  assert.equal(retried.ok && retried.version, "1.2.0");
+});
+
+test("checkAgyBinary bounds diagnostics and never invokes an installer", async () => {
+  resetAgyBinaryCache();
+  const checked = await checkAgyBinary({
+    env: { AGY_BINARY: "/fake/agy" },
+    whichOverride: found,
+    spawnOverride: fakeSpawn({ stderr: `1.1.22\n${"x".repeat(20_000)}` }),
+  });
+  assert.equal(checked.ok, true);
+  assert.ok(checked.stderr.length <= 8_192);
+});

--- a/packages/pi-antigravity/test/agy-diagnostics.test.ts
+++ b/packages/pi-antigravity/test/agy-diagnostics.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import { test } from "node:test";
 import {
@@ -42,6 +43,9 @@ function fakeSpawn(options: FakeProcessOptions) {
 }
 
 const found = async (command: string) => `/resolved/${command.replaceAll("/", "_")}`;
+const pathBinary = path.resolve("/path/agy");
+const managedBinary = path.resolve("/home/test/.gemini/bin/agy");
+const selectedBinary = path.resolve("/selected/agy");
 
 test("extractAgyVersion recognizes stdout, stderr, dev, and HEAD", () => {
   assert.deepEqual(extractAgyVersion("1.1.22\n"), { version: "1.1.22", development: false });
@@ -142,12 +146,12 @@ test("automatic selection chooses the newest compatible stable candidate", async
       command === "agy" ? "/path/agy" : "/home/test/.gemini/bin/agy",
     spawnOverride: ((file: string) =>
       (
-        fakeSpawn({ stdout: file === "/path/agy" ? "1.1.22" : "1.4.0" }) as () => unknown
+        fakeSpawn({ stdout: file === pathBinary ? "1.1.22" : "1.4.0" }) as () => unknown
       )()) as never,
   });
   assert.equal(checked.ok, true);
   if (!checked.ok) return;
-  assert.equal(checked.binary, "/home/test/.gemini/bin/agy");
+  assert.equal(checked.binary, managedBinary);
   assert.equal(checked.version, "1.4.0");
   assert.match(checked.selectionReason ?? "", /highest compatible stable/);
   assert.deepEqual(
@@ -168,10 +172,10 @@ test("automatic selection prefers stable over a newer prerelease", async () => {
       command === "agy" ? "/path/agy" : "/home/test/.gemini/bin/agy",
     spawnOverride: ((file: string) =>
       (
-        fakeSpawn({ stdout: file === "/path/agy" ? "1.4.0" : "2.0.0-beta.1" }) as () => unknown
+        fakeSpawn({ stdout: file === pathBinary ? "1.4.0" : "2.0.0-beta.1" }) as () => unknown
       )()) as never,
   });
-  assert.equal(checked.ok && checked.binary, "/path/agy");
+  assert.equal(checked.ok && checked.binary, pathBinary);
   assert.match((checked.ok && checked.selectionReason) || "", /stable/);
 });
 
@@ -184,10 +188,10 @@ test("automatic selection bypasses an incompatible PATH binary", async () => {
       command === "agy" ? "/path/agy" : "/home/test/.gemini/bin/agy",
     spawnOverride: ((file: string) =>
       (
-        fakeSpawn({ stdout: file === "/path/agy" ? "1.1.21" : "1.2.0" }) as () => unknown
+        fakeSpawn({ stdout: file === pathBinary ? "1.1.21" : "1.2.0" }) as () => unknown
       )()) as never,
   });
-  assert.equal(checked.ok && checked.binary, "/home/test/.gemini/bin/agy");
+  assert.equal(checked.ok && checked.binary, managedBinary);
   assert.equal(checked.candidates?.[0]?.category, "unsupported-version");
 });
 
@@ -200,10 +204,10 @@ test("automatic selection prefers a compatible stable build over development", a
       command === "agy" ? "/path/agy" : "/home/test/.gemini/bin/agy",
     spawnOverride: ((file: string) =>
       (
-        fakeSpawn({ stdout: file === "/path/agy" ? "agy HEAD" : "1.2.0" }) as () => unknown
+        fakeSpawn({ stdout: file === pathBinary ? "agy HEAD" : "1.2.0" }) as () => unknown
       )()) as never,
   });
-  assert.equal(checked.ok && checked.binary, "/home/test/.gemini/bin/agy");
+  assert.equal(checked.ok && checked.binary, managedBinary);
 });
 
 test("auxiliary commands use the exact preflight-selected binary", async () => {
@@ -224,7 +228,7 @@ test("auxiliary commands use the exact preflight-selected binary", async () => {
       return commandSpawn();
     }) as never,
   });
-  assert.equal(invoked, "/selected/agy");
+  assert.equal(invoked, selectedBinary);
 });
 
 test("candidate file changes invalidate a cached compatibility result", async () => {

--- a/packages/pi-antigravity/test/agy-driver.test.ts
+++ b/packages/pi-antigravity/test/agy-driver.test.ts
@@ -1,0 +1,553 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { EventEmitter, getEventListeners } from "node:events";
+import { PassThrough } from "node:stream";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  AgySpawnError,
+  AgyStallError,
+  buildDriverAgyArgs,
+  type AgyTurnRequest,
+} from "../lib/agy-client.ts";
+import { AgyDriverSession, AgyOneShotExecutor } from "../lib/agy-driver.ts";
+
+async function driverFixture(): Promise<{ dir: string; script: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "agy-driver-"));
+  const script = path.join(dir, "driver.mjs");
+  await writeFile(
+    script,
+    `#!/usr/bin/env node
+import readline from "node:readline";
+const args = process.argv.slice(2);
+let turns = 0;
+const conversation = "driver-conversation";
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+rl.on("line", (line) => {
+  const event = JSON.parse(line);
+  turns += 1;
+  console.log(JSON.stringify({ event: "init", conversation_id: conversation, init: {} }));
+  if (event.message.content === "tool-silent") {
+    console.log(JSON.stringify({
+      event: "step_update",
+      step_update: {
+        conversation_id: conversation,
+        step_index: turns,
+        state: "ACTIVE",
+        step_type: "tool",
+        tool_name: "run_command",
+        tool_info: { name: "run_command", parameters: { CommandLine: "sleep 60" } }
+      }
+    }));
+    return;
+  }
+  if (event.message.content === "silent") return;
+  if (event.message.content === "exit-before-result") process.exit(7);
+  console.log(JSON.stringify({
+    event: "result",
+    conversation_id: conversation,
+    result: {
+      status: "SUCCESS",
+      response: JSON.stringify({ pid: process.pid, turns, args, event }),
+      conversation_id: conversation,
+      num_turns: turns
+    }
+  }));
+});
+`,
+  );
+  await chmod(script, 0o755);
+  return { dir, script };
+}
+
+function fixtureSpawn(script: string): typeof spawn {
+  return ((_binary: string, args: readonly string[], options: Parameters<typeof spawn>[2]) =>
+    spawn(process.execPath, [script, ...args], options)) as typeof spawn;
+}
+
+test("buildDriverAgyArgs uses stream input and omits print deadlines", () => {
+  const args = buildDriverAgyArgs({
+    conversationId: "c1",
+    model: "gemini-3.7-flash",
+    effort: "high",
+    cwd: "/repo",
+    timeoutMs: 5,
+    agent: "reviewer",
+    mode: "plan",
+    bridgeRevision: "3:7",
+  });
+  assert.equal(args[args.indexOf("--input-format") + 1], "stream-json");
+  assert.equal(args[args.indexOf("--output-format") + 1], "stream-json");
+  assert.equal(args[args.indexOf("--conversation") + 1], "c1");
+  assert.equal(args[args.indexOf("--effort") + 1], "high");
+  assert.equal(args[args.indexOf("--agent") + 1], "reviewer");
+  assert.equal(args[args.indexOf("--mode") + 1], "plan");
+  assert.ok(!args.includes("--print"));
+  assert.ok(!args.includes("--print-timeout"));
+  assert.ok(!args.includes("3:7"));
+});
+
+test("persistent driver handles fragmented CRLF and a final unterminated result", async () => {
+  const spawnOverride = (() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdin: PassThrough;
+      stdout: PassThrough;
+      stderr: PassThrough;
+      pid?: number;
+    };
+    child.stdin = new PassThrough();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.stdin.once("data", () => {
+      queueMicrotask(() => {
+        const init = JSON.stringify({ event: "init", conversation_id: "fragmented", init: {} });
+        const result = JSON.stringify({
+          event: "result",
+          conversation_id: "fragmented",
+          result: { status: "SUCCESS", response: "ok", conversation_id: "fragmented" },
+        });
+        child.stdout.write(`{not-json}\r\n${init.slice(0, 10)}`);
+        child.stdout.write(`${init.slice(10)}\r\n${result}`);
+        child.emit("close", 0, null);
+      });
+    });
+    return child;
+  }) as never;
+  const executor = new AgyDriverSession();
+  try {
+    const outcome = await executor.run({
+      prompt: "hello",
+      binary: "/fake/agy",
+      spawnOverride,
+      timeoutMs: 1_000,
+      inactivityTimeoutMs: 500,
+    });
+    assert.equal(outcome.status, "OK");
+    assert.equal(outcome.response, "ok");
+    assert.equal(outcome.conversationId, "fragmented");
+  } finally {
+    await executor.close("shutdown");
+  }
+});
+
+test("persistent driver honors stdin backpressure and removes abort listeners", async () => {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter & {
+      write: (line: string, callback: (error?: Error | null) => void) => boolean;
+      end: () => void;
+    };
+    stdout: PassThrough;
+    stderr: PassThrough;
+    pid?: number;
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  let written = "";
+  child.stdin = Object.assign(new EventEmitter(), {
+    write: (line: string, callback: (error?: Error | null) => void) => {
+      written += line;
+      queueMicrotask(() => {
+        callback();
+        child.stdin.emit("drain");
+        child.stdout.write(
+          `${JSON.stringify({ event: "init", conversation_id: "backpressure", init: {} })}\n${JSON.stringify(
+            {
+              event: "result",
+              conversation_id: "backpressure",
+              result: {
+                status: "SUCCESS",
+                response: "ok",
+                conversation_id: "backpressure",
+              },
+            },
+          )}\n`,
+        );
+      });
+      return false;
+    },
+    end: () => queueMicrotask(() => child.emit("close", 0, null)),
+  });
+  const signal = new AbortController();
+  const executor = new AgyDriverSession();
+  try {
+    const outcome = await executor.run({
+      prompt: "backpressured",
+      binary: "/fake/agy",
+      spawnOverride: (() => child) as never,
+      signal: signal.signal,
+    });
+    assert.equal(outcome.response, "ok");
+    assert.deepEqual(JSON.parse(written), {
+      event: "user",
+      message: { role: "user", content: "backpressured" },
+    });
+    assert.equal(getEventListeners(signal.signal, "abort").length, 0);
+  } finally {
+    await executor.close("shutdown");
+  }
+});
+
+test("persistent driver turns stdin callback errors into AgySpawnError", async () => {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter & {
+      write: (line: string, callback: (error?: Error | null) => void) => boolean;
+      end: () => void;
+    };
+    stdout: PassThrough;
+    stderr: PassThrough;
+    pid?: number;
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = Object.assign(new EventEmitter(), {
+    write: (_line: string, callback: (error?: Error | null) => void) => {
+      queueMicrotask(() => callback(Object.assign(new Error("broken pipe"), { code: "EPIPE" })));
+      return true;
+    },
+    end: () => {},
+  });
+  const executor = new AgyDriverSession();
+  try {
+    await assert.rejects(
+      () =>
+        executor.run({
+          prompt: "epipe",
+          binary: "/fake/agy",
+          spawnOverride: (() => child) as never,
+        }),
+      (error: unknown) => error instanceof AgySpawnError && /broken pipe/.test(error.message),
+    );
+  } finally {
+    await executor.close("shutdown");
+  }
+});
+
+test("persistent driver sends exact NDJSON and reuses one PID across idle time", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  const spawnOverride = fixtureSpawn(fixture.script);
+  try {
+    const first = await executor.run({
+      prompt: "first",
+      binary: fixture.script,
+      model: "gemini-3.7-flash",
+      effort: "high",
+      cwd: fixture.dir,
+      inactivityTimeoutMs: 1_000,
+      spawnOverride,
+    });
+    const firstResponse = JSON.parse(first.response) as {
+      pid: number;
+      turns: number;
+      args: string[];
+      event: unknown;
+    };
+    assert.deepEqual(firstResponse.event, {
+      event: "user",
+      message: { role: "user", content: "first" },
+    });
+    assert.ok(!firstResponse.args.includes("--print"));
+    assert.ok(!firstResponse.args.includes("--print-timeout"));
+    assert.equal(executor.snapshot().state, "ready");
+
+    // No watchdog is armed while the process is idle.
+    await new Promise<void>((resolve) => setTimeout(resolve, 1_100));
+    const second = await executor.run({
+      prompt: "second",
+      conversationId: first.conversationId,
+      binary: fixture.script,
+      model: "gemini-3.7-flash",
+      effort: "high",
+      cwd: fixture.dir,
+      inactivityTimeoutMs: 1_000,
+      spawnOverride,
+    });
+    const secondResponse = JSON.parse(second.response) as { pid: number; turns: number };
+    assert.equal(secondResponse.pid, firstResponse.pid);
+    assert.equal(secondResponse.turns, 2);
+    const snapshot = executor.snapshot();
+    assert.equal(snapshot.pid, firstResponse.pid);
+    assert.deepEqual(snapshot.stats, {
+      spawnCount: 1,
+      submittedTurns: 2,
+      reusedTurns: 1,
+      recycleCount: 0,
+      currentProcessTurns: 2,
+      recycleReasons: {},
+      lastRecycleReason: undefined,
+    });
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver recycles on process fingerprint changes and resumes the conversation", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  const spawnOverride = fixtureSpawn(fixture.script);
+  try {
+    const first = await executor.run({
+      prompt: "first",
+      binary: fixture.script,
+      model: "gemini-3.7-flash",
+      effort: "high",
+      cwd: fixture.dir,
+      bridgeRevision: "1:1",
+      spawnOverride,
+    });
+    const firstResponse = JSON.parse(first.response) as { pid: number };
+    const second = await executor.run({
+      prompt: "second",
+      conversationId: first.conversationId,
+      binary: fixture.script,
+      model: "gemini-3.7-flash",
+      effort: "low",
+      cwd: fixture.dir,
+      bridgeRevision: "1:2",
+      spawnOverride,
+    });
+    const secondResponse = JSON.parse(second.response) as { pid: number; args: string[] };
+    assert.notEqual(secondResponse.pid, firstResponse.pid);
+    assert.equal(
+      secondResponse.args[secondResponse.args.indexOf("--conversation") + 1],
+      first.conversationId,
+    );
+    assert.equal(secondResponse.args[secondResponse.args.indexOf("--effort") + 1], "low");
+    const snapshot = executor.snapshot();
+    assert.equal(snapshot.stats?.spawnCount, 2);
+    assert.equal(snapshot.stats?.recycleCount, 1);
+    assert.equal(snapshot.stats?.lastRecycleReason, "effort");
+    assert.deepEqual(snapshot.stats?.recycleReasons, { effort: 1 });
+    assert.ok(snapshot.lifecycle.some((entry) => entry.endsWith("close:recycle:effort")));
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver identifies every process reuse mismatch", async () => {
+  const fixture = await driverFixture();
+  const spawnOverride = fixtureSpawn(fixture.script);
+  const cases: Array<{
+    cause: string;
+    first?: Partial<AgyTurnRequest>;
+    second: Partial<AgyTurnRequest>;
+  }> = [
+    { cause: "binary", first: { binary: "/fake/agy-v1" }, second: { binary: "/fake/agy-v2" } },
+    { cause: "cwd", second: { cwd: tmpdir() } },
+    { cause: "model", first: { model: "model-a" }, second: { model: "model-b" } },
+    { cause: "effort", first: { effort: "high" }, second: { effort: "low" } },
+    { cause: "agent", first: { agent: "reviewer" }, second: { agent: "planner" } },
+    { cause: "mode", first: { mode: "plan" }, second: { mode: "accept-edits" } },
+    {
+      cause: "bridge-catalog",
+      first: { bridgeRevision: "1:1" },
+      second: { bridgeRevision: "1:2" },
+    },
+    { cause: "conversation", second: { conversationId: "another-conversation" } },
+    { cause: "conversation-reset", second: { conversationId: undefined } },
+  ];
+  try {
+    for (const entry of cases) {
+      const executor = new AgyDriverSession();
+      const base: AgyTurnRequest = {
+        prompt: "first",
+        conversationId: "driver-conversation",
+        binary: fixture.script,
+        cwd: fixture.dir,
+        spawnOverride,
+      };
+      try {
+        await executor.run({ ...base, ...entry.first });
+        await executor.run({ ...base, prompt: "second", ...entry.second });
+        const stats = executor.snapshot().stats;
+        assert.equal(stats?.recycleCount, 1, entry.cause);
+        assert.equal(stats?.lastRecycleReason, entry.cause);
+        assert.deepEqual(stats?.recycleReasons, { [entry.cause]: 1 });
+      } finally {
+        await executor.close("shutdown");
+      }
+    }
+  } finally {
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver kills a silent active process with AgyStallError", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  try {
+    await assert.rejects(
+      () =>
+        executor.run({
+          prompt: "silent",
+          binary: fixture.script,
+          cwd: fixture.dir,
+          inactivityTimeoutMs: 30,
+          timeoutMs: 5_000,
+          spawnOverride: fixtureSpawn(fixture.script),
+        }),
+      (error: unknown) => error instanceof AgyStallError,
+    );
+    assert.equal(executor.snapshot().state, "dead");
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver enforces the Pi-owned overall turn timeout", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  try {
+    await assert.rejects(
+      () =>
+        executor.run({
+          prompt: "silent",
+          binary: fixture.script,
+          cwd: fixture.dir,
+          inactivityTimeoutMs: 0,
+          timeoutMs: 60,
+          spawnOverride: fixtureSpawn(fixture.script),
+        }),
+      (error: unknown) => error instanceof AgySpawnError && /timed out/.test(error.message),
+    );
+    const snapshot = executor.snapshot();
+    assert.equal(snapshot.state, "dead");
+    assert.equal(snapshot.stats?.currentProcessTurns, 0);
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver uses the longer watchdog budget for an active tool", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  try {
+    await assert.rejects(
+      () =>
+        executor.run({
+          prompt: "tool-silent",
+          binary: fixture.script,
+          cwd: fixture.dir,
+          inactivityTimeoutMs: 500,
+          toolInactivityTimeoutMs: 70,
+          timeoutMs: 2_000,
+          spawnOverride: fixtureSpawn(fixture.script),
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof AgyStallError);
+        assert.equal(error.stalledMs, 70);
+        assert.equal(error.toolActive, true);
+        return true;
+      },
+    );
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver aborts an active turn and removes its signal listener", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  const abort = new AbortController();
+  try {
+    const pending = executor.run({
+      prompt: "silent",
+      binary: fixture.script,
+      cwd: fixture.dir,
+      signal: abort.signal,
+      inactivityTimeoutMs: 0,
+      timeoutMs: 5_000,
+      spawnOverride: fixtureSpawn(fixture.script),
+    });
+    setTimeout(() => abort.abort(), 30);
+    const outcome = await pending;
+    assert.equal(outcome.status, "ERROR");
+    assert.match(outcome.error ?? "", /aborted/);
+    assert.equal(getEventListeners(abort.signal, "abort").length, 0);
+    assert.equal(executor.snapshot().state, "dead");
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver serializes concurrent submissions on one process", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  const spawnOverride = fixtureSpawn(fixture.script);
+  try {
+    const request = {
+      conversationId: "driver-conversation",
+      binary: fixture.script,
+      cwd: fixture.dir,
+      model: "gemini-3.7-flash",
+      effort: "high",
+      spawnOverride,
+    } as const;
+    const [first, second] = await Promise.all([
+      executor.run({ ...request, prompt: "first concurrent" }),
+      executor.run({ ...request, prompt: "second concurrent" }),
+    ]);
+    const firstResponse = JSON.parse(first.response) as { pid: number; turns: number };
+    const secondResponse = JSON.parse(second.response) as { pid: number; turns: number };
+    assert.equal(firstResponse.pid, secondResponse.pid);
+    assert.deepEqual([firstResponse.turns, secondResponse.turns], [1, 2]);
+    assert.equal(executor.snapshot().stats?.reusedTurns, 1);
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver reports a child close before its terminal result", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  try {
+    await assert.rejects(
+      () =>
+        executor.run({
+          prompt: "exit-before-result",
+          binary: fixture.script,
+          cwd: fixture.dir,
+          spawnOverride: fixtureSpawn(fixture.script),
+        }),
+      (error: unknown) =>
+        error instanceof AgySpawnError &&
+        /exited with code 7 before producing a result/.test(error.message),
+    );
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver wraps synchronous spawn failures and marks itself dead", async () => {
+  const executor = new AgyDriverSession();
+  await assert.rejects(
+    () =>
+      executor.run({
+        prompt: "hello",
+        binary: "/fake/agy",
+        spawnOverride: (() => {
+          throw new Error("spawn exploded");
+        }) as never,
+      }),
+    (error: unknown) => error instanceof AgySpawnError && /spawn exploded/.test(error.message),
+  );
+  assert.equal(executor.snapshot().state, "dead");
+  await executor.close("shutdown");
+});
+
+test("one-shot executor exposes rollback mode and abortable close", async () => {
+  const executor = new AgyOneShotExecutor();
+  assert.equal(executor.snapshot().mode, "one-shot");
+  await executor.close("shutdown");
+  assert.equal(executor.snapshot().state, "dead");
+});

--- a/packages/pi-antigravity/test/agy-profile.test.ts
+++ b/packages/pi-antigravity/test/agy-profile.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseAgyAgents, readAgyProcessProfile } from "../lib/agy-profile.ts";
+
+test("readAgyProcessProfile validates agent and execution mode", () => {
+  assert.deepEqual(
+    readAgyProcessProfile({
+      PI_ANTIGRAVITY_AGENT: " reviewer ",
+      PI_ANTIGRAVITY_MODE: "plan",
+    }),
+    { agent: "reviewer", mode: "plan" },
+  );
+  assert.deepEqual(readAgyProcessProfile({}), {});
+  assert.throws(
+    () => readAgyProcessProfile({ PI_ANTIGRAVITY_MODE: "danger" }),
+    /plan.*accept-edits/,
+  );
+  assert.throws(() => readAgyProcessProfile({ PI_ANTIGRAVITY_AGENT: "  " }), /must not be empty/);
+  assert.throws(() => readAgyProcessProfile({ PI_ANTIGRAVITY_AGENT: "bad\0name" }), /NUL/);
+  assert.throws(
+    () => readAgyProcessProfile({ PI_ANTIGRAVITY_AGENT: "bad\nname" }),
+    /control characters/,
+  );
+});
+
+test("parseAgyAgents tolerates empty, tabular, and bullet output", () => {
+  assert.deepEqual(parseAgyAgents(""), []);
+  assert.deepEqual(
+    parseAgyAgents("Available agents:\nreviewer  Reviews code\n- planner\nreviewer\tduplicate"),
+    ["reviewer", "planner"],
+  );
+});

--- a/packages/pi-antigravity/test/artifacts-ui.test.ts
+++ b/packages/pi-antigravity/test/artifacts-ui.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { AgyArtifact } from "../lib/artifacts.ts";
+import { AgyArtifactsDashboard, readMarkdownPreview } from "../src/artifacts-ui.ts";
+
+async function temporaryFile(
+  name: string,
+  content: string | Buffer,
+): Promise<{ dir: string; file: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "agy-preview-"));
+  const file = path.join(dir, name);
+  await writeFile(file, content);
+  return { dir, file };
+}
+
+test("readMarkdownPreview reports exact checklist counts for complete UTF-8", async () => {
+  const { dir, file } = await temporaryFile(
+    "plan.md",
+    "# Plan\n- [x] one\n- [X] two\n- [ ] three\n",
+  );
+  try {
+    const preview = await readMarkdownPreview(file);
+    assert.equal(preview.truncated, false);
+    assert.equal(preview.completed, 2);
+    assert.equal(preview.total, 3);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("readMarkdownPreview bounds reads and rejects invalid UTF-8", async () => {
+  const large = await temporaryFile("large.md", `- [x] one\n${"x".repeat(100)}`);
+  const splitCodePoint = await temporaryFile("unicode.md", "a🙂b");
+  const invalid = await temporaryFile("invalid.md", Buffer.from([0xc3, 0x28]));
+  try {
+    const preview = await readMarkdownPreview(large.file, 16);
+    assert.equal(preview.truncated, true);
+    assert.equal(preview.completed, 1);
+    const unicode = await readMarkdownPreview(splitCodePoint.file, 3);
+    assert.equal(unicode.truncated, true);
+    assert.equal(unicode.text, "a");
+    await assert.rejects(() => readMarkdownPreview(invalid.file), /encoded data|encoding/i);
+  } finally {
+    await rm(large.dir, { recursive: true, force: true });
+    await rm(splitCodePoint.dir, { recursive: true, force: true });
+    await rm(invalid.dir, { recursive: true, force: true });
+  }
+});
+
+test("artifact dashboard list and markdown preview remain width-safe", async () => {
+  const { dir, file } = await temporaryFile(
+    "long-plan-name-that-needs-truncation.md",
+    "# Unicode 計画\n\n- [x] completed item with a very long description\n- [ ] next\n\x1b[31mterminal color\x1b[0m\ttext\n",
+  );
+  const artifact: AgyArtifact = {
+    name: path.basename(file),
+    absolutePath: file,
+    kind: "conversation",
+    mediaType: "markdown",
+    bytes: 100,
+    modifiedMs: Date.now(),
+  };
+  let renders = 0;
+  const tui = { terminal: { rows: 16 }, requestRender: () => renders++ } as any;
+  const theme = {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  } as any;
+  const keybindings = {
+    getKeys: (binding: string) => [
+      binding.includes("cancel") ? "esc" : binding.includes("confirm") ? "enter" : "↑",
+    ],
+    matches: (data: string, binding: string) =>
+      (data === "enter" && binding === "tui.select.confirm") ||
+      (data === "esc" && binding === "tui.select.cancel"),
+  } as any;
+  const dashboard = new AgyArtifactsDashboard(
+    tui,
+    theme,
+    keybindings,
+    { getArtifacts: () => [artifact], refresh: async () => {} },
+    { index: 0 },
+    () => {},
+  );
+  try {
+    for (const width of [12, 24, 50]) {
+      assert.ok(dashboard.render(width).every((line) => visibleWidth(line) <= width));
+    }
+    dashboard.handleInput("enter");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.ok(renders > 0);
+    for (const width of [12, 24, 50]) {
+      const lines = dashboard.render(width);
+      assert.ok(lines.every((line) => visibleWidth(line) <= width));
+      assert.ok(lines.every((line) => !line.includes("\x1b[31m")));
+    }
+    assert.ok(
+      dashboard.render(50).some((line) => line.includes("checklist") || line.includes("preview")),
+    );
+    dashboard.handleInput("esc");
+    assert.ok(dashboard.render(30).some((line) => line.includes("agy artifacts")));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/pi-antigravity/test/artifacts.test.ts
+++ b/packages/pi-antigravity/test/artifacts.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { findAgyArtifact, listAgyArtifacts, type AgyArtifact } from "../lib/artifacts.ts";
@@ -34,6 +34,40 @@ test("listAgyArtifacts lists generated and uploaded files, newest first", async 
     assert.equal(artifacts[1].kind, "uploaded");
     assert.equal(artifacts[1].mediaType, "pdf");
     assert.equal(artifacts[0].bytes, 9);
+  } finally {
+    await rm(brainDir, { recursive: true, force: true });
+  }
+});
+
+test("listAgyArtifacts includes root markdown and excludes internal, metadata, and symlink entries", async () => {
+  const brainDir = await makeBrain();
+  const root = path.join(brainDir, CONV);
+  try {
+    await writeFile(path.join(root, "plan.md"), "# Plan\n\n- [x] done\n- [ ] next\n");
+    await writeFile(path.join(root, "plan.metadata.json"), "{}");
+    await mkdir(path.join(root, "scratch"), { recursive: true });
+    await writeFile(path.join(root, "scratch", "secret.md"), "secret");
+    await mkdir(path.join(root, ".system_generated"), { recursive: true });
+    await writeFile(path.join(root, ".system_generated", "content.md"), "internal");
+    await symlink(path.join(root, "plan.md"), path.join(root, "linked.md"));
+
+    const artifacts = await listAgyArtifacts(CONV, { brainDir });
+    const plan = artifacts.find((artifact) => artifact.name === "plan.md");
+    assert.equal(plan?.kind, "conversation");
+    assert.equal(plan?.mediaType, "markdown");
+    assert.ok(!artifacts.some((artifact) => artifact.name === "plan.metadata.json"));
+    assert.ok(!artifacts.some((artifact) => artifact.name === "secret.md"));
+    assert.ok(!artifacts.some((artifact) => artifact.name === "content.md"));
+    assert.ok(!artifacts.some((artifact) => artifact.name === "linked.md"));
+  } finally {
+    await rm(brainDir, { recursive: true, force: true });
+  }
+});
+
+test("listAgyArtifacts rejects conversation path traversal", async () => {
+  const brainDir = await makeBrain();
+  try {
+    assert.deepEqual(await listAgyArtifacts("../outside", { brainDir }), []);
   } finally {
     await rm(brainDir, { recursive: true, force: true });
   }

--- a/packages/pi-antigravity/test/bridge-lifecycle.test.ts
+++ b/packages/pi-antigravity/test/bridge-lifecycle.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { AgyPiBridge } from "../lib/bridge.ts";
+import { createBridgeLifecycleManager } from "../lib/bridge-lifecycle.ts";
+
+test("bridge lifecycle process revision combines registration generation and catalog revision", async () => {
+  const bridge = new AgyPiBridge("pi-bridge-generation");
+  bridge.setToolSource(() => [
+    { name: "mcp", description: "gateway", parameters: { type: "object" } },
+  ]);
+  const manager = createBridgeLifecycleManager({
+    bridge,
+    bridgeToken: "token",
+    addMcpServer: async () => {},
+    removeMcpServer: async () => {},
+    evictMcpCache: async () => {},
+  });
+  try {
+    assert.equal(manager.processRevision(), "0:0");
+    assert.equal(await manager.ensureRegistered(), true);
+    assert.equal(manager.registrationGeneration(), 1);
+    assert.equal(manager.processRevision(), `1:${bridge.catalogRevision}`);
+    const registeredRevision = manager.processRevision();
+
+    assert.equal(await manager.ensureRegistered(), true);
+    assert.equal(manager.processRevision(), registeredRevision);
+
+    bridge.setDynamicTools([
+      {
+        name: "activate_skill",
+        description: "activate",
+        parameters: { type: "object", properties: { name: { enum: ["x"] } } },
+        handler: async () => ({ content: "ok", isError: false }),
+      },
+    ]);
+    assert.notEqual(manager.processRevision(), registeredRevision);
+
+    await manager.teardown();
+    assert.equal(manager.registrationGeneration(), 2);
+    assert.match(manager.processRevision(), /^2:/);
+  } finally {
+    await manager.teardown();
+  }
+});

--- a/packages/pi-antigravity/test/bridge.test.ts
+++ b/packages/pi-antigravity/test/bridge.test.ts
@@ -39,6 +39,38 @@ function post(
   }).then(async (res) => ({ status: res.status, json: (await res.json()) as Record<string, any> }));
 }
 
+test("bridge catalog revision is stable across ordering and changes with canonical content", () => {
+  const bridge = new AgyPiBridge();
+  let tools = [
+    { name: "z", description: "z", parameters: { type: "object", properties: { b: {}, a: {} } } },
+    { name: "a", description: "a", parameters: { required: ["x", "y"], type: "object" } },
+  ];
+  bridge.setToolSource(() => tools);
+  assert.equal(bridge.refreshTools(), true);
+  const first = bridge.catalogRevision;
+
+  tools = [
+    { name: "a", description: "a", parameters: { type: "object", required: ["x", "y"] } },
+    { name: "z", description: "z", parameters: { properties: { a: {}, b: {} }, type: "object" } },
+  ];
+  assert.equal(bridge.refreshTools(), false);
+  assert.equal(bridge.catalogRevision, first);
+
+  tools[0] = { ...tools[0], description: "changed" };
+  assert.equal(bridge.refreshTools(), true);
+  assert.equal(bridge.catalogRevision, first + 1);
+
+  bridge.setDynamicTools([
+    {
+      name: "activate_skill",
+      description: "skills",
+      parameters: { type: "object", properties: { name: { enum: ["one"] } } },
+      handler: async () => ({ content: "ok", isError: false }),
+    },
+  ]);
+  assert.equal(bridge.catalogRevision, first + 2);
+});
+
 test("bridge responds to initialize and lists prefixed tools", async () => {
   const bridge = await startedBridge(() => false);
   try {

--- a/packages/pi-antigravity/test/conversation-metadata.test.ts
+++ b/packages/pi-antigravity/test/conversation-metadata.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  parseAgyConversationMetadata,
+  readAgyConversationMetadata,
+} from "../lib/conversation-metadata.ts";
+
+const ID = "conversation-123";
+const SHAPE = {
+  conversations: {
+    [ID]: {
+      summary: {
+        ID,
+        Title: "Implement persistent agy driver",
+        Preview: "Reuse one process",
+        NumSteps: 17,
+        UpdatedAt: "2026-09-01T10:11:12.000Z",
+        WorkspaceURIs: ["file:///repo"],
+        AgentName: "default",
+      },
+    },
+  },
+};
+
+test("parseAgyConversationMetadata accepts the real capitalized shape", () => {
+  assert.deepEqual(parseAgyConversationMetadata(SHAPE, ID), {
+    id: ID,
+    title: "Implement persistent agy driver",
+    preview: "Reuse one process",
+    numSteps: 17,
+    updatedAt: "2026-09-01T10:11:12.000Z",
+    workspaceUris: ["file:///repo"],
+    agentName: "default",
+  });
+});
+
+test("parseAgyConversationMetadata bounds and rejects malformed identity", () => {
+  const malformed = structuredClone(SHAPE);
+  malformed.conversations[ID].summary.ID = "other";
+  assert.equal(parseAgyConversationMetadata(malformed, ID), undefined);
+
+  const partial = structuredClone(SHAPE);
+  partial.conversations[ID].summary.Title = "x".repeat(600);
+  partial.conversations[ID].summary.NumSteps = -1;
+  partial.conversations[ID].summary.UpdatedAt = "not-a-date";
+  const parsed = parseAgyConversationMetadata(partial, ID);
+  assert.equal(parsed?.title, undefined);
+  assert.equal(parsed?.numSteps, undefined);
+  assert.equal(parsed?.updatedAt, undefined);
+});
+
+test("readAgyConversationMetadata tolerates missing, malformed, and oversized files", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "agy-metadata-"));
+  const file = path.join(dir, "conversation_metadata.json");
+  try {
+    assert.equal((await readAgyConversationMetadata(ID, { file })).status, "missing");
+    await writeFile(file, "not json");
+    assert.equal((await readAgyConversationMetadata(ID, { file })).status, "invalid");
+    await writeFile(file, Buffer.from([0xff, 0xfe]));
+    assert.equal((await readAgyConversationMetadata(ID, { file })).status, "invalid");
+    await writeFile(file, JSON.stringify(SHAPE));
+    const ok = await readAgyConversationMetadata(ID, { file });
+    assert.equal(ok.status, "ok");
+    assert.equal(ok.metadata?.title, "Implement persistent agy driver");
+    assert.equal(
+      (await readAgyConversationMetadata(ID, { file, maxBytes: 4 })).status,
+      "oversized",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/pi-antigravity/test/models.test.ts
+++ b/packages/pi-antigravity/test/models.test.ts
@@ -6,20 +6,33 @@ import {
   modelCacheTtlMs,
   parseAgyModels,
   pricingForModel,
+  resolveAgyModelEffort,
 } from "../lib/models.ts";
 import { MODELS_OUTPUT } from "./fixtures.ts";
 
 test("parseAgyModels parses tab-separated model lines, collapses effort variants, and skips noise", () => {
   const models = parseAgyModels(MODELS_OUTPUT);
   assert.equal(models.length, 7);
-  assert.deepEqual(models[0], { id: "gemini-3.7-flash", name: "Gemini 3.7 Flash" });
+  assert.deepEqual(models[0], {
+    id: "gemini-3.7-flash",
+    name: "Gemini 3.7 Flash",
+    supportedEfforts: ["high", "medium"],
+    defaultEffort: "high",
+  });
   assert.equal(models[1].id, "gemini-3.6-flash");
   assert.deepEqual(models[4], {
     id: "claude-sonnet-4-6",
     name: "Claude Sonnet 4.6 (Thinking)",
+    supportedEfforts: [],
+    defaultEffort: undefined,
   });
   assert.equal(models[5].id, "claude-opus-4-6-thinking");
-  assert.deepEqual(models[6], { id: "gpt-oss-120b", name: "GPT-OSS 120B" });
+  assert.deepEqual(models[6], {
+    id: "gpt-oss-120b",
+    name: "GPT-OSS 120B",
+    supportedEfforts: ["medium"],
+    defaultEffort: "medium",
+  });
 });
 
 test("parseAgyModels dedupes ids and rejects malformed lines", () => {
@@ -34,6 +47,14 @@ test("parseAgyModels dedupes ids and rejects malformed lines", () => {
 
 test("parseAgyModels returns empty for empty output", () => {
   assert.deepEqual(parseAgyModels(""), []);
+});
+
+test("resolveAgyModelEffort never launches a normalized model with an invalid effort", () => {
+  const [gemini, , , pro, claude, , gpt] = FALLBACK_MODELS;
+  assert.equal(resolveAgyModelEffort(gemini, "low"), "low");
+  assert.equal(resolveAgyModelEffort(pro, "medium"), "high");
+  assert.equal(resolveAgyModelEffort(claude, "high"), undefined);
+  assert.equal(resolveAgyModelEffort(gpt, "high"), "medium");
 });
 
 test("pricingForModel uses vendor-specific reference rates and no cross-vendor fallback", () => {

--- a/packages/pi-antigravity/test/provider.test.ts
+++ b/packages/pi-antigravity/test/provider.test.ts
@@ -226,6 +226,76 @@ function makeStreamHarness(options: { prompt?: string; createIsolatedRuntime?: (
   };
 }
 
+test("streamAntigravity refreshes bridge state and passes effort, profile, and revision before begin", async () => {
+  const prompt = "configured turn";
+  const controller = new AgyTurnController(prompt);
+  const bridge = new AgyPiBridge("test-config-bridge");
+  bridge.setToolSource(() => [
+    { name: "mcp", description: "gateway", parameters: { type: "object" } },
+  ]);
+  let captured: Record<string, unknown> | undefined;
+  const service = {
+    beginStreamTurn: (request: Record<string, unknown>) =>
+      Effect.sync(() => {
+        captured = request;
+        return controller;
+      }),
+    finishTurn: Effect.void,
+    snapshot: Effect.succeed({ cwd: "/repo" }),
+    setSession: () => Effect.void,
+    close: Effect.void,
+  };
+  const runtime = { runPromise: (effect: Effect.Effect<any, any>) => Effect.runPromise(effect) };
+  const streamFn = streamAntigravity(
+    runtime as any,
+    service as any,
+    new AgyReplayStore(),
+    bridge,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    () => ({
+      id: "gemini-3.7-flash",
+      name: "Gemini 3.7 Flash",
+      supportedEfforts: ["high", "low"],
+      defaultEffort: "high",
+    }),
+    () => ({ agent: "reviewer", mode: "plan" }),
+    () => `2:${bridge.catalogRevision}`,
+  );
+  const model = {
+    id: "gemini-3.7-flash",
+    provider: "antigravity",
+    api: "antigravity-stream-json",
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  } as any;
+  const eventsPromise = (async () => {
+    const events = [];
+    for await (const event of streamFn(
+      model,
+      contextWith([{ role: "user", content: [{ type: "text", text: prompt }] }]),
+      { reasoning: "medium" },
+    )) {
+      events.push(event);
+    }
+    return events;
+  })();
+  controller.push({
+    type: "result",
+    status: "OK",
+    response: "done",
+    error: undefined,
+    usage: undefined,
+  });
+  await eventsPromise;
+  assert.equal(captured?.effort, "high", "unsupported medium falls back to discovered default");
+  assert.equal(captured?.agent, "reviewer");
+  assert.equal(captured?.mode, "plan");
+  assert.equal(captured?.bridgeRevision, "2:1");
+});
+
 test("streamAntigravity isolates pi summarization from the resumed agy conversation", async () => {
   const summaryPrompt =
     "<conversation>\nuser: real request\nassistant: result\n</conversation>\n\nSummarize the conversation above.";

--- a/packages/pi-antigravity/test/runtime.test.ts
+++ b/packages/pi-antigravity/test/runtime.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import { AgySpawnError, AgyStallError, type AgyTurnRequest } from "../lib/agy-client.ts";
 import { stallContinuationPrompt } from "../lib/prompt.ts";
 import { newTurnOutcome, type AgyTurnOutcome } from "../lib/reducer.ts";
+import type { AgyTurnExecutor } from "../lib/agy-driver.ts";
 import { AntigravityRuntime, createAntigravityRuntime, runAntigravity } from "../src/runtime.ts";
 
 function completedOutcome(conversationId: string): AgyTurnOutcome {
@@ -13,6 +14,98 @@ function completedOutcome(conversationId: string): AgyTurnOutcome {
     finished: true,
   };
 }
+
+test("runtime owns and recycles its executor on reset, restore, and shutdown", async () => {
+  const closes: string[] = [];
+  const executor: AgyTurnExecutor = {
+    run: async (request) => {
+      request.onConversation?.("owned-conversation");
+      return completedOutcome("owned-conversation");
+    },
+    snapshot: () => ({ mode: "persistent", state: "ready", pid: 123, lifecycle: [] }),
+    close: async (reason, cause) => {
+      closes.push(`${reason}:${cause ?? "none"}`);
+    },
+  };
+  const runtime = createAntigravityRuntime(executor);
+  const service = runtime.runSync(AntigravityRuntime);
+  try {
+    await runAntigravity(runtime, service.setSession("/repo", undefined));
+    closes.length = 0;
+    const turn = await runAntigravity(
+      runtime,
+      service.beginStreamTurn({ prompt: "one", modelId: "gemini-3.7-flash" }),
+    );
+    assert.equal(await turn.next(), null);
+    await runAntigravity(runtime, service.finishTurn);
+    await runAntigravity(runtime, service.reset);
+    assert.deepEqual(closes, ["recycle:reset"]);
+
+    await runAntigravity(
+      runtime,
+      service.restoreConversation({
+        conversationId: "restored",
+        modelId: "gemini-3.7-flash",
+        cwd: "/repo",
+        turns: 1,
+        usage: {},
+      }),
+    );
+    assert.deepEqual(closes, ["recycle:reset", "recycle:restore"]);
+    await runAntigravity(runtime, service.close);
+    assert.deepEqual(closes, ["recycle:reset", "recycle:restore", "shutdown:none"]);
+  } finally {
+    await runtime.dispose();
+  }
+});
+
+test("runtime re-entry keeps the active driver turn despite a newer bridge revision", async () => {
+  let runs = 0;
+  const closes: string[] = [];
+  let resolveRun: ((outcome: AgyTurnOutcome) => void) | undefined;
+  const executor: AgyTurnExecutor = {
+    run: async () => {
+      runs += 1;
+      return new Promise<AgyTurnOutcome>((resolve) => {
+        resolveRun = resolve;
+      });
+    },
+    snapshot: () => ({ mode: "persistent", state: "running", lifecycle: [] }),
+    close: async (reason) => {
+      closes.push(reason);
+    },
+  };
+  const runtime = createAntigravityRuntime(executor);
+  const service = runtime.runSync(AntigravityRuntime);
+  try {
+    const first = await runAntigravity(
+      runtime,
+      service.beginStreamTurn({
+        prompt: "same user turn",
+        modelId: "gemini-3.7-flash",
+        bridgeRevision: "1:1",
+      }),
+    );
+    const reentered = await runAntigravity(
+      runtime,
+      service.beginStreamTurn({
+        prompt: "same user turn",
+        modelId: "gemini-3.7-flash",
+        bridgeRevision: "1:2",
+      }),
+    );
+    assert.equal(reentered, first);
+    assert.equal(runs, 1);
+    assert.deepEqual(closes, []);
+
+    resolveRun?.(completedOutcome("reentry-conversation"));
+    assert.equal(await first.next(), null);
+    await runAntigravity(runtime, service.close);
+    assert.deepEqual(closes, ["shutdown"]);
+  } finally {
+    await runtime.dispose();
+  }
+});
 
 test("runtime restores the selected pi branch only when starting a fresh conversation", async () => {
   const requests: AgyTurnRequest[] = [];
@@ -157,6 +250,7 @@ test("runtime restores a persisted native conversation and cumulative usage", as
       cwd: "/repo",
       turns: 8,
       conversationUsage: { input_tokens: 1_250, output_tokens: 125, total_tokens: 1_375 },
+      executor: { mode: "one-shot", state: "idle", lifecycle: [] },
     });
   } finally {
     await runtime.dispose();
@@ -291,6 +385,7 @@ test("runtime reset aborts the active process and clears conversation state", as
       cwd: "/repo",
       turns: 0,
       conversationUsage: {},
+      executor: { mode: "one-shot", state: "idle", lifecycle: [] },
     });
   } finally {
     await runtime.dispose();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,10 +57,22 @@ importers:
       effect:
         specifier: 4.0.0-beta.101
         version: 4.0.0-beta.101
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
+      which:
+        specifier: ^7.0.0
+        version: 7.0.0
     devDependencies:
       '@effect/language-service':
         specifier: ^0.87.2
         version: 0.87.2
+      '@types/semver':
+        specifier: ^7.8.0
+        version: 7.8.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -1008,8 +1020,14 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
+  '@types/semver@7.8.0':
+    resolution: {integrity: sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==}
+
   '@types/vscode@1.125.0':
     resolution: {integrity: sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==}
+
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -1376,6 +1394,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -1674,6 +1696,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  which@7.0.0:
+    resolution: {integrity: sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     hasBin: true
 
   ws@8.21.3:
@@ -2421,7 +2448,11 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@types/semver@7.8.0': {}
+
   '@types/vscode@1.125.0': {}
+
+  '@types/which@3.0.4': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -2724,6 +2755,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@4.0.0: {}
+
   jiti@2.7.0: {}
 
   jju@1.4.0: {}
@@ -3016,6 +3049,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@7.0.0:
+    dependencies:
+      isexe: 4.0.0
 
   ws@8.21.3: {}
 


### PR DESCRIPTION
## Summary

- require `agy` 1.1.22+, validate all installed candidates, select the newest compatible stable binary, and invalidate the cached selection when an executable changes
- reuse one persistent stream-json driver across ordinary turns with Pi-owned deadlines, serialized submissions, safe conversation resume, and an operational `PI_ANTIGRAVITY_DRIVER=0` rollback
- recycle on binary/workspace/model/effort/agent/mode/bridge-catalog changes and expose spawn, reuse, recycle, and per-cause diagnostics through `/agy doctor`
- preserve effort variants during model discovery and add validated custom-agent and execution-mode pass-through
- keep the Pi MCP/skill catalog coherent across persistent processes using a canonical bridge revision
- enrich conversation status from bounded display-only metadata and add safe direct markdown artifact discovery/preview
- document the VS Code extension research, rejected private/unsafe surfaces, implementation decisions, and scoped delivery gates in `packages/pi-antigravity/PLAN.md`

## Safety and rollout

- does not download or update executables
- does not use private hub/Connect RPC, webviews, passive editor context, or reconstructed accept/reject diffs
- keeps Pi summaries in disposable isolated agy processes
- retains branch-owned conversation persistence and readable-database fallback
- includes a minor changeset

## Verification

- `pnpm --filter @tian.zuo/pi-antigravity run check`
- `pnpm --filter @tian.zuo/pi-antigravity test` — 212 passed
- `pnpm exec biome check packages/pi-antigravity .changeset/bright-drivers-travel.md`
- `pnpm run typecheck`
- `pnpm run check`
- `pnpm test`
- Herdr pane verification — `__HERDR_ANTIGRAVITY_RESULT=0`
