### PR TITLE
fix(background-terminals): batch nearby completion notifications

### DIFF
--- a/.changeset/calm-terminal-completions.md
+++ b/.changeset/calm-terminal-completions.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-background-terminals": patch
+---
+
+Batch background terminals that finish close together into one bounded completion follow-up while preserving exactly-once delivery and the existing singleton message shape.

--- a/packages/pi-background-terminals/README.md
+++ b/packages/pi-background-terminals/README.md
@@ -7,10 +7,12 @@ A managed replacement for Pi's built-in `bash` tool.
 Every model shell command follows one path: start it, wait briefly, and return
 its final output if it finishes. If it outlives the initial wait, return control
 to the model while the command continues as a session-scoped background
-terminal. Its final result is delivered automatically exactly once. Quick Bash
-calls show a bounded command/output preview in the main transcript; only calls
-that actually yield collapse to compact terminal rows. `/ps` retains complete
-invocation metadata and the detailed stdout/stderr viewer.
+terminal. Its final result is delivered automatically exactly once. Results
+that settle close together share one bounded follow-up; an isolated result keeps
+its existing message shape. Quick Bash calls show a bounded command/output
+preview in the main transcript; only calls that actually yield collapse to
+compact terminal rows. `/ps` retains complete invocation metadata and the
+detailed stdout/stderr viewer.
 
 ```text
 ■ 2 background terminals running • /ps to view
@@ -51,8 +53,10 @@ Behavior:
    errors. The TUI keeps the quick command visibly distinct from background work.
 5. If it remains alive, return an id such as `bt-1`. Only then does the row
    collapse to compact background-terminal status. The model should continue
-   rather than poll; a compact follow-up wakes it exactly once on exit, while
-   detailed stdout/stderr remain in `/ps`.
+   rather than poll. Nearby exits share one compact follow-up after a 1,000 ms
+   sliding quiet window, with a 3,000 ms maximum hold. An isolated exit keeps
+   the original message shape, and every terminal result remains exactly-once.
+   Detailed stdout/stderr remain in `/ps`.
 
 There are no model-facing status, list, kill, polling, or stdin tools. The
 read-only `terminal_log_read` tool only pages an opaque archive ref emitted by
@@ -115,9 +119,11 @@ While at least one terminal runs, a one-line widget renders above the editor.
   syntax (redirects, command substitution) always fails open. Every settled
   result also names the directory the command actually ran in, because the
   common mistake is assuming a cwd that was never set.
-- **Exactly-once completion.** A race-safe waiter token decides whether the
-  initial Bash call or the later follow-up owns settlement. A drain-once map
-  handles delivery retries without duplicates.
+- **Exactly-once batched completion.** A race-safe waiter token decides whether
+  the initial Bash call or a later follow-up owns settlement. A drain-once map
+  handles delivery retries without duplicates. A bounded quiet-window scheduler
+  combines nearby map entries into one follow-up, caps aggregate content at
+  32 KiB, and leaves isolated completion messages unchanged.
 - **Bounded head+tail memory plus full capture.** Each stdout/stderr stream
   retains a stable **256 KiB startup head** and rolling tail within a **2 MiB**
   cap. Omitted middle bytes are marked. Complete output spills from byte zero

--- a/packages/pi-background-terminals/completion-batcher.test.ts
+++ b/packages/pi-background-terminals/completion-batcher.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  COMPLETION_BATCH_MAX_WAIT_MS,
+  COMPLETION_BATCH_QUIET_MS,
+  type CompletionBatchTimers,
+  createCompletionBatchScheduler,
+} from "./src/completion-batcher.ts";
+
+interface ScheduledTimer {
+  readonly id: number;
+  readonly callback: () => void;
+  readonly deadline: number;
+  active: boolean;
+}
+
+class ManualTimers implements CompletionBatchTimers {
+  private now = 0;
+  private nextId = 0;
+  private readonly scheduled: ScheduledTimer[] = [];
+
+  setTimeout(callback: () => void, delayMs: number) {
+    const timer = {
+      id: ++this.nextId,
+      callback,
+      deadline: this.now + delayMs,
+      active: true,
+    };
+    this.scheduled.push(timer);
+    return timer.id;
+  }
+
+  clearTimeout(handle: unknown) {
+    const timer = this.scheduled.find((candidate) => candidate.id === handle);
+    if (timer) timer.active = false;
+  }
+
+  advance(elapsedMs: number) {
+    const target = this.now + elapsedMs;
+    while (true) {
+      const next = this.scheduled
+        .filter((timer) => timer.active && timer.deadline <= target)
+        .sort((left, right) => left.deadline - right.deadline || left.id - right.id)[0];
+      if (!next) break;
+      this.now = next.deadline;
+      next.active = false;
+      next.callback();
+    }
+    this.now = target;
+  }
+}
+
+test("completion batching slides the quiet deadline", () => {
+  const timers = new ManualTimers();
+  let flushes = 0;
+  const scheduler = createCompletionBatchScheduler(() => flushes++, { timers });
+
+  scheduler.schedule();
+  timers.advance(COMPLETION_BATCH_QUIET_MS - 1);
+  scheduler.schedule();
+  timers.advance(1);
+  assert.equal(flushes, 0);
+  timers.advance(COMPLETION_BATCH_QUIET_MS - 1);
+  assert.equal(flushes, 1);
+});
+
+test("completion batching keeps sustained arrivals within the maximum hold", () => {
+  const timers = new ManualTimers();
+  let flushes = 0;
+  const scheduler = createCompletionBatchScheduler(() => flushes++, { timers });
+
+  scheduler.schedule();
+  timers.advance(900);
+  scheduler.schedule();
+  timers.advance(900);
+  scheduler.schedule();
+  timers.advance(900);
+  scheduler.schedule();
+  timers.advance(COMPLETION_BATCH_MAX_WAIT_MS - 2_700 - 1);
+  assert.equal(flushes, 0);
+  timers.advance(1);
+  assert.equal(flushes, 1);
+});
+
+test("clearing completion batching invalidates every pending deadline", () => {
+  const timers = new ManualTimers();
+  let flushes = 0;
+  const scheduler = createCompletionBatchScheduler(() => flushes++, { timers });
+
+  scheduler.schedule();
+  scheduler.clear();
+  timers.advance(COMPLETION_BATCH_MAX_WAIT_MS * 2);
+  assert.equal(flushes, 0);
+});

--- a/packages/pi-background-terminals/docs/implementation-guide.md
+++ b/packages/pi-background-terminals/docs/implementation-guide.md
@@ -17,8 +17,8 @@ Every model shell command goes through `bash`:
 5. If the process settles during that wait, return its final state and output in
    the Bash result. A non-zero exit, kill, or timeout is a tool error.
 6. Otherwise return a terminal id and leave the process running.
-7. When a yielded process settles, deliver its final result as an exactly-once
-   follow-up that wakes the model.
+7. When a yielded process settles, admit its final result exactly once. Results
+   that settle close together share one bounded follow-up that wakes the model.
 
 The model-facing tool result and completion message retain bounded stdout/stderr.
 Quick and initial-wait TUI rows show a sanitized bounded output preview plus a
@@ -300,10 +300,23 @@ The settle hook receives `(snapshot, consumed)`:
 - `consumed = false`: copy the final snapshot into the drain-once delivery map.
 
 The map is keyed by terminal id. `drain()` clears entries before delivery, so a
-result can be sent only once. A failed `pi.sendMessage` call re-defers the same
-id for a later `agent_settled` retry. Interactive mode does not write that
-failure through `console.error`, which would corrupt the active TUI frame;
-non-TUI modes retain the diagnostic.
+result can be sent only once. A failed `pi.sendMessage` call re-defers every id
+from the failed batch for a later `agent_settled` retry. Interactive mode does
+not write that failure through `console.error`, which would corrupt the active
+TUI frame; non-TUI modes retain the diagnostic.
+
+Idle settlements schedule delivery instead of sending immediately. The
+scheduler waits for a 1,000 ms quiet period after the latest admitted result and
+holds the first result for at most 3,000 ms. New results slide only the quiet
+deadline; they never extend the maximum hold. A busy agent keeps results in the
+map until `agent_settled` starts the same bounded window. Session shutdown
+cancels both deadlines before clearing the map.
+
+The timer group detaches before delivery, so a settlement triggered during a
+synchronous delivery callback starts a new group. Generation tokens make stale
+callbacks harmless even if timer cancellation races. If the initial Bash wait
+consumes the only deferred result during the start-to-wait race, the now-empty
+group is cancelled.
 
 Delivery uses:
 
@@ -314,10 +327,13 @@ pi.sendMessage(message, {
 });
 ```
 
-The custom message content includes bounded output for model context, while its
-message renderer always shows one status line with a `/ps` hint and ignores
-expanded mode. A busy agent receives the message after its current run settles.
-An idle agent is woken immediately. No model-driven polling is required.
+A singleton keeps the existing message content and detail shape. A batch carries
+all compact terminal details in settlement order and allocates its 32 KiB
+content budget across results so every terminal summary survives truncation. Its
+message renderer shows one status line with the terminal count, aggregate
+outcomes, and a `/ps` hint. A busy agent receives the message after its current
+run settles. An idle agent is woken when the quiet window closes. No model-driven
+polling is required.
 
 ## 11. Head+tail output retention
 
@@ -370,9 +386,12 @@ Automatic completion budgets:
 ```text
 stdout:  8 KiB / 40 lines
 stderr:  4 KiB / 20 lines
+batch:  32 KiB total content
 ```
 
-Every model-visible output remains bounded even if a child is a firehose.
+A multi-terminal batch divides the aggregate budget across its results and
+retains each status prefix before bounded output. Every model-visible output
+remains bounded even if a child is a firehose.
 
 ## 12. Spill files and backpressure
 
@@ -552,6 +571,9 @@ The package test suite covers:
 - registration of only the `bash` override plus `/ps`;
 - quick completion without a duplicate follow-up;
 - yielded completion with exactly one automatic delivery;
+- sliding quiet and maximum-hold batching deadlines, including cancellation;
+- synchronized yielded completions sharing one follow-up;
+- unchanged singleton messages and UTF-8-bounded aggregate content;
 - safe pre-spawn foreground fallback;
 - non-zero commands executing only once, without fallback retry;
 - Pi managed-bin `PATH`, session environment, and command-prefix preservation;

--- a/packages/pi-background-terminals/index.test.ts
+++ b/packages/pi-background-terminals/index.test.ts
@@ -297,6 +297,27 @@ test("renderers distinguish quick bash from actually yielded terminals", async (
     const renderedCompletion = completion.render(120).join("\n").trimEnd();
     assert.match(renderedCompletion, /terminal bt-9.*\/ps to inspect/);
     assert.doesNotMatch(renderedCompletion, /stdout|later-output|server/);
+
+    const completionBatch = completionRenderer(
+      {
+        content: "3 background terminals completed.",
+        details: {
+          count: 3,
+          ids: ["bt-1", "bt-2", "bt-3"],
+          results: [
+            { id: "bt-1", status: "done", exitCode: 0 },
+            { id: "bt-2", status: "failed", exitCode: 1 },
+            { id: "bt-3", status: "done", exitCode: 0 },
+          ],
+        },
+      },
+      { expanded: true },
+      theme,
+    );
+    assert.match(
+      completionBatch.render(120).join("\n").trimEnd(),
+      /3 terminals.*1 failed.*\/ps to inspect/,
+    );
   } finally {
     await app.shutdown();
   }
@@ -747,6 +768,55 @@ test("yielded command returns an id then sends exactly one completion", async ()
     assert.equal(app.messages.length, 1);
     assert.equal(app.messages[0].message.customType, "background-terminal-result");
     assert.match(app.messages[0].message.content, /exited \(exit 0\)/);
+    assert.deepEqual(app.messages[0].options, {
+      deliverAs: "followUp",
+      triggerTurn: true,
+    });
+  } finally {
+    await app.shutdown();
+  }
+});
+
+test("near-simultaneous yielded completions share one follow-up", async () => {
+  const app = harness();
+  try {
+    const tool = app.tools.get("bash");
+    const finishAt = Date.now() + 2_500;
+    const results = await Promise.all(
+      Array.from({ length: 3 }, (_, index) =>
+        tool.execute(
+          `call-batch-${index + 1}`,
+          {
+            command: command(
+              `setTimeout(() => console.log("batch-${index + 1}"), Math.max(0, ${finishAt} - Date.now()))`,
+            ),
+            title: `batch command ${index + 1}`,
+            yield_time_ms: 250,
+          },
+          undefined,
+          undefined,
+          app.ctx,
+        ),
+      ),
+    );
+    const ids = results.map((result) => {
+      const id = /background terminal (bt-\d+)/.exec(result.content[0].text)?.[1];
+      assert.ok(id, result.content[0].text);
+      return id;
+    });
+
+    assert.equal(
+      await pollUntil(
+        () =>
+          app.messages.length === 1 &&
+          ids.every((id) => app.messages[0].message.content.includes(id)),
+      ),
+      true,
+      "one follow-up contains every nearby completion",
+    );
+    assert.equal(app.messages.length, 1);
+    assert.equal(app.messages[0].message.details.count, 3);
+    assert.deepEqual([...app.messages[0].message.details.ids].sort(), [...ids].sort());
     assert.deepEqual(app.messages[0].options, {
       deliverAs: "followUp",
       triggerTurn: true,

--- a/packages/pi-background-terminals/index.ts
+++ b/packages/pi-background-terminals/index.ts
@@ -33,6 +33,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { createCompletionBatchScheduler } from "./src/completion-batcher.ts";
 import { SpawnError, type TerminalSnapshot, type TerminalStatus } from "./src/domain.ts";
 import {
   duplicateCommandError,
@@ -55,7 +56,7 @@ import {
   BASH_TOOL_DESCRIPTION,
   buildBashProgress,
   buildBashResult,
-  buildTerminalResultMessage,
+  buildTerminalResultBatchMessage,
   deriveCommandTitle,
   describeTerminal,
   TERMINAL_LOG_READ_PARAMETER_DESCRIPTIONS,
@@ -258,48 +259,64 @@ export function createBackgroundTerminalsExtension(
       }
     };
 
-    const deliverResult = (snap: TerminalSnapshot) => {
+    const deliverResults = (snaps: readonly TerminalSnapshot[]) => {
+      if (snaps.length === 0) return true;
       try {
+        const results = snaps.map((snap) => ({
+          id: snap.id,
+          title: snap.title,
+          status: snap.status,
+          exitCode: snap.exitCode,
+          signal: snap.signal,
+        }));
         pi.sendMessage(
           {
             customType: "background-terminal-result",
-            content: buildTerminalResultMessage(snap),
+            content: buildTerminalResultBatchMessage(snaps),
             display: true,
-            details: {
-              id: snap.id,
-              title: snap.title,
-              status: snap.status,
-              exitCode: snap.exitCode,
-              signal: snap.signal,
-            },
+            details:
+              results.length === 1
+                ? results[0]
+                : {
+                    count: results.length,
+                    ids: results.map((result) => result.id),
+                    results,
+                  },
           },
           // followUp: queued until the agent has no more tool calls — never
           // interrupts a mid-turn stream. triggerTurn: wakes the model
           // immediately iff idle; if busy, the queued follow-up is delivered
-          // when the current run settles. Either way exactly one delivery.
+          // when the current run settles. Either way each terminal is delivered
+          // exactly once, with nearby settlements sharing one follow-up.
           { deliverAs: "followUp", triggerTurn: true },
         );
         return true;
       } catch (error) {
-        // Session may be shutting down, but retain the snapshot so any later
-        // agent-settled flush can retry instead of silently dropping it.
+        // Session may be shutting down, but retain every snapshot so any later
+        // agent-settled flush can retry instead of silently dropping the batch.
         if (sessionContext?.mode !== "tui") {
-          console.error("background-terminals: failed to deliver result", error);
+          console.error("background-terminals: failed to deliver results", error);
         }
         return false;
       }
     };
 
     const flushResults = () => {
-      for (const snap of resultDelivery.drain()) {
-        if (!deliverResult(snap)) resultDelivery.defer(snap);
+      const snaps = resultDelivery.drain();
+      if (!deliverResults(snaps)) {
+        for (const snap of snaps) resultDelivery.defer(snap);
       }
+    };
+    const resultBatchScheduler = createCompletionBatchScheduler(flushResults);
+    const scheduleResultFlush = () => {
+      if (resultDelivery.size() > 0) resultBatchScheduler.schedule();
     };
 
     const onSettled = (snap: TerminalSnapshot, consumed: boolean) => {
       if (consumed) {
         // The initial bash wait is returning this settlement itself.
         resultDelivery.consume([snap.id]);
+        if (resultDelivery.size() === 0) resultBatchScheduler.clear();
         return;
       }
       // Defer a deep-enough copy: the live snapshot's output views keep
@@ -309,7 +326,7 @@ export function createBackgroundTerminalsExtension(
         stdout: { ...snap.stdout },
         stderr: { ...snap.stderr },
       });
-      if (sessionContext?.isIdle()) flushResults();
+      if (sessionContext?.isIdle()) scheduleResultFlush();
     };
 
     pi.on("session_start", (_event, ctx) => {
@@ -323,10 +340,10 @@ export function createBackgroundTerminalsExtension(
     // user/follow-up run rather than per turn.
     pi.on("agent_start", resetTerminalLogBudget);
 
-    // Drain deferred results when the agent settles: together with the
-    // isIdle() fast path above and the Map-keyed delivery (drain clears),
-    // double delivery is structurally impossible — whoever drains first wins.
-    pi.on("agent_settled", flushResults);
+    // Start or slide one bounded batch when the agent settles. Together with
+    // the idle path above and Map-keyed delivery, this preserves exactly-once
+    // admission while coalescing terminals that finish close together.
+    pi.on("agent_settled", scheduleResultFlush);
 
     // /new, /resume, /fork, /reload, and quit all emit session_shutdown for
     // the old extension instance. Processes never survive a session
@@ -336,6 +353,7 @@ export function createBackgroundTerminalsExtension(
     pi.on("session_shutdown", async () => {
       sessionContext = undefined;
       resetTerminalLogBudget();
+      resultBatchScheduler.clear();
       resultDelivery.clear();
       unsubStatus?.();
       unsubStatus = undefined;
@@ -737,29 +755,49 @@ export function createBackgroundTerminalsExtension(
     // --- Result message rendering ------------------------------------------
 
     pi.registerMessageRenderer("background-terminal-result", (message, _options, theme) => {
-      const details = (message.details ?? {}) as {
-        id?: string;
-        status?: string;
-        exitCode?: number;
-        signal?: string;
+      interface ResultDetails {
+        readonly id?: string;
+        readonly status?: string;
+        readonly exitCode?: number;
+        readonly signal?: string;
+      }
+      const details = (message.details ?? {}) as ResultDetails & {
+        readonly results?: readonly ResultDetails[];
       };
-      const failed = details.status === "failed";
-      const timedOut = details.status === "timed_out";
-      const killed = details.status === "killed";
+      const results = details.results?.length ? details.results : [details];
+      const failedCount = results.filter((result) => result.status === "failed").length;
+      const timedOutCount = results.filter((result) => result.status === "timed_out").length;
+      const killedCount = results.filter((result) => result.status === "killed").length;
       const icon =
-        failed || timedOut
+        failedCount > 0 || timedOutCount > 0
           ? theme.fg("error", "x")
-          : killed
+          : killedCount === results.length
             ? theme.fg("muted", "■")
             : theme.fg("success", "■");
-      const how = killed
-        ? "killed"
-        : timedOut
-          ? "timed out"
-          : (details.signal ?? `exit ${details.exitCode ?? "?"}`);
+
+      let label: string;
+      let how: string;
+      if (results.length > 1) {
+        label = `${results.length} terminals`;
+        const outcomes = [
+          failedCount > 0 ? `${failedCount} failed` : undefined,
+          timedOutCount > 0 ? `${timedOutCount} timed out` : undefined,
+          killedCount > 0 ? `${killedCount} killed` : undefined,
+        ].filter(Boolean);
+        how = outcomes.length > 0 ? outcomes.join(", ") : "completed";
+      } else {
+        const result = results[0];
+        label = `terminal ${result.id ?? "?"}`;
+        how =
+          result.status === "killed"
+            ? "killed"
+            : result.status === "timed_out"
+              ? "timed out"
+              : (result.signal ?? `exit ${result.exitCode ?? "?"}`);
+      }
       const header =
         `${icon} ` +
-        theme.fg("accent", theme.bold(`terminal ${details.id ?? "?"}`)) +
+        theme.fg("accent", theme.bold(label)) +
         theme.fg("muted", ` · ${how} · `) +
         theme.fg("accent", "/ps") +
         theme.fg("dim", " to inspect");

--- a/packages/pi-background-terminals/package.json
+++ b/packages/pi-background-terminals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tian.zuo/pi-background-terminals",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Replace Pi's built-in Bash with automatic background yielding, exactly-once completion notifications, and a /ps viewer.",
   "type": "module",
   "keywords": [
@@ -38,7 +38,7 @@
   "scripts": {
     "check": "tsc --noEmit -p .",
     "prepare": "effect-tsgo patch",
-    "test": "node --test --test-force-exit --test-concurrency=1 --experimental-strip-types index.test.ts manager.test.ts output.test.ts prompt.test.ts command-shape.test.ts result-delivery.test.ts ps.test.ts spill-source.test.ts"
+    "test": "node --test --test-force-exit --test-concurrency=1 --experimental-strip-types index.test.ts manager.test.ts output.test.ts prompt.test.ts command-shape.test.ts completion-batcher.test.ts result-delivery.test.ts ps.test.ts spill-source.test.ts"
   },
   "dependencies": {
     "effect": "4.0.0-beta.101",

--- a/packages/pi-background-terminals/package.json
+++ b/packages/pi-background-terminals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tian.zuo/pi-background-terminals",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "description": "Replace Pi's built-in Bash with automatic background yielding, exactly-once completion notifications, and a /ps viewer.",
   "type": "module",
   "keywords": [

--- a/packages/pi-background-terminals/prompt.test.ts
+++ b/packages/pi-background-terminals/prompt.test.ts
@@ -10,8 +10,10 @@ import {
   BASH_TOOL_DESCRIPTION,
   buildBashProgress,
   buildBashResult,
+  buildTerminalResultBatchMessage,
   buildTerminalResultMessage,
   deriveCommandTitle,
+  MAX_COMPLETION_BATCH_CONTENT_BYTES,
   TERMINAL_LOG_READ_PROMPT_SNIPPET,
   TERMINAL_LOG_READ_TOOL_DESCRIPTION,
 } from "./src/prompt.ts";
@@ -280,6 +282,34 @@ test("completion message reports kill vs exit", () => {
     }),
   );
   assert.match(timedOut, /timed out after/);
+});
+
+test("an isolated completion keeps the existing message shape", () => {
+  const terminal = snap();
+  assert.equal(buildTerminalResultBatchMessage([terminal]), buildTerminalResultMessage(terminal));
+});
+
+test("batched completions retain every terminal summary within one bounded message", () => {
+  const output = "界".repeat(10_000);
+  const terminals = Array.from({ length: 8 }, (_, index) =>
+    snap({
+      id: `bt-${index + 1}`,
+      title: `batch command ${index + 1}`,
+      stdout: view({
+        text: output,
+        head: output,
+        totalBytes: Buffer.byteLength(output),
+      }),
+    }),
+  );
+
+  const message = buildTerminalResultBatchMessage(terminals);
+  assert.ok(Buffer.byteLength(message) <= MAX_COMPLETION_BATCH_CONTENT_BYTES);
+  assert.match(message, /^8 background terminals completed\./);
+  for (const terminal of terminals) {
+    assert.match(message, new RegExp(`Background terminal ${terminal.id} `));
+  }
+  assert.match(message, /output truncated; use \/ps for complete logs/);
 });
 
 test("failed and timed-out completions keep the diagnostic output budget", () => {

--- a/packages/pi-background-terminals/result-delivery.test.ts
+++ b/packages/pi-background-terminals/result-delivery.test.ts
@@ -9,8 +9,10 @@ test("a result consumed by the initial bash wait is not delivered", () => {
   }>();
 
   delivery.defer({ id: "bt-1", output: "done" });
+  assert.equal(delivery.size(), 1);
   delivery.consume(["bt-1"]);
 
+  assert.equal(delivery.size(), 0);
   assert.deepEqual(delivery.drain(), []);
 });
 

--- a/packages/pi-background-terminals/src/completion-batcher.ts
+++ b/packages/pi-background-terminals/src/completion-batcher.ts
@@ -1,0 +1,109 @@
+export const COMPLETION_BATCH_QUIET_MS = 1_000;
+export const COMPLETION_BATCH_MAX_WAIT_MS = 3_000;
+
+export interface CompletionBatchTimers {
+  setTimeout(callback: () => void, delayMs: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+export interface CompletionBatchScheduler {
+  /** Start a batch or slide its quiet deadline without extending its maximum hold. */
+  schedule(): void;
+  /** Cancel every pending deadline. Stale timer callbacks become no-ops. */
+  clear(): void;
+}
+
+interface TimerRegistration {
+  readonly handle: unknown;
+  readonly groupGeneration: number;
+  readonly timerGeneration: number;
+}
+
+const systemTimers: CompletionBatchTimers = {
+  setTimeout(callback, delayMs) {
+    return setTimeout(callback, delayMs);
+  },
+  clearTimeout(handle) {
+    clearTimeout(handle as ReturnType<typeof setTimeout>);
+  },
+};
+
+export function createCompletionBatchScheduler(
+  onFlush: () => void,
+  options: {
+    readonly timers?: CompletionBatchTimers;
+    readonly quietMs?: number;
+    readonly maxWaitMs?: number;
+  } = {},
+): CompletionBatchScheduler {
+  const timers = options.timers ?? systemTimers;
+  const quietMs = options.quietMs ?? COMPLETION_BATCH_QUIET_MS;
+  const maxWaitMs = options.maxWaitMs ?? COMPLETION_BATCH_MAX_WAIT_MS;
+  let nextGroupGeneration = 0;
+  let activeGroupGeneration = 0;
+  let nextTimerGeneration = 0;
+  let quietTimer: TimerRegistration | undefined;
+  let maximumTimer: TimerRegistration | undefined;
+
+  const cancelQuietTimer = () => {
+    if (!quietTimer) return;
+    timers.clearTimeout(quietTimer.handle);
+    quietTimer = undefined;
+  };
+
+  const cancelMaximumTimer = () => {
+    if (!maximumTimer) return;
+    timers.clearTimeout(maximumTimer.handle);
+    maximumTimer = undefined;
+  };
+
+  const detachGroup = () => {
+    activeGroupGeneration = 0;
+    cancelQuietTimer();
+    cancelMaximumTimer();
+  };
+
+  const flushFromTimer = (
+    kind: "quiet" | "maximum",
+    groupGeneration: number,
+    timerGeneration: number,
+  ) => {
+    if (activeGroupGeneration !== groupGeneration) return;
+    const registration = kind === "quiet" ? quietTimer : maximumTimer;
+    if (
+      !registration ||
+      registration.groupGeneration !== groupGeneration ||
+      registration.timerGeneration !== timerGeneration
+    ) {
+      return;
+    }
+    // Detach before delivery so a synchronous settlement starts a new group.
+    detachGroup();
+    onFlush();
+  };
+
+  const armTimer = (kind: "quiet" | "maximum", groupGeneration: number, delayMs: number) => {
+    const timerGeneration = ++nextTimerGeneration;
+    const handle = timers.setTimeout(
+      () => flushFromTimer(kind, groupGeneration, timerGeneration),
+      delayMs,
+    );
+    const registration = { handle, groupGeneration, timerGeneration };
+    if (kind === "quiet") quietTimer = registration;
+    else maximumTimer = registration;
+  };
+
+  return {
+    schedule() {
+      if (activeGroupGeneration === 0) {
+        activeGroupGeneration = ++nextGroupGeneration;
+        armTimer("maximum", activeGroupGeneration, maxWaitMs);
+      }
+      cancelQuietTimer();
+      armTimer("quiet", activeGroupGeneration, quietMs);
+    },
+    clear() {
+      detachGroup();
+    },
+  };
+}

--- a/packages/pi-background-terminals/src/prompt.ts
+++ b/packages/pi-background-terminals/src/prompt.ts
@@ -25,6 +25,8 @@ const PROGRESS_STDERR_MAX = 4 * 1024;
 /** Completion follow-up output. Keep this concise; /ps has the detailed view. */
 export const RESULT_STDOUT_MAX = 8 * 1024;
 export const RESULT_STDERR_MAX = 4 * 1024;
+/** Aggregate follow-ups retain every terminal summary without flooding context. */
+export const MAX_COMPLETION_BATCH_CONTENT_BYTES = 32 * 1024;
 const BASH_STDOUT_MAX_LINES = 400;
 const BASH_STDERR_MAX_LINES = 200;
 const PROGRESS_STDOUT_MAX_LINES = 100;
@@ -254,4 +256,38 @@ export function buildTerminalResultMessage(snap: TerminalSnapshot) {
     diagnostic ? BASH_STDERR_MAX : RESULT_STDERR_MAX,
     diagnostic ? BASH_STDERR_MAX_LINES : RESULT_STDERR_MAX_LINES,
   );
+}
+
+function truncateUtf8WithMarker(value: string, maximumBytes: number) {
+  if (Buffer.byteLength(value) <= maximumBytes) return value;
+  const marker = "\n[output truncated; use /ps for complete logs]";
+  const contentBudget = Math.max(0, maximumBytes - Buffer.byteLength(marker));
+  let result = "";
+  let usedBytes = 0;
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character);
+    if (usedBytes + characterBytes > contentBudget) break;
+    result += character;
+    usedBytes += characterBytes;
+  }
+  return result + marker;
+}
+
+/** One follow-up for terminal completions that settle in the same quiet window. */
+export function buildTerminalResultBatchMessage(snaps: readonly TerminalSnapshot[]) {
+  if (snaps.length === 0) return "";
+  if (snaps.length === 1) return buildTerminalResultMessage(snaps[0]);
+
+  const header = `${snaps.length} background terminals completed.`;
+  const separator = "\n\n";
+  const messages = snaps.map(buildTerminalResultMessage);
+  const fixedBytes = Buffer.byteLength(header) + Buffer.byteLength(separator) * messages.length;
+  const perMessageBytes = Math.max(
+    0,
+    Math.floor((MAX_COMPLETION_BATCH_CONTENT_BYTES - fixedBytes) / messages.length),
+  );
+  const boundedMessages = messages.map((message) =>
+    truncateUtf8WithMarker(message, perMessageBytes),
+  );
+  return [header, ...boundedMessages].join(separator);
 }

--- a/packages/pi-background-terminals/src/result-delivery.ts
+++ b/packages/pi-background-terminals/src/result-delivery.ts
@@ -20,6 +20,9 @@ export function createDeferredResultDelivery<T extends { id: string }>() {
       pending.clear();
       return results;
     },
+    size() {
+      return pending.size;
+    },
     clear() {
       pending.clear();
     },


### PR DESCRIPTION
Nearby background terminal completions now arrive in one follow-up instead of interrupting the conversation once per process.

This adds a one-second sliding quiet window with a three-second maximum hold. Single completions keep their existing shape, every terminal remains exactly-once, aggregate content stays under 32 KiB, and the TUI renders one compact batch row.

A patch Changeset now owns release versioning, so the package manifest stays at the current release until automation bumps it.

Verified with the package's 106-test suite: 105 passed and one platform test skipped. A live Windows run launched eight terminals; all eight completed after two seconds and arrived in one notification. Root type-check and lint passed. The repo-wide test hook is blocked on Windows by the existing pi-antigravity symlink-permission test, outside this package.

Ready for review.