### PR TITLE
fix(background-terminals): tighten completion batching edges

### DIFF
--- a/.changeset/steady-terminal-batches.md
+++ b/.changeset/steady-terminal-batches.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-background-terminals": patch
+---
+
+Preserve the full quiet window for arrivals that follow a busy-held expiry, keep the maximum hold fixed, and charge truncation markers to the strict aggregate completion budget.

--- a/packages/pi-background-terminals/completion-batcher.test.ts
+++ b/packages/pi-background-terminals/completion-batcher.test.ts
@@ -82,6 +82,62 @@ test("completion batching keeps sustained arrivals within the maximum hold", () 
   assert.equal(flushes, 1);
 });
 
+test("a quiet expiry held while busy flushes when the agent becomes idle", () => {
+  const timers = new ManualTimers();
+  let idle = false;
+  let flushes = 0;
+  const scheduler = createCompletionBatchScheduler(() => flushes++, {
+    timers,
+    isIdle: () => idle,
+  });
+
+  scheduler.schedule();
+  timers.advance(COMPLETION_BATCH_QUIET_MS);
+  assert.equal(flushes, 0);
+  idle = true;
+  assert.equal(scheduler.notifyIdle(), true);
+  assert.equal(flushes, 1);
+});
+
+test("arrivals after a busy quiet expiry start a fresh quiet window", () => {
+  const timers = new ManualTimers();
+  let idle = false;
+  let flushes = 0;
+  const scheduler = createCompletionBatchScheduler(() => flushes++, {
+    timers,
+    isIdle: () => idle,
+  });
+
+  scheduler.schedule();
+  timers.advance(COMPLETION_BATCH_QUIET_MS);
+  assert.equal(flushes, 0);
+
+  timers.advance(500);
+  scheduler.schedule();
+  idle = true;
+  assert.equal(scheduler.notifyIdle(), true);
+  assert.equal(flushes, 0);
+  timers.advance(COMPLETION_BATCH_QUIET_MS - 1);
+  assert.equal(flushes, 0);
+  timers.advance(1);
+  assert.equal(flushes, 1);
+});
+
+test("the maximum hold flushes even while the batch remains busy", () => {
+  const timers = new ManualTimers();
+  let flushes = 0;
+  const scheduler = createCompletionBatchScheduler(() => flushes++, {
+    timers,
+    isIdle: () => false,
+  });
+
+  scheduler.schedule();
+  timers.advance(COMPLETION_BATCH_QUIET_MS);
+  assert.equal(flushes, 0);
+  timers.advance(COMPLETION_BATCH_MAX_WAIT_MS - COMPLETION_BATCH_QUIET_MS);
+  assert.equal(flushes, 1);
+});
+
 test("clearing completion batching invalidates every pending deadline", () => {
   const timers = new ManualTimers();
   let flushes = 0;

--- a/packages/pi-background-terminals/docs/implementation-guide.md
+++ b/packages/pi-background-terminals/docs/implementation-guide.md
@@ -305,11 +305,12 @@ from the failed batch for a later `agent_settled` retry. Interactive mode does
 not write that failure through `console.error`, which would corrupt the active
 TUI frame; non-TUI modes retain the diagnostic.
 
-Idle settlements schedule delivery instead of sending immediately. The
-scheduler waits for a 1,000 ms quiet period after the latest admitted result and
-holds the first result for at most 3,000 ms. New results slide only the quiet
-deadline; they never extend the maximum hold. A busy agent keeps results in the
-map until `agent_settled` starts the same bounded window. Session shutdown
+Every unconsumed settlement starts or slides a 1,000 ms quiet deadline while the
+first result keeps one fixed 3,000 ms maximum deadline. If quiet expires while
+the agent is busy, the scheduler holds that expiry without cancelling the
+maximum. `agent_settled` flushes the held group when no later result arrived. A
+later result instead clears the held expiry and starts its own full quiet window;
+settling the agent cannot flush that newer result early. Session shutdown
 cancels both deadlines before clearing the map.
 
 The timer group detaches before delivery, so a settlement triggered during a
@@ -390,8 +391,10 @@ batch:  32 KiB total content
 ```
 
 A multi-terminal batch divides the aggregate budget across its results and
-retains each status prefix before bounded output. Every model-visible output
-remains bounded even if a child is a firehose.
+retains each status prefix before bounded output. The truncation marker is
+charged to the same per-result share, including when an artificial share is
+shorter than the full marker. Every model-visible output remains bounded even if
+a child is a firehose.
 
 ## 12. Spill files and backpressure
 
@@ -572,8 +575,9 @@ The package test suite covers:
 - quick completion without a duplicate follow-up;
 - yielded completion with exactly one automatic delivery;
 - sliding quiet and maximum-hold batching deadlines, including cancellation;
+- busy-held quiet expiry, later-arrival rearming, and maximum-hold delivery;
 - synchronized yielded completions sharing one follow-up;
-- unchanged singleton messages and UTF-8-bounded aggregate content;
+- unchanged singleton messages and strict UTF-8 aggregate and marker budgets;
 - safe pre-spawn foreground fallback;
 - non-zero commands executing only once, without fallback retry;
 - Pi managed-bin `PATH`, session environment, and command-prefix preservation;

--- a/packages/pi-background-terminals/index.ts
+++ b/packages/pi-background-terminals/index.ts
@@ -307,9 +307,14 @@ export function createBackgroundTerminalsExtension(
         for (const snap of snaps) resultDelivery.defer(snap);
       }
     };
-    const resultBatchScheduler = createCompletionBatchScheduler(flushResults);
+    const resultBatchScheduler = createCompletionBatchScheduler(flushResults, {
+      isIdle: () => sessionContext?.isIdle() === true,
+    });
     const scheduleResultFlush = () => {
       if (resultDelivery.size() > 0) resultBatchScheduler.schedule();
+    };
+    const settleResultFlush = () => {
+      if (!resultBatchScheduler.notifyIdle()) scheduleResultFlush();
     };
 
     const onSettled = (snap: TerminalSnapshot, consumed: boolean) => {
@@ -326,7 +331,7 @@ export function createBackgroundTerminalsExtension(
         stdout: { ...snap.stdout },
         stderr: { ...snap.stderr },
       });
-      if (sessionContext?.isIdle()) scheduleResultFlush();
+      scheduleResultFlush();
     };
 
     pi.on("session_start", (_event, ctx) => {
@@ -340,10 +345,10 @@ export function createBackgroundTerminalsExtension(
     // user/follow-up run rather than per turn.
     pi.on("agent_start", resetTerminalLogBudget);
 
-    // Start or slide one bounded batch when the agent settles. Together with
-    // the idle path above and Map-keyed delivery, this preserves exactly-once
-    // admission while coalescing terminals that finish close together.
-    pi.on("agent_settled", scheduleResultFlush);
+    // Release a quiet expiry held while the agent was busy. A later arrival
+    // rearms quiet first, so settling the agent cannot flush that new result
+    // before its own quiet window. A delivery retry starts a fresh group.
+    pi.on("agent_settled", settleResultFlush);
 
     // /new, /resume, /fork, /reload, and quit all emit session_shutdown for
     // the old extension instance. Processes never survive a session

--- a/packages/pi-background-terminals/prompt.test.ts
+++ b/packages/pi-background-terminals/prompt.test.ts
@@ -16,6 +16,7 @@ import {
   MAX_COMPLETION_BATCH_CONTENT_BYTES,
   TERMINAL_LOG_READ_PROMPT_SNIPPET,
   TERMINAL_LOG_READ_TOOL_DESCRIPTION,
+  truncateUtf8WithMarker,
 } from "./src/prompt.ts";
 
 test("bash metadata states the managed-shell contract concisely", () => {
@@ -287,6 +288,14 @@ test("completion message reports kill vs exit", () => {
 test("an isolated completion keeps the existing message shape", () => {
   const terminal = snap();
   assert.equal(buildTerminalResultBatchMessage([terminal]), buildTerminalResultMessage(terminal));
+});
+
+test("the truncation marker stays inside an arbitrarily small UTF-8 budget", () => {
+  const maximumBytes = 17;
+  const truncated = truncateUtf8WithMarker("界".repeat(100), maximumBytes);
+
+  assert.ok(Buffer.byteLength(truncated) <= maximumBytes);
+  assert.doesNotMatch(truncated, /�/);
 });
 
 test("batched completions retain every terminal summary within one bounded message", () => {

--- a/packages/pi-background-terminals/src/completion-batcher.ts
+++ b/packages/pi-background-terminals/src/completion-batcher.ts
@@ -9,6 +9,8 @@ export interface CompletionBatchTimers {
 export interface CompletionBatchScheduler {
   /** Start a batch or slide its quiet deadline without extending its maximum hold. */
   schedule(): void;
+  /** Resolve a quiet expiry held while busy. Returns whether a group was active. */
+  notifyIdle(): boolean;
   /** Cancel every pending deadline. Stale timer callbacks become no-ops. */
   clear(): void;
 }
@@ -34,16 +36,19 @@ export function createCompletionBatchScheduler(
     readonly timers?: CompletionBatchTimers;
     readonly quietMs?: number;
     readonly maxWaitMs?: number;
+    readonly isIdle?: () => boolean;
   } = {},
 ): CompletionBatchScheduler {
   const timers = options.timers ?? systemTimers;
   const quietMs = options.quietMs ?? COMPLETION_BATCH_QUIET_MS;
   const maxWaitMs = options.maxWaitMs ?? COMPLETION_BATCH_MAX_WAIT_MS;
+  const isIdle = options.isIdle ?? (() => true);
   let nextGroupGeneration = 0;
   let activeGroupGeneration = 0;
   let nextTimerGeneration = 0;
   let quietTimer: TimerRegistration | undefined;
   let maximumTimer: TimerRegistration | undefined;
+  let quietExpiredWhileBusy = false;
 
   const cancelQuietTimer = () => {
     if (!quietTimer) return;
@@ -59,6 +64,7 @@ export function createCompletionBatchScheduler(
 
   const detachGroup = () => {
     activeGroupGeneration = 0;
+    quietExpiredWhileBusy = false;
     cancelQuietTimer();
     cancelMaximumTimer();
   };
@@ -75,6 +81,11 @@ export function createCompletionBatchScheduler(
       registration.groupGeneration !== groupGeneration ||
       registration.timerGeneration !== timerGeneration
     ) {
+      return;
+    }
+    if (kind === "quiet" && !isIdle()) {
+      quietTimer = undefined;
+      quietExpiredWhileBusy = true;
       return;
     }
     // Detach before delivery so a synchronous settlement starts a new group.
@@ -99,8 +110,18 @@ export function createCompletionBatchScheduler(
         activeGroupGeneration = ++nextGroupGeneration;
         armTimer("maximum", activeGroupGeneration, maxWaitMs);
       }
+      // A later arrival supersedes a quiet expiry held while busy.
+      quietExpiredWhileBusy = false;
       cancelQuietTimer();
       armTimer("quiet", activeGroupGeneration, quietMs);
+    },
+    notifyIdle() {
+      const hadActiveGroup = activeGroupGeneration !== 0;
+      if (hadActiveGroup && quietExpiredWhileBusy && isIdle()) {
+        detachGroup();
+        onFlush();
+      }
+      return hadActiveGroup;
     },
     clear() {
       detachGroup();

--- a/packages/pi-background-terminals/src/prompt.ts
+++ b/packages/pi-background-terminals/src/prompt.ts
@@ -258,19 +258,24 @@ export function buildTerminalResultMessage(snap: TerminalSnapshot) {
   );
 }
 
-function truncateUtf8WithMarker(value: string, maximumBytes: number) {
-  if (Buffer.byteLength(value) <= maximumBytes) return value;
-  const marker = "\n[output truncated; use /ps for complete logs]";
-  const contentBudget = Math.max(0, maximumBytes - Buffer.byteLength(marker));
+function truncateUtf8(value: string, maximumBytes: number) {
   let result = "";
   let usedBytes = 0;
   for (const character of value) {
     const characterBytes = Buffer.byteLength(character);
-    if (usedBytes + characterBytes > contentBudget) break;
+    if (usedBytes + characterBytes > maximumBytes) break;
     result += character;
     usedBytes += characterBytes;
   }
-  return result + marker;
+  return result;
+}
+
+export function truncateUtf8WithMarker(value: string, maximumBytes: number) {
+  const byteLimit = Math.max(0, maximumBytes);
+  if (Buffer.byteLength(value) <= byteLimit) return value;
+  const marker = truncateUtf8("\n[output truncated; use /ps for complete logs]", byteLimit);
+  const contentBudget = byteLimit - Buffer.byteLength(marker);
+  return truncateUtf8(value, contentBudget) + marker;
 }
 
 /** One follow-up for terminal completions that settle in the same quiet window. */


### PR DESCRIPTION
The two non-blocking completion-batching edge cases identified in #18 are now covered.

A quiet deadline that expires while the agent is busy stays held under the original three-second maximum. If another result arrives before the agent settles, that held expiry is cleared and the newer result receives its full one-second quiet window instead of flushing early.

UTF-8 truncation now charges the marker against the same per-result share, even when that share is shorter than the full marker, so the aggregate 32 KiB limit remains strict.

Verified with the package's 110-test suite: 109 passed and one platform test skipped. Changesets status and package type-check also passed.

Ready for review.