### PR TITLE
feat(pi-web-search): OpenAI detection visibility, /websearch-order, config under ~/.pi

### DIFF
--- a/.changeset/openai-detection-visibility.md
+++ b/.changeset/openai-detection-visibility.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-web-search": patch
+---
+
+Fix OpenAI/Codex detection being invisible: add a `/web-search` status command (provider credentials + active search/fetch chains), list openai as a read-only auto-detected row in `/websearch-auth`, and warn when the stored `openai-codex` token has expired (re-run `/login`) instead of silently skipping it.

--- a/.changeset/openai-internal-source-attribution.md
+++ b/.changeset/openai-internal-source-attribution.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-web-search": patch
+---
+
+Attribute answer-only OpenAI searches to their internal source: when the Responses API answers from an internal tool (e.g. `oai-weather`, `oai-finance`) with no web URLs, the tool result now says `answer via openai (internal source: oai-weather)` and notes the internal source for the model, instead of showing a bare `0 results`.

--- a/.changeset/websearch-order-command.md
+++ b/.changeset/websearch-order-command.md
@@ -2,6 +2,6 @@
 "@tian.zuo/pi-web-search": minor
 ---
 
-Add `/websearch-order`: an interactive grab-and-move dialog to reorder the search fallback chain (enter grab, ↑↓ move, enter save, esc cancel). Saves the result as `searchProvider` (head) + `searchOrder` in `~/.pi/web-search.json`; `/web-search` and `/websearch-auth` now point to it for reordering. The config file now lives at `~/.pi/web-search.json` (the old `~/.config/pi-web-search/config.json` is still read if present, and migrates on the next save).
+Add `/websearch-order`: an interactive grab-and-move dialog to reorder the search fallback chain (enter grab, ↑↓ move, enter save, esc cancel). Saves the complete `searchOrder` in `~/.pi/web-search.json`; unconfigured providers keep their chosen position but are skipped until credentials become available. `/web-search` and `/websearch-auth` now point to it for reordering. The config file now lives at `~/.pi/web-search.json` (the old `~/.config/pi-web-search/config.json` is still read if present, and migrates on the next save).
 
 Also add `openai.reasoning` (`"low" | "medium" | "high"`, or `OPENAI_SEARCH_REASONING`): sets the Responses API reasoning effort for search calls. By default the effort now follows the session's pi thinking level (mapped through the model registry); with neither set the model default (medium) applies. `"low"` is ~40% faster in practice and usually plenty for search.

--- a/.changeset/websearch-order-command.md
+++ b/.changeset/websearch-order-command.md
@@ -1,0 +1,7 @@
+---
+"@tian.zuo/pi-web-search": minor
+---
+
+Add `/websearch-order`: an interactive grab-and-move dialog to reorder the search fallback chain (enter grab, ↑↓ move, enter save, esc cancel). Saves the result as `searchProvider` (head) + `searchOrder` in `~/.pi/web-search.json`; `/web-search` and `/websearch-auth` now point to it for reordering. The config file now lives at `~/.pi/web-search.json` (the old `~/.config/pi-web-search/config.json` is still read if present, and migrates on the next save).
+
+Also add `openai.reasoning` (`"low" | "medium" | "high"`, or `OPENAI_SEARCH_REASONING`): sets the Responses API reasoning effort for search calls. By default the effort now follows the session's pi thinking level (mapped through the model registry); with neither set the model default (medium) applies. `"low"` is ~40% faster in practice and usually plenty for search.

--- a/packages/pi-web-search/README.md
+++ b/packages/pi-web-search/README.md
@@ -1,118 +1,148 @@
 # @tian.zuo/pi-web-search
 
-Release notes: [changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-web-search/CHANGELOG.md) · [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)
+Web search and web fetch for the [pi coding agent](https://pi.dev). Two tools,
+six providers plus a built-in keyless fetcher, automatic fallback — no single
+point of failure. **Works with zero configuration** thanks to Firecrawl's
+keyless tier (search + fetch, no signup).
 
-Web search and web fetch for the [pi coding agent](https://pi.dev). Two tools, six providers plus a built-in keyless fetcher, automatic fallback — no single point of failure. **Works with zero configuration** thanks to Firecrawl's keyless tier (search + fetch, no signup).
-
-> **Token-light by design.** The whole extension adds **196 characters** of model-facing text — two tool descriptions of one sentence each. For comparison, [pi-web-access](https://www.npmjs.com/package/pi-web-access) spends ≈3,200 characters on its `web_search` tool alone (1,853-char description + parameter guidance) — **~16× our entire prompt surface**, across 4 tools vs our 2. All the routing intelligence (fallback orders, keyless ladders, quota handling) lives in extension code, not in the prompt, so the model spends its attention on your code instead of reading tool manuals.
-
-## Install
-
-```bash
-pi install npm:@tian.zuo/pi-web-search
-```
+> **Token-light by design.** The whole extension adds **196 characters** of
+> model-facing text — two tool descriptions of one sentence each. For
+> comparison, [pi-web-access](https://www.npmjs.com/package/pi-web-access)
+> spends ≈3,200 characters on its `web_search` tool alone (1,853-char
+> description + parameter guidance) — **~16× our entire prompt surface**, across
+> 4 tools vs our 2. All the routing intelligence (fallback orders, keyless
+> ladders, quota handling) lives in extension code, not in the prompt, so the
+> model spends its attention on your code instead of reading tool manuals.
 
 ## Configuration
 
-**Easiest — `/websearch-auth`** inside a pi session: pick a provider, paste your key, done. Keys are stored in pi's own auth file (`~/.pi/agent/auth.json`, same place as `/login` credentials) and never in plain project files. Each option shows its state in pi's login style — green `✓ env: EXA_API_KEY` when an env var is set, green `✓ auth: fc-1…ab3d` for a stored key, `• unconfigured` otherwise. Ollama asks for a base URL (empty = `localhost:11434`, saved to `~/.config/pi-web-search/config.json`) and an optional API key. Empty input removes a stored value; `esc` cancels.
+**Easiest — `/websearch-auth` + `/websearch-order`** inside a pi session.
 
-**Where to get a key** — create an account, then generate an API key:
+`/websearch-auth`: pick a provider, paste your key, done — or skip it
+entirely: keyless Firecrawl is the default, no key needed.
 
-| Provider    | Sign up / API key |
-| :---------- | :-------------------------------------------------------------------------------- |
-| Exa         | https://dashboard.exa.ai/api-keys |
-| Firecrawl   | https://www.firecrawl.dev/app/api-keys — *optional*: works without a key (keyless, 1,000 free credits/mo) |
-| Tavily      | https://app.tavily.com |
-| Monid (TinyFish) | https://app.monid.ai/access/api-keys |
-| OpenAI      | https://platform.openai.com/api-keys (or just stay logged in with `/login`) |
-| Ollama      | https://ollama.com — run locally, no key needed |
+```text
+ Configure provider:
+
+ → openai    ✓ auto: pi login (openai-codex)
+   exa       • unconfigured
+   firecrawl ✓ keyless (1,000 free credits/mo)
+   tavily    • unconfigured
+   monid     • unconfigured
+   ollama    • unconfigured (default localhost:11434)
+```
+
+`/websearch-order`: grab a provider with `enter`, move it with `↑↓`, `enter` to
+save — or do nothing and the default chain (keyless Firecrawl first) applies:
+
+```text
+ Search provider order
+
+ ↑↓ navigate • enter grab • esc cancel
+
+ → openai    ✓ ~/.pi/agent/auth.json (openai-codex)
+   exa       ✓ EXA_API_KEY env
+   firecrawl ✓ FIRECRAWL_API_KEY env (overflow after keyless credits)
+   ollama    ✓ default localhost
+   tavily    • unconfigured
+   monid     • unconfigured
+```
 
 **Manual** — env variables:
 
-| Variable                         | Unlocks                                                                               |
-| :------------------------------- | :------------------------------------------------------------------------------------ |
-| `OPENAI_API_KEY`                 | OpenAI search — your pi Codex/OpenAI login is used first; this key is only a fallback |
-| `EXA_API_KEY`                    | Exa search + fetch                                                                    |
+| Variable                         | Unlocks                                                                                                                                    |
+| :------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPENAI_API_KEY`                 | OpenAI search — your pi Codex/OpenAI login is used first; this key is only a fallback                                                      |
+| `EXA_API_KEY`                    | Exa search + fetch                                                                                                                         |
 | `FIRECRAWL_API_KEY`              | Firecrawl search + fetch — optional: without a key, the keyless tier is used (1,000 free credits/mo; set `FIRECRAWL_KEYLESS=0` to disable) |
-| `TAVILY_API_KEY`                 | Tavily search **and** fetch — one key unlocks both tools (fetch uses Tavily Extract)  |
-| `MONID_API_KEY`                  | Monid search + fetch — TinyFish endpoints via api.monid.ai, $0/call                   |
-| `OLLAMA_HOST` / `OLLAMA_API_KEY` | Ollama (default `http://localhost:11434`)                                             |
+| `TAVILY_API_KEY`                 | Tavily search **and** fetch — one key unlocks both tools (fetch uses Tavily Extract)                                                       |
+| `MONID_API_KEY`                  | Monid search + fetch — TinyFish endpoints via api.monid.ai, $0/call                                                                        |
+| `OLLAMA_HOST` / `OLLAMA_API_KEY` | Ollama (default `http://localhost:11434`)                                                                                                  |
 
-…or `~/.config/pi-web-search/config.json` for non-secret options (base URLs, preferred provider, fallback order):
+…or `~/.pi/web-search.json` for non-secret options. Every key is optional — omit
+what you don't need:
 
-```json
-{
-    "searchProvider": "exa",
-    "fetchProvider": "firecrawl",
-    "ollama": { "baseUrl": "http://localhost:11434" }
-}
-```
-
-API keys themselves live in `~/.pi/agent/auth.json` under `websearch-exa` / `websearch-firecrawl` / `websearch-tavily` / `websearch-monid` / `websearch-ollama` (manageable via `/websearch-auth`).
-
-### Firecrawl keyless tier
-
-Firecrawl works without any API key (their [keyless launch](https://www.firecrawl.dev/blog/firecrawl-keyless-launch)): 1,000 free credits/month, no account. This is what makes the extension zero-config. How the ladder works:
-
-- **Keyless first** — free credits are consumed before anything paid.
-- **Your key as overflow** — if a Firecrawl key is configured (env or `/websearch-auth`) and the keyless credits run out, requests automatically switch to your key for the rest of the session.
-- **Opt out** — set `FIRECRAWL_KEYLESS=0` (env) or `"firecrawl": { "keyless": false }` in `~/.config/pi-web-search/config.json` to only ever use a key. Note keyless sends fetched URLs to firecrawl.dev; the opt-out is there if you don't want that without an account.
-
-### Configuring the fallback
-
-Nothing to configure by default — every call automatically tries all credentialed providers in the canonical order. Two levels of control:
-
-**1. Pick the starting provider** — `searchProvider` / `fetchProvider`:
-
-- `searchProvider` — `"openai"` | `"exa"` | `"tavily"` | `"firecrawl"` | `"ollama"` | `"monid"`
-- `fetchProvider` — `"firecrawl"` | `"exa"` | `"tavily"` | `"ollama"` | `"monid"` | `"direct"`
-
-**2. Define the whole priority sequence** — `searchOrder` / `fetchOrder` arrays:
+A maximal example (defaults shown for `searchOrder`/`fetchOrder` are just
+illustration — the real default is the canonical order filtered by what's
+credentialed):
 
 ```json
 {
-    "searchOrder": ["tavily", "exa", "firecrawl"],
-    "fetchOrder": ["exa", "tavily", "direct"]
+  "searchProvider": "exa",
+  "fetchProvider": "firecrawl",
+  "searchOrder": ["tavily", "exa", "firecrawl"],
+  "fetchOrder": ["exa", "tavily", "direct"],
+  "openai": {
+    "model": "gpt-5.6-luna",
+    "baseUrl": "https://api.openai.com/v1/responses",
+    "systemPrompt": "Search the web. Answer concisely and accurately; cite sources with Markdown links.",
+    "reasoning": "low"
+  },
+  "exa": { "baseUrl": "https://api.exa.ai" },
+  "firecrawl": { "baseUrl": "https://api.firecrawl.dev/v2", "keyless": true },
+  "tavily": { "baseUrl": "https://api.tavily.com" },
+  "ollama": { "baseUrl": "http://localhost:11434" },
+  "monid": { "baseUrl": "https://api.monid.ai" }
 }
 ```
 
-Rules for both levels:
+`openai.reasoning` is optional: without it the search call follows the
+session's thinking level (via pi's model registry), falling back to the model
+default; set `"low"` to always search ~40% faster.
 
-- Listed first = tried first; a requested/configured single provider still jumps the queue ahead of `searchOrder` / `fetchOrder`.
-- Entries without valid credentials (and unknown names) are silently skipped.
-- Credentialed providers you didn't list still join the end of the chain as backup — you only ever reorder, never lose fallbacks.
-- `"direct"` can be listed in `fetchOrder` to pin the keyless fetch as an early step.
+Prefer the interactive route? `/websearch-order` writes `searchProvider` +
+`searchOrder` for you, and `/websearch-auth` manages Ollama's base URL — no
+hand-editing needed.
 
-With Exa, Tavily, and Firecrawl keys present, the config above gives `web_search` the chain `tavily → exa → firecrawl → openai → ollama → monid` (the `openai` hop appears only when a pi login or `OPENAI_API_KEY` exists; `monid` only when `MONID_API_KEY` is set) and `web_fetch` the chain `exa → tavily → direct → firecrawl` (`ollama` joins when configured). Without a key, keyless Firecrawl still occupies Firecrawl's slot — so `searchOrder` entries for `firecrawl` are always honored.
+## Commands
 
-No keys at all? Search and fetch both start at **keyless firecrawl**, then fall back to Ollama (search) and **direct fetch** (fetch).
+| Command            | Description                                                                                                                                                                 |
+| :----------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/web-search`      | Show provider status: detected credentials (incl. auto-detected OpenAI) and the active search/fetch fallback chains                                                         |
+| `/websearch-order` | Interactively reorder the search fallback chain: enter grab • ↑↓ move • enter save • esc cancel (saved as `searchProvider` + `searchOrder`)                                 |
+| `/websearch-auth`  | Interactive credential setup (Exa / Firecrawl / Tavily / Monid / Ollama). OpenAI is listed read-only — it's auto-detected from your pi `/login` (Codex) or `OPENAI_API_KEY` |
+| `/websearch-usage` | Show this session's per-provider usage (calls, failures, avg latency), providers on cooldown/blocked, and your Monid wallet balance with recent run costs                   |
 
-### What each provider unlocks
+## The tools
 
-| Provider  | Sign up |        `web_search`         | `web_fetch` |
-| :-------- | :------------------------- | :-------------------------: | :---------: |
-| OpenAI    | [platform.openai.com](https://platform.openai.com/api-keys) |     ✓ (pi login or key)     |      —      |
-| Exa       | [dashboard.exa.ai](https://dashboard.exa.ai/api-keys) |              ✓              |      ✓      |
-| Tavily    | [app.tavily.com](https://app.tavily.com) | ✓ (with synthesized answer) | ✓ (Extract) |
-| Firecrawl | [firecrawl.dev](https://www.firecrawl.dev/app/api-keys) | ✓ (keyless: 1k credits/mo) | ✓ (keyless) |
-| Monid     | [app.monid.ai](https://app.monid.ai/access/api-keys) | ✓ (TinyFish, $0/call) | ✓ (batch, $0/call) |
-| Ollama    | [ollama.com](https://ollama.com) |              ✓              |      ✓      |
-| Direct    | — (built-in)                |              —              | ✓ (keyless) |
+### `web_search`
 
-## How the fallback chain works
+Queries live web sources and returns ranked results with links and snippets.
+OpenAI and Tavily additionally return a synthesized summary (shown as
+`## Summary`).
 
-The chain is built automatically from whichever providers have credentials:
+- **Firecrawl** (default): live SERP results, keyed or keyless (1,000 free
+  credits/mo without a key; `FIRECRAWL_KEYLESS=0` to opt out).
+- **OpenAI**: server-side web search via the Responses API with a simple prompt;
+  uses your active pi login (`openai-codex` / `openai`) first, falling back to
+  `OPENAI_API_KEY`.
+- **Exa / Tavily / Firecrawl / Monid / Ollama**: native API calls. Exa, Tavily,
+  Firecrawl, and Monid keys each power **both** search and fetch.
+- **Monid** (TinyFish via [api.monid.ai](https://monid.ai), $0/call):
+  browser-rendered search — never-cached results with snippets and dates.
 
-- **search:** `firecrawl → openai → exa → tavily → ollama → monid`
-- **fetch:** `firecrawl → exa → tavily → ollama → monid → direct`
+### `web_fetch`
 
-Keyless Firecrawl (real browser, never cached) is the default first option for both tools. Monid (TinyFish) is intentionally the **last** credentialed fallback, and keyless `direct` remains the absolute final fetch fallback. Since Firecrawl works without a key, the extension is fully functional out of the box; add keys to prefer higher-limit providers.
+Reads web pages as clean Markdown.
 
-Every call starts at your preferred provider and walks the chain until one succeeds:
+- **Firecrawl** (`/v2/scrape`, `onlyMainContent` on): keyed or
+  [keyless](https://www.firecrawl.dev/blog/firecrawl-keyless-launch) — a real
+  browser renders the page, so it succeeds where plain HTTP clients are
+  bot-blocked or starved of JavaScript. **Exa** (`/contents`), **Tavily**
+  (`/extract`, markdown format), **Monid** (TinyFish `/fetch`: real-browser
+  rendering, clean Markdown), **Ollama** (`/api/web_fetch`): native scrapers.
+- **Direct fetch** (the keyless fallback): plain HTTP GET, then main-content
+  extraction with [Defuddle](https://github.com/kepano/defuddle) (the engine
+  behind Obsidian Web Clipper) — navigation, sidebars, and cookie banners are
+  removed before Markdown conversion. If Defuddle finds no usable main content
+  (SPAs, tiny fragments), it falls back to a built-in regex-based converter.
+  Pass `raw: true` to get the untouched response body instead.
 
-- **Quota failures** (402/403, out of credits, usage limits) skip that provider **for the rest of the session** — the next call starts directly at the next healthy provider.
-- **Rate limits** (429) only apply a short 2-minute cooldown.
-- Successful responses report which providers they fell back from.
+## License
+
+MIT
+
+## Workflow
 
 ```mermaid
 flowchart TB
@@ -129,31 +159,7 @@ flowchart TB
     Next2 -- "no" --> Fail
 ```
 
-## Commands
+## Release notes
 
-| Command           | Description                                                      |
-| :---------------- | :--------------------------------------------------------------- |
-| `/websearch-auth` | Interactive credential setup (Exa / Firecrawl / Tavily / Monid / Ollama) |
-| `/websearch-usage` | Show this session's per-provider usage (calls, failures, avg latency), providers on cooldown/blocked, and your Monid wallet balance with recent run costs |
-
-## The tools
-
-### `web_search`
-
-Queries live web sources and returns ranked results with links and snippets. OpenAI and Tavily additionally return a synthesized summary (shown as `## Summary`).
-
-- **Firecrawl** (default): live SERP results, keyed or keyless — see the keyless tier above.
-- **OpenAI**: server-side web search via the Responses API with a simple prompt; uses your active pi login (`openai-codex` / `openai`) first, falling back to `OPENAI_API_KEY`.
-- **Exa / Tavily / Firecrawl / Monid / Ollama**: native API calls. Exa, Tavily, Firecrawl, and Monid keys each power **both** search and fetch.
-- **Monid** (TinyFish via [api.monid.ai](https://monid.ai), $0/call): browser-rendered search — never-cached results with snippets and dates.
-
-### `web_fetch`
-
-Reads web pages as clean Markdown.
-
-- **Firecrawl** (`/v2/scrape`, `onlyMainContent` on): keyed or [keyless](https://www.firecrawl.dev/blog/firecrawl-keyless-launch) — a real browser renders the page, so it succeeds where plain HTTP clients are bot-blocked or starved of JavaScript. **Exa** (`/contents`), **Tavily** (`/extract`, markdown format), **Monid** (TinyFish `/fetch`: real-browser rendering, clean Markdown), **Ollama** (`/api/web_fetch`): native scrapers.
-- **Direct fetch** (the keyless fallback): plain HTTP GET, then main-content extraction with [Defuddle](https://github.com/kepano/defuddle) (the engine behind Obsidian Web Clipper) — navigation, sidebars, and cookie banners are removed before Markdown conversion. If Defuddle finds no usable main content (SPAs, tiny fragments), it falls back to a built-in regex-based converter. Pass `raw: true` to get the untouched response body instead.
-
-## License
-
-MIT
+[changelog](https://github.com/TianZuo555/pi-extensions/blob/main/packages/pi-web-search/CHANGELOG.md)
+· [GitHub releases](https://github.com/TianZuo555/pi-extensions/releases)

--- a/packages/pi-web-search/README.md
+++ b/packages/pi-web-search/README.md
@@ -90,7 +90,7 @@ credentialed):
 session's thinking level (via pi's model registry), falling back to the model
 default; set `"low"` to always search ~40% faster.
 
-Prefer the interactive route? `/websearch-order` writes `searchProvider` +
+Prefer the interactive route? `/websearch-order` writes the complete
 `searchOrder` for you, and `/websearch-auth` manages Ollama's base URL — no
 hand-editing needed.
 
@@ -99,7 +99,7 @@ hand-editing needed.
 | Command            | Description                                                                                                                                                                 |
 | :----------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/web-search`      | Show provider status: detected credentials (incl. auto-detected OpenAI) and the active search/fetch fallback chains                                                         |
-| `/websearch-order` | Interactively reorder the search fallback chain: enter grab • ↑↓ move • enter save • esc cancel (saved as `searchProvider` + `searchOrder`)                                 |
+| `/websearch-order` | Interactively reorder the search fallback chain: enter grab • ↑↓ move • enter save • esc cancel (saved as `searchOrder`)                                                    |
 | `/websearch-auth`  | Interactive credential setup (Exa / Firecrawl / Tavily / Monid / Ollama). OpenAI is listed read-only — it's auto-detected from your pi `/login` (Codex) or `OPENAI_API_KEY` |
 | `/websearch-usage` | Show this session's per-provider usage (calls, failures, avg latency), providers on cooldown/blocked, and your Monid wallet balance with recent run costs                   |
 

--- a/packages/pi-web-search/index.ts
+++ b/packages/pi-web-search/index.ts
@@ -1,14 +1,26 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   AUTH_IDS,
+  SEARCH_PROVIDER_ORDER,
+  getProviderStatuses,
+  inspectOpenAICodexAuth,
   loadProviderKey,
   loadStoredConfig,
+  resolveExaConfig,
+  resolveFetchChain,
+  resolveFirecrawlConfig,
+  resolveMonidConfig,
+  resolveOllamaConfig,
+  resolveOpenAIConfig,
+  resolveSearchChain,
+  resolveTavilyConfig,
   saveStoredConfig,
   writePiAuthKey,
 } from "./lib/config.ts";
 import { getMonidWallet, listMonidRuns } from "./lib/monid.ts";
-import type { WebSearchConfig } from "./lib/types.ts";
+import type { WebSearchConfig, SearchProviderName } from "./lib/types.ts";
 import { registerTools } from "./lib/tools.ts";
+import { promptProviderOrder } from "./src/order-ui.ts";
 import {
   createWebSearchRuntime,
   runWebSearch,
@@ -20,6 +32,7 @@ const OLLAMA_DEFAULT_URL = "http://localhost:11434";
 const PI_AUTH_FILE = "~/.pi/agent/auth.json";
 
 const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
 const RESET = "\x1b[0m";
 
 function maskKey(key: string | undefined): string {
@@ -87,6 +100,57 @@ function providerLine(name: KeyProvider | "ollama", config: WebSearchConfig): st
   return `${GREEN}${label}✓ auth: ${url}${key}${RESET}`;
 }
 
+/** Read-only openai row: credentials are auto-detected (pi /login codex,
+ * OPENAI_API_KEY, config file) and never configured through this command. */
+function openaiLine(config: WebSearchConfig): string {
+  const label = "openai".padEnd(10);
+  const codex = inspectOpenAICodexAuth();
+  if (codex.state === "fresh") {
+    return `${GREEN}${label}✓ auto: pi login (openai-codex)${RESET}`;
+  }
+  const resolved = resolveOpenAIConfig(undefined, config);
+  if (resolved) {
+    return `${GREEN}${label}✓ auto: ${resolved.source}${RESET}`;
+  }
+  if (codex.state === "expired") {
+    return `${YELLOW}${label}• codex login expired — re-run /login${RESET}`;
+  }
+  return `${label}• auto: /login with OpenAI or set OPENAI_API_KEY`;
+}
+
+function codexExpiryHint(): string[] {
+  return inspectOpenAICodexAuth().state === "expired"
+    ? [
+        "",
+        "⚠ your openai-codex token in ~/.pi/agent/auth.json is expired —",
+        "  re-run /login (OpenAI Codex) to refresh it.",
+      ]
+    : [];
+}
+
+/** One-line credential/config summary for the order dialog. */
+function searchProviderDetail(id: SearchProviderName, config: WebSearchConfig): string {
+  switch (id) {
+    case "openai": {
+      const resolved = resolveOpenAIConfig(undefined, config);
+      if (resolved) return resolved.source;
+      return inspectOpenAICodexAuth().state === "expired"
+        ? "codex login expired — re-run /login"
+        : "not detected (/login or OPENAI_API_KEY)";
+    }
+    case "exa":
+      return resolveExaConfig(config)?.source ?? "unconfigured";
+    case "tavily":
+      return resolveTavilyConfig(config)?.source ?? "unconfigured";
+    case "firecrawl":
+      return resolveFirecrawlConfig(config)?.source ?? "unconfigured";
+    case "monid":
+      return resolveMonidConfig(config)?.source ?? "unconfigured";
+    case "ollama":
+      return resolveOllamaConfig(config).source;
+  }
+}
+
 export default function webSearchExtension(pi: ExtensionAPI): void {
   let runtime: WebSearchRuntimeInstance | undefined;
   const getRuntime = () => (runtime ??= createWebSearchRuntime());
@@ -152,9 +216,82 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
     },
   });
 
+  pi.registerCommand("web-search", {
+    description:
+      "Show web search provider status: detected credentials and the active search/fetch chains",
+    handler: async (_args, ctx) => {
+      const config = loadStoredConfig();
+      const lines: string[] = [
+        "Web search providers",
+        "",
+        `search chain: ${resolveSearchChain(undefined, config).join(" → ")}`,
+        `fetch chain:  ${resolveFetchChain(undefined, config).join(" → ")}`,
+        "",
+      ];
+      for (const s of getProviderStatuses(ctx)) {
+        const label = s.name.padEnd(10);
+        if (s.configured) {
+          const model = s.model ? ` · ${s.model}` : "";
+          lines.push(`${GREEN}${label}✓ ${s.source ?? "configured"}${model}${RESET}`);
+        } else {
+          lines.push(`${label}• unconfigured`);
+        }
+      }
+      lines.push(...codexExpiryHint());
+      lines.push(
+        "",
+        "openai is auto-detected (pi /login with OpenAI, or OPENAI_API_KEY) — it is not",
+        "listed as configurable in /websearch-auth. It ranks after keyless Firecrawl by",
+        'default; reorder the chain with /websearch-order, or set "searchProvider": "openai" in',
+        "~/.pi/web-search.json.",
+      );
+      ctx.ui.notify(lines.join("\n"), "info");
+    },
+  });
+
+  pi.registerCommand("websearch-order", {
+    description:
+      "Reorder the web search fallback chain (enter grab • ↑↓ move • enter save • esc cancel)",
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) {
+        ctx.ui.notify(
+          '/websearch-order needs an interactive session — edit "searchOrder" in ~/.pi/web-search.json instead',
+          "warning",
+        );
+        return;
+      }
+
+      const config = loadStoredConfig();
+      const chain = resolveSearchChain(undefined, config);
+      const list = [...chain, ...SEARCH_PROVIDER_ORDER.filter((p) => !chain.includes(p))];
+
+      const order = await promptProviderOrder(
+        ctx,
+        "Search provider order",
+        list.map((id) => ({
+          id,
+          detail: searchProviderDetail(id, config),
+          active: chain.includes(id),
+        })),
+      );
+      if (!order) return; // cancelled
+      if (order.every((id, index) => id === list[index])) {
+        ctx.ui.notify("Order unchanged", "info");
+        return;
+      }
+
+      saveStoredConfig({
+        ...config,
+        searchProvider: order[0] as SearchProviderName,
+        searchOrder: order.slice(1) as SearchProviderName[],
+      });
+      ctx.ui.notify(`search chain saved: ${order.join(" → ")}\n(~/.pi/web-search.json)`, "info");
+    },
+  });
+
   pi.registerCommand("websearch-auth", {
     description:
-      "Configure web search providers: Exa / Firecrawl / Tavily / Monid / Ollama API keys (stored in pi auth)",
+      "Configure web search providers: Exa / Firecrawl / Tavily / Monid / Ollama API keys (stored in pi auth); openai is auto-detected — see /web-search",
     handler: async (_args, ctx) => {
       if (!ctx.hasUI) {
         ctx.ui.notify(
@@ -166,6 +303,7 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
 
       const config = loadStoredConfig();
       const provider = await ctx.ui.select("Configure provider:", [
+        openaiLine(config),
         providerLine("exa", config),
         providerLine("firecrawl", config),
         providerLine("tavily", config),
@@ -173,11 +311,28 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
         providerLine("ollama", config),
       ]);
       if (!provider) return;
-      // Lines may start with a green ANSI code; match on the provider name.
-      const name = (["exa", "firecrawl", "tavily", "monid", "ollama"] as const).find((n) =>
-        provider.includes(n),
+      // Lines may start with an ANSI code; match on the provider name.
+      const name = (["openai", "exa", "firecrawl", "tavily", "monid", "ollama"] as const).find(
+        (n) => provider.includes(n),
       );
       if (!name) return;
+
+      if (name === "openai") {
+        ctx.ui.notify(
+          [
+            "openai is auto-detected — there is no key to configure here:",
+            "  1. /login → OpenAI (ChatGPT Plus/Pro Codex) — used automatically",
+            '  2. OPENAI_API_KEY env, or "openai": { "apiKey": … } in',
+            "     ~/.pi/web-search.json",
+            ...codexExpiryHint(),
+            "",
+            "It ranks after keyless Firecrawl by default; reorder with /websearch-order",
+            'or set "searchProvider": "openai" in ~/.pi/web-search.json.',
+          ].join("\n"),
+          "info",
+        );
+        return;
+      }
 
       if (name !== "ollama") {
         const key = await ctx.ui.input(

--- a/packages/pi-web-search/index.ts
+++ b/packages/pi-web-search/index.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   AUTH_IDS,
   SEARCH_PROVIDER_ORDER,
+  availableSearchProviders,
   getProviderStatuses,
   inspectOpenAICodexAuth,
   loadProviderKey,
@@ -253,9 +254,9 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
     description:
       "Reorder the web search fallback chain (enter grab • ↑↓ move • enter save • esc cancel)",
     handler: async (_args, ctx) => {
-      if (!ctx.hasUI) {
+      if (ctx.mode !== "tui") {
         ctx.ui.notify(
-          '/websearch-order needs an interactive session — edit "searchOrder" in ~/.pi/web-search.json instead',
+          '/websearch-order needs a TUI session — edit "searchOrder" in ~/.pi/web-search.json instead',
           "warning",
         );
         return;
@@ -263,6 +264,7 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
 
       const config = loadStoredConfig();
       const chain = resolveSearchChain(undefined, config);
+      const available = availableSearchProviders(config);
       const list = [...chain, ...SEARCH_PROVIDER_ORDER.filter((p) => !chain.includes(p))];
 
       const order = await promptProviderOrder(
@@ -271,7 +273,7 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
         list.map((id) => ({
           id,
           detail: searchProviderDetail(id, config),
-          active: chain.includes(id),
+          active: available.includes(id),
         })),
       );
       if (!order) return; // cancelled
@@ -282,10 +284,13 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
 
       saveStoredConfig({
         ...config,
-        searchProvider: order[0] as SearchProviderName,
-        searchOrder: order.slice(1) as SearchProviderName[],
+        searchProvider: undefined,
+        searchOrder: order as SearchProviderName[],
       });
-      ctx.ui.notify(`search chain saved: ${order.join(" → ")}\n(~/.pi/web-search.json)`, "info");
+      ctx.ui.notify(
+        `search provider order saved: ${order.join(" → ")}\n(~/.pi/web-search.json)`,
+        "info",
+      );
     },
   });
 

--- a/packages/pi-web-search/lib/config.ts
+++ b/packages/pi-web-search/lib/config.ts
@@ -176,8 +176,12 @@ function piThinkingToReasoning(
     (ctx?.model?.provider === "openai-codex" || ctx?.model?.provider === "openai"
       ? ctx.model
       : undefined);
-  const mapped = entry?.thinkingLevelMap?.[level] ?? level;
-  return mapped === "low" || mapped === "medium" || mapped === "high" ? mapped : undefined;
+  const mapped = entry?.thinkingLevelMap?.[level];
+  if (mapped === null) return undefined;
+  const effective = mapped ?? level;
+  return effective === "low" || effective === "medium" || effective === "high"
+    ? effective
+    : undefined;
 }
 
 export function resolveOpenAIConfig(
@@ -545,7 +549,11 @@ export function resolveSearchChain(
   config = loadStoredConfig(),
 ): SearchProviderName[] {
   const available = availableSearchProviders(config);
-  const head = requested ?? config.searchProvider;
+  const configuredHead =
+    config.searchProvider && available.includes(config.searchProvider)
+      ? config.searchProvider
+      : undefined;
+  const head = requested ?? configuredHead;
   const order = filterOrder(config.searchOrder, SEARCH_PROVIDER_ORDER).filter((p) =>
     available.includes(p),
   );
@@ -558,7 +566,11 @@ export function resolveFetchChain(
   config = loadStoredConfig(),
 ): FetchProviderName[] {
   const available = availableFetchProviders(config);
-  const head = requested ?? config.fetchProvider;
+  const configuredHead =
+    config.fetchProvider && available.includes(config.fetchProvider)
+      ? config.fetchProvider
+      : undefined;
+  const head = requested ?? configuredHead;
   const order = filterOrder(config.fetchOrder, FETCH_PROVIDER_ORDER).filter((p) =>
     available.includes(p),
   );

--- a/packages/pi-web-search/lib/config.ts
+++ b/packages/pi-web-search/lib/config.ts
@@ -12,13 +12,8 @@ import { DEFAULT_OPENAI_SYSTEM_PROMPT } from "./prompt.ts";
 
 export { DEFAULT_OPENAI_SYSTEM_PROMPT } from "./prompt.ts";
 
-export const PRIMARY_CONFIG_PATH = path.join(
-  os.homedir(),
-  ".config",
-  "pi-web-search",
-  "config.json",
-);
-const LEGACY_CONFIG_PATH = path.join(os.homedir(), ".pi", "web-search.json");
+export const PRIMARY_CONFIG_PATH = path.join(os.homedir(), ".pi", "web-search.json");
+const LEGACY_CONFIG_PATH = path.join(os.homedir(), ".config", "pi-web-search", "config.json");
 const PI_AUTH_FILE = path.join(os.homedir(), ".pi", "agent", "auth.json");
 
 export const DEFAULT_OPENAI_MODEL = "gpt-5.6-luna";
@@ -119,6 +114,7 @@ export interface ResolvedOpenAIConfig {
   baseUrl: string;
   model: string;
   systemPrompt: string;
+  reasoning?: "low" | "medium" | "high";
   source: string;
   isCodexOAuth: boolean;
   accountId?: string;
@@ -163,8 +159,29 @@ function isFreshTimestamp(expires: number | undefined): boolean {
   return ms > Date.now();
 }
 
+/** Reasoning effort derived from the session's pi thinking level, mapped
+ * through the search model's registry entry (thinkingLevelMap; a missing
+ * entry passes the level through, null/unsupported values are dropped so
+ * the model default applies). */
+function piThinkingToReasoning(
+  ctx: ExtensionContext | undefined,
+  model: string,
+): ResolvedOpenAIConfig["reasoning"] {
+  const level = ctx?.thinkingLevel;
+  if (!level || level === "off") return undefined;
+  const registry = ctx?.modelRegistry;
+  const entry =
+    registry?.find("openai-codex", model) ??
+    registry?.find("openai", model) ??
+    (ctx?.model?.provider === "openai-codex" || ctx?.model?.provider === "openai"
+      ? ctx.model
+      : undefined);
+  const mapped = entry?.thinkingLevelMap?.[level] ?? level;
+  return mapped === "low" || mapped === "medium" || mapped === "high" ? mapped : undefined;
+}
+
 export function resolveOpenAIConfig(
-  _ctx?: ExtensionContext,
+  ctx?: ExtensionContext,
   config = loadStoredConfig(),
 ): ResolvedOpenAIConfig | null {
   const systemPrompt =
@@ -174,6 +191,11 @@ export function resolveOpenAIConfig(
 
   const model =
     process.env.OPENAI_SEARCH_MODEL?.trim() || config.openai?.model?.trim() || DEFAULT_OPENAI_MODEL;
+
+  const explicitReasoning = (process.env.OPENAI_SEARCH_REASONING?.trim() ||
+    config.openai?.reasoning?.trim() ||
+    "") as ResolvedOpenAIConfig["reasoning"];
+  const reasoning = explicitReasoning || piThinkingToReasoning(ctx, model) || undefined;
 
   const customBaseUrl =
     process.env.OPENAI_BASE_URL?.trim() || config.openai?.baseUrl?.trim() || undefined;
@@ -189,6 +211,10 @@ export function resolveOpenAIConfig(
           : "https://api.openai.com/v1/responses"),
       model,
       systemPrompt,
+      reasoning:
+        reasoning === "low" || reasoning === "medium" || reasoning === "high"
+          ? reasoning
+          : undefined,
       source,
       isCodexOAuth: isCodex,
       accountId: extractAccountId(apiKey),
@@ -218,6 +244,18 @@ export function resolveOpenAIConfig(
   }
 
   return null;
+}
+
+/** State of pi's `openai-codex` login entry in ~/.pi/agent/auth.json.
+ * `expired` means the access token needs a fresh /login (pi refreshes it
+ * lazily, only when a codex model is actually used for chat). */
+export type OpenAICodexAuthState = "fresh" | "expired" | "missing";
+
+export function inspectOpenAICodexAuth(): { state: OpenAICodexAuthState; expires?: number } {
+  const entry = readPiAuthData()["openai-codex"];
+  if (!entry?.access) return { state: "missing" };
+  if (!isFreshTimestamp(entry.expires)) return { state: "expired", expires: entry.expires };
+  return { state: "fresh", expires: entry.expires };
 }
 
 export interface ResolvedExaConfig {

--- a/packages/pi-web-search/lib/exa.ts
+++ b/packages/pi-web-search/lib/exa.ts
@@ -39,9 +39,7 @@ export async function searchExa(
 ): Promise<SearchResponse> {
   const config = resolveExaConfig();
   if (!config) {
-    throw new Error(
-      "Exa API key not found. Set EXA_API_KEY or configure ~/.config/pi-web-search/config.json",
-    );
+    throw new Error("Exa API key not found. Set EXA_API_KEY or configure ~/.pi/web-search.json");
   }
 
   const searchUrl = `${config.baseUrl.replace(/\/+$/, "")}/search`;
@@ -112,9 +110,7 @@ export async function searchExa(
 export async function fetchExa(url: string, options: FetchOptions = {}): Promise<FetchResponse> {
   const config = resolveExaConfig();
   if (!config) {
-    throw new Error(
-      "Exa API key not found. Set EXA_API_KEY or configure ~/.config/pi-web-search/config.json",
-    );
+    throw new Error("Exa API key not found. Set EXA_API_KEY or configure ~/.pi/web-search.json");
   }
 
   const contentsUrl = `${config.baseUrl.replace(/\/+$/, "")}/contents`;

--- a/packages/pi-web-search/lib/openai.ts
+++ b/packages/pi-web-search/lib/openai.ts
@@ -94,9 +94,13 @@ function addResult(
   });
 }
 
-function extractSearchResults(output: unknown[], numResults: number | undefined): SearchResult[] {
+function extractSearchResults(
+  output: unknown[],
+  numResults: number | undefined,
+): { results: SearchResult[]; internalSources: string[] } {
   const results: SearchResult[] = [];
   const seenUrls = new Set<string>();
+  const internalSources = new Set<string>();
 
   for (const item of output) {
     if (!item || typeof item !== "object" || (item as { type?: unknown }).type !== "message")
@@ -151,20 +155,21 @@ function extractSearchResults(output: unknown[], numResults: number | undefined)
       for (const source of group) {
         if (!source || typeof source !== "object") continue;
         const record = source as Record<string, unknown>;
-        addResult(
-          results,
-          seenUrls,
-          record.url ?? record.source_website_url,
-          record.title ?? record.caption,
-        );
+        const url = record.url ?? record.source_website_url;
+        if (typeof url === "string" && url.trim().length > 0) {
+          addResult(results, seenUrls, url, record.title ?? record.caption);
+        } else if (record.type === "api" && typeof record.name === "string" && record.name) {
+          internalSources.add(record.name);
+        }
       }
     }
   }
 
-  if (typeof numResults === "number" && Number.isFinite(numResults) && numResults > 0) {
-    return results.slice(0, Math.min(Math.floor(numResults), 20));
-  }
-  return results;
+  const sliced =
+    typeof numResults === "number" && Number.isFinite(numResults) && numResults > 0
+      ? results.slice(0, Math.min(Math.floor(numResults), 20))
+      : results;
+  return { results: sliced, internalSources: [...internalSources] };
 }
 
 function extractAnswer(output: unknown[]): string {
@@ -247,7 +252,7 @@ export async function searchOpenAI(
   const auth = resolveOpenAIConfig(ctx);
   if (!auth) {
     throw new Error(
-      "OpenAI credentials not found. Set OPENAI_API_KEY, configure ~/.config/pi-web-search/config.json, or log into pi with Codex.",
+      "OpenAI credentials not found. Set OPENAI_API_KEY, configure ~/.pi/web-search.json, or log into pi with Codex.",
     );
   }
 
@@ -273,6 +278,7 @@ export async function searchOpenAI(
     include: ["web_search_call.action.sources"],
     stream: true,
     tool_choice: "required",
+    ...(auth.reasoning ? { reasoning: { effort: auth.reasoning } } : {}),
   };
 
   const timeoutSignal = AbortSignal.timeout(SEARCH_TIMEOUT_MS);
@@ -296,12 +302,13 @@ export async function searchOpenAI(
 
   const parsed = await parseOpenAIResponse(response);
   const answer = extractAnswer(parsed.output);
-  const results = extractSearchResults(parsed.output, options.numResults);
+  const { results, internalSources } = extractSearchResults(parsed.output, options.numResults);
 
   return {
     query,
     results,
     answer: answer || undefined,
     provider: "openai",
+    internalSources: internalSources.length > 0 ? internalSources : undefined,
   };
 }

--- a/packages/pi-web-search/lib/tools.ts
+++ b/packages/pi-web-search/lib/tools.ts
@@ -49,6 +49,8 @@ export interface WebSearchDetails {
   resultsCount: number;
   hasAnswer: boolean;
   results: Array<{ title: string; url: string }>;
+  /** Non-URL sources behind an answer-only response (e.g. oai-weather). */
+  internalSources?: string[];
   fallbackFrom?: string[];
 }
 
@@ -106,6 +108,10 @@ export async function executeSearch(
       return r.snippet ? `${header}\n   ${r.snippet}` : header;
     });
     sections.push(`## Sources & Results (${response.provider})\n\n${list.join("\n\n")}`);
+  } else if (response.internalSources?.length) {
+    sections.push(
+      `Answer from internal ${response.provider} source: ${response.internalSources.join(", ")} (no web URLs).`,
+    );
   } else if (!response.answer) {
     sections.push(`No search results found for: "${params.query}" via ${response.provider}.`);
   }
@@ -117,6 +123,7 @@ export async function executeSearch(
     resultsCount: response.results.length,
     hasAnswer: !!response.answer,
     results: response.results.map((r) => ({ title: r.title, url: r.url })),
+    internalSources: response.internalSources?.length ? response.internalSources : undefined,
     fallbackFrom: response.fallbacks?.length
       ? response.fallbacks.map((f) => f.provider)
       : undefined,
@@ -199,9 +206,11 @@ export function registerTools(
         theme.fg("success", "✓ ") +
         theme.fg(
           "muted",
-          `${details.resultsCount} result${details.resultsCount === 1 ? "" : "s"} via ${details.provider}${
-            details.hasAnswer ? " (with summary)" : ""
-          }`,
+          details.internalSources?.length
+            ? `answer via ${details.provider} (internal source: ${details.internalSources.join(", ")})`
+            : `${details.resultsCount} result${details.resultsCount === 1 ? "" : "s"} via ${details.provider}${
+                details.hasAnswer ? " (with summary)" : ""
+              }`,
         ) +
         fallbackStr;
 

--- a/packages/pi-web-search/lib/types.ts
+++ b/packages/pi-web-search/lib/types.ts
@@ -22,6 +22,10 @@ export interface SearchResponse {
   provider: SearchProviderName;
   /** Providers that were tried before this response and failed */
   fallbacks?: ProviderFallback[];
+  /** Non-URL sources that produced the answer, e.g. OpenAI internal APIs
+   * ("oai-weather"). Present when the answer came from an internal source
+   * instead of web pages — web result lists are then legitimately empty. */
+  internalSources?: string[];
 }
 
 export interface FetchOptions {
@@ -66,6 +70,11 @@ export interface WebSearchConfig {
     baseUrl?: string;
     model?: string;
     systemPrompt?: string;
+    /** Responses API reasoning effort. Explicit setting wins; otherwise the
+     * session's pi thinking level is used (mapped via the model registry);
+     * with neither, the model default (medium) applies. "low" is ~40%
+     * faster and usually plenty for search queries. */
+    reasoning?: "low" | "medium" | "high";
   };
   exa?: {
     baseUrl?: string;

--- a/packages/pi-web-search/src/order-ui.ts
+++ b/packages/pi-web-search/src/order-ui.ts
@@ -1,0 +1,118 @@
+/**
+ * /websearch-order UI — grab-and-move list for the search fallback chain.
+ * Keys: ↑↓ navigate (or move the grabbed item), enter grab then save,
+ * space drop without saving, esc cancel. Every rendered line is
+ * width-safe via truncateToWidth.
+ */
+
+import type {
+  ExtensionCommandContext,
+  KeybindingsManager,
+  Theme,
+} from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+
+export interface OrderItem {
+  id: string;
+  /** Short credential/config summary shown next to the name. */
+  detail: string;
+  /** True when the provider currently has resolvable credentials. */
+  active: boolean;
+}
+
+const NAME_WIDTH = 11;
+
+/** Open the reorder dialog; resolves with the new id order, or null on cancel. */
+export function promptProviderOrder(
+  ctx: ExtensionCommandContext,
+  title: string,
+  items: OrderItem[],
+): Promise<string[] | null> {
+  const detailById = new Map(items.map((item) => [item.id, item.detail]));
+  const activeById = new Map(items.map((item) => [item.id, item.active]));
+
+  return ctx.ui.custom<string[] | null>(
+    (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done) => {
+      const order = items.map((item) => item.id);
+      const initial = [...order];
+      let cursor = 0;
+      let grabbed = false;
+
+      const move = (delta: -1 | 1): void => {
+        if (grabbed) {
+          const target = cursor + delta;
+          if (target < 0 || target >= order.length) return;
+          [order[cursor], order[target]] = [order[target], order[cursor]];
+          cursor = target;
+        } else if (order.length > 0) {
+          cursor = (cursor + delta + order.length) % order.length;
+        }
+        tui.requestRender();
+      };
+
+      const component: Component = {
+        render: (width: number): string[] => {
+          const help = grabbed
+            ? "↑↓ move item • space drop • enter save • esc cancel"
+            : "↑↓ navigate • enter grab • esc cancel";
+          const lines = [theme.fg("accent", theme.bold(title)), "", theme.fg("dim", help), ""];
+          order.forEach((id, index) => {
+            const isCursor = index === cursor;
+            const isGrabbed = isCursor && grabbed;
+            const marker = isGrabbed
+              ? theme.fg("accent", "● ")
+              : isCursor
+                ? theme.fg("accent", "→ ")
+                : "  ";
+            const name = isGrabbed ? theme.fg("accent", theme.bold(id)) : theme.bold(id);
+            const pad = " ".repeat(Math.max(0, NAME_WIDTH - id.length));
+            const status =
+              (activeById.get(id) ?? false) ? theme.fg("success", "✓") : theme.fg("dim", "•");
+            const detail = theme.fg("muted", detailById.get(id) ?? "");
+            lines.push(`${marker}${name}${pad} ${status} ${detail}`);
+          });
+          lines.push(
+            "",
+            theme.fg(
+              "dim",
+              "Top runs first; unconfigured (•) providers are skipped until they have credentials.",
+            ),
+          );
+          return lines.map((line) => truncateToWidth(line, width));
+        },
+        invalidate: (): void => {
+          tui.requestRender();
+        },
+        handleInput: (data: string): void => {
+          if (keybindings.matches(data, "tui.select.cancel")) {
+            done(null);
+            return;
+          }
+          if (keybindings.matches(data, "tui.select.up")) {
+            move(-1);
+            return;
+          }
+          if (keybindings.matches(data, "tui.select.down")) {
+            move(1);
+            return;
+          }
+          if (keybindings.matches(data, "tui.select.confirm")) {
+            if (grabbed) {
+              done(order.every((id, index) => id === initial[index]) ? [...initial] : [...order]);
+              return;
+            }
+            grabbed = true;
+            tui.requestRender();
+            return;
+          }
+          if (data === " ") {
+            grabbed = !grabbed;
+            tui.requestRender();
+          }
+        },
+      };
+      return component;
+    },
+  );
+}

--- a/packages/pi-web-search/test/config.test.ts
+++ b/packages/pi-web-search/test/config.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_MONID_API_URL,
   DEFAULT_OPENAI_SYSTEM_PROMPT,
   getProviderStatuses,
+  inspectOpenAICodexAuth,
   resolveExaConfig,
   resolveFetchProvider,
   resolveFirecrawlConfig,
@@ -32,6 +33,31 @@ test("resolveOpenAIConfig prefers pi's openai-codex login over OPENAI_API_KEY", 
       process.env.OPENAI_API_KEY = originalEnv;
     } else {
       delete process.env.OPENAI_API_KEY;
+    }
+  }
+});
+
+test("inspectOpenAICodexAuth reports fresh / expired / missing states", () => {
+  const cases: Array<[Record<string, unknown>, string]> = [
+    [{}, "missing"],
+    [{ "openai-codex": { type: "oauth", access: "tok", expires: Date.now() + 60_000 } }, "fresh"],
+    [
+      {
+        "openai-codex": {
+          type: "oauth",
+          access: "tok",
+          expires: Math.floor((Date.now() - 1_000) / 1000), // legacy epoch seconds
+        },
+      },
+      "expired",
+    ],
+  ];
+  for (const [data, expected] of cases) {
+    const restoreFs = stubPiAuthData(data);
+    try {
+      assert.equal(inspectOpenAICodexAuth().state, expected);
+    } finally {
+      restoreFs();
     }
   }
 });

--- a/packages/pi-web-search/test/fallback.test.ts
+++ b/packages/pi-web-search/test/fallback.test.ts
@@ -246,10 +246,10 @@ test("order entries without credentials or with unknown names are dropped", () =
     process.env.TAVILY_API_KEY = "tvly-key";
     // Config files arrive as untyped JSON, so bogus names are possible.
     const cfg = JSON.parse(
-      '{"searchOrder": ["firecrawl", "bogus"], "fetchOrder": ["exa", "bogus"]}',
+      '{"searchProvider": "exa", "fetchProvider": "exa", "searchOrder": ["firecrawl", "bogus"], "fetchOrder": ["exa", "bogus"]}',
     ) as WebSearchConfig;
 
-    // exa is listed in fetchOrder but has no credentials, so it is dropped;
+    // exa is preferred and listed in fetchOrder but has no credentials, so it is dropped;
     // the chain is the remaining available providers in canonical order
     // (keyless firecrawl included).
     assert.deepEqual(resolveSearchChain(undefined, cfg), ["firecrawl", "tavily", "ollama"]);

--- a/packages/pi-web-search/test/providers.test.ts
+++ b/packages/pi-web-search/test/providers.test.ts
@@ -167,10 +167,7 @@ test("resolveOpenAIConfig derives reasoning from the session thinking level", ()
       "low",
     );
     // model map nulls out an unsupported level → model default
-    assert.equal(
-      resolve(fakeCtx("minimal" as never, { minimal: null, low: null }), {}).reasoning,
-      undefined,
-    );
+    assert.equal(resolve(fakeCtx("low" as never, { low: null }), {}).reasoning, undefined);
     // off → undefined; xhigh (unsupported effort) → undefined
     assert.equal(resolve(fakeCtx("off" as never), {}).reasoning, undefined);
     assert.equal(resolve(fakeCtx("xhigh" as never), {}).reasoning, undefined);

--- a/packages/pi-web-search/test/providers.test.ts
+++ b/packages/pi-web-search/test/providers.test.ts
@@ -6,6 +6,7 @@ import { resetFirecrawlKeylessState, searchFirecrawl, fetchFirecrawl } from "../
 import { searchMonid, fetchMonid, getMonidWallet, listMonidRuns } from "../lib/monid.ts";
 import { searchOllama, fetchOllama } from "../lib/ollama.ts";
 import { searchOpenAI } from "../lib/openai.ts";
+import { resolveOpenAIConfig } from "../lib/config.ts";
 import { searchTavily, fetchTavily } from "../lib/tavily.ts";
 
 test("searchOpenAI parses JSON Responses API output with citations", async () => {
@@ -67,6 +68,115 @@ test("searchOpenAI parses JSON Responses API output with citations", async () =>
   } finally {
     globalThis.fetch = originalFetch;
     process.env.OPENAI_API_KEY = originalKey;
+  }
+});
+
+test("searchOpenAI reports internal API sources when no web URLs are returned", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.OPENAI_API_KEY;
+
+  try {
+    process.env.OPENAI_API_KEY = "sk-test";
+
+    const mockOutput = {
+      output: [
+        {
+          type: "message",
+          content: [{ type: "text", text: "Seoul: 24°C, mostly clear.", annotations: [] }],
+        },
+        {
+          type: "web_search_call",
+          action: {
+            type: "search",
+            sources: [{ type: "api", name: "oai-weather" }],
+          },
+        },
+      ],
+    };
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify(mockOutput), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const res = await searchOpenAI("seoul weather");
+    assert.equal(res.answer, "Seoul: 24°C, mostly clear.");
+    assert.equal(res.results.length, 0);
+    assert.deepEqual(res.internalSources, ["oai-weather"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.OPENAI_API_KEY = originalKey;
+  }
+});
+
+test("searchOpenAI sends configured reasoning effort", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.OPENAI_API_KEY;
+  const originalReasoning = process.env.OPENAI_SEARCH_REASONING;
+
+  try {
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.OPENAI_SEARCH_REASONING = "low";
+
+    let sentBody: Record<string, unknown> | undefined;
+    globalThis.fetch = async (_input, init) => {
+      sentBody = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ output: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    await searchOpenAI("test");
+    assert.deepEqual(sentBody?.reasoning, { effort: "low" });
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.OPENAI_API_KEY = originalKey;
+    if (originalReasoning === undefined) delete process.env.OPENAI_SEARCH_REASONING;
+    else process.env.OPENAI_SEARCH_REASONING = originalReasoning;
+  }
+});
+
+test("resolveOpenAIConfig derives reasoning from the session thinking level", () => {
+  const originalKey = process.env.OPENAI_API_KEY;
+  const originalReasoning = process.env.OPENAI_SEARCH_REASONING;
+  delete process.env.OPENAI_SEARCH_REASONING;
+
+  const fakeCtx = (thinkingLevel: string, thinkingLevelMap?: Record<string, unknown>) =>
+    ({
+      thinkingLevel,
+      modelRegistry: {
+        find: (_provider: string, id: string) =>
+          id === "gpt-5.6-luna" ? { thinkingLevelMap } : undefined,
+      },
+    }) as unknown as Parameters<typeof resolveOpenAIConfig>[0];
+
+  try {
+    process.env.OPENAI_API_KEY = "sk-test";
+    const resolve = (...args: Parameters<typeof resolveOpenAIConfig>) => {
+      const res = resolveOpenAIConfig(...args);
+      assert.ok(res);
+      return res;
+    };
+    // unmapped level passes through
+    assert.equal(resolve(fakeCtx("low" as never), {}).reasoning, "low");
+    // explicit config beats the session level
+    assert.equal(
+      resolve(fakeCtx("high" as never), { openai: { reasoning: "low" } }).reasoning,
+      "low",
+    );
+    // model map nulls out an unsupported level → model default
+    assert.equal(
+      resolve(fakeCtx("minimal" as never, { minimal: null, low: null }), {}).reasoning,
+      undefined,
+    );
+    // off → undefined; xhigh (unsupported effort) → undefined
+    assert.equal(resolve(fakeCtx("off" as never), {}).reasoning, undefined);
+    assert.equal(resolve(fakeCtx("xhigh" as never), {}).reasoning, undefined);
+  } finally {
+    process.env.OPENAI_API_KEY = originalKey;
+    if (originalReasoning !== undefined) process.env.OPENAI_SEARCH_REASONING = originalReasoning;
   }
 });
 

--- a/packages/pi-web-search/test/runtime.test.ts
+++ b/packages/pi-web-search/test/runtime.test.ts
@@ -8,7 +8,7 @@ test("WebSearchRuntime search dispatches to resolved provider and returns result
   const originalKey = process.env.OPENAI_API_KEY;
   const originalFirecrawlKey = process.env.FIRECRAWL_API_KEY;
   const originalKeyless = process.env.FIRECRAWL_KEYLESS;
-  // Ignore the developer machine's real ~/.config/pi-web-search/config.json:
+  // Ignore the developer machine's real ~/.pi/web-search.json:
   // a configured searchProvider would win over the env-key canonical head.
   const restoreConfig = hideStoredConfig();
 


### PR DESCRIPTION
## Summary

Fixes #21 — the reporter logged into pi with Codex but could not tell whether OpenAI search was enabled. Root cause: OpenAI detection was invisible in every state (detected, undetected, or broken), because:

1. `/websearch-auth` deliberately never listed openai, and `getProviderStatuses()` was dead code wired to no command — no status surface existed at all
2. keyless Firecrawl is the default chain head, so openai never visibly runs (results always say `via firecrawl`)
3. expired codex tokens (pi refreshes them lazily) were silently skipped

## Changes

**Visibility**
- **`/web-search`** (new): provider status — detected credentials + the active search/fetch chains, plus a codex-expiry warning
- **`/websearch-auth`**: openai listed as a read-only row (`✓ auto: pi login (openai-codex)` / `• codex login expired — re-run /login`); selecting it explains auto-detection instead of prompting for a key

**Ordering**
- **`/websearch-order`** (new): custom TUI component (`ctx.ui.custom`) — `enter` grabs, `↑↓` moves, `enter` saves, `space` drops, `esc` cancels; keybinding-aware (`tui.select.*`), width-safe via `truncateToWidth`. Saves the complete `searchOrder`; unconfigured providers retain their chosen position but are skipped until credentials are available

**Config location**
- Primary config is now `~/.pi/web-search.json` (XDG path still read as fallback, migrates on next save) — aligns with the repo's "state under `~/.pi/`" convention

**OpenAI provider**
- `openai.reasoning` / `OPENAI_SEARCH_REASONING` (`low|medium|high`): explicit effort; **otherwise follows the session's pi thinking level**, mapped through the model registry's `thinkingLevelMap` (off/unsupported levels are dropped → model default). Measured: `low` ≈ 40% faster (5.8s vs 9.5s)
- Answer-only responses from internal APIs (`oai-weather`, `oai-finance`) now render `✓ answer via openai (internal source: oai-weather)` and tell the model, instead of a bare `0 results`
- Verified end-to-end against the codex backend (3/3 successful searches, 25–28 results, answer extraction OK)

**Docs**: README restructured — UI previews for both commands, complete config-option reference, release notes moved to the end

## Testing

- `pnpm run typecheck`, `pnpm run check` (repo + package), 59 package tests pass
- New tests: `inspectOpenAICodexAuth` states, internal-source extraction, reasoning effort in request body, thinking-level → reasoning mapping (passthrough / explicit override / null clamp / off+xhigh drop)
- Changesets: 1 minor + 2 patch

