### PR TITLE
feat(pi-web-search): configure fetch provider order

### DIFF
--- a/.changeset/web-fetch-order-tab.md
+++ b/.changeset/web-fetch-order-tab.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-web-search": minor
+---
+
+Expand `/websearch-order` into a tabbed editor for both fallback chains. The dialog opens on Search and switches to Fetch with Tab, preserves edits across tabs, and saves complete `searchOrder` and `fetchOrder` arrays together. The Fetch tab uses the same grab-and-move controls and includes the built-in `direct` provider.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each extension has its own package and its own README under
 | [pi-compact-output](packages/pi-compact-output/README.md) | (TUI only) | Compact tool status blocks; Ctrl+O restores full output. |
 | [pi-goal](packages/pi-goal/README.md) | `/goal`, tools `get_goal`/`update_goal` | User-owned, editable objective with evidence-checked bounded continuation. |
 | [pi-todo](packages/pi-todo/README.md) | tool `todo` | Small shared todo list for multi-step work. |
-| [pi-web-search](packages/pi-web-search/README.md) | tools `web_search`/`web_fetch` | Clean web search & fetch via OpenAI Responses, Exa, Firecrawl, or Ollama. |
+| [pi-web-search](packages/pi-web-search/README.md) | tools `web_search`/`web_fetch`, `/websearch-order` | Web search and fetch with tabbed fallback-order configuration across six providers plus direct fetch. |
 | [pi-antigravity](packages/pi-antigravity/README.md) | `/agy`, `/agy-tasks`, `/agy-artifacts`, `/agy-usage` | Google Antigravity (`agy`) models inside pi via stream-json RPC. |
 | [pi-vscode-bridge](packages/pi-vscode-bridge/README.md) | `/vscode-connect` | Send file/line/diff-hunk refs from VS Code into pi's editor. |
 

--- a/packages/pi-web-search/README.md
+++ b/packages/pi-web-search/README.md
@@ -32,13 +32,17 @@ entirely: keyless Firecrawl is the default, no key needed.
    ollama    • unconfigured (default localhost:11434)
 ```
 
-`/websearch-order`: grab a provider with `enter`, move it with `↑↓`, `enter` to
-save — or do nothing and the default chain (keyless Firecrawl first) applies:
+`/websearch-order`: configure both fallback chains in one dialog. It opens on
+**Search**; press `tab` to switch to **Fetch**. Grab a provider with `enter`,
+move it with `↑↓`, press `space` to drop it, and use `enter` while grabbed to
+save both tabs. `esc` cancels all edits.
 
 ```text
- Search provider order
+ Web provider order
 
- ↑↓ navigate • enter grab • esc cancel
+  Search   Fetch    Tab switches tool
+
+ ↑↓ navigate • enter grab • tab switch • esc cancel
 
  → openai    ✓ ~/.pi/agent/auth.json (openai-codex)
    exa       ✓ EXA_API_KEY env
@@ -47,6 +51,9 @@ save — or do nothing and the default chain (keyless Firecrawl first) applies:
    tavily    • unconfigured
    monid     • unconfigured
 ```
+
+The Fetch tab uses the same controls and includes `direct`, the built-in HTTP
+fallback. The default chains still apply when you do not save a custom order.
 
 **Manual** — env variables:
 
@@ -90,16 +97,16 @@ credentialed):
 session's thinking level (via pi's model registry), falling back to the model
 default; set `"low"` to always search ~40% faster.
 
-Prefer the interactive route? `/websearch-order` writes the complete
-`searchOrder` for you, and `/websearch-auth` manages Ollama's base URL — no
-hand-editing needed.
+Prefer the interactive route? `/websearch-order` writes complete `searchOrder`
+and `fetchOrder` arrays for you; use `tab` to switch between them.
+`/websearch-auth` manages Ollama's base URL — no hand-editing needed.
 
 ## Commands
 
 | Command            | Description                                                                                                                                                                 |
 | :----------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/web-search`      | Show provider status: detected credentials (incl. auto-detected OpenAI) and the active search/fetch fallback chains                                                         |
-| `/websearch-order` | Interactively reorder the search fallback chain: enter grab • ↑↓ move • enter save • esc cancel (saved as `searchOrder`)                                                    |
+| `/websearch-order` | Interactively reorder search and fetch fallback chains: tab switch • enter grab • ↑↓ move • enter save • esc cancel (saved as `searchOrder` and `fetchOrder`)                        |
 | `/websearch-auth`  | Interactive credential setup (Exa / Firecrawl / Tavily / Monid / Ollama). OpenAI is listed read-only — it's auto-detected from your pi `/login` (Codex) or `OPENAI_API_KEY` |
 | `/websearch-usage` | Show this session's per-provider usage (calls, failures, avg latency), providers on cooldown/blocked, and your Monid wallet balance with recent run costs                   |
 
@@ -123,7 +130,8 @@ OpenAI and Tavily additionally return a synthesized summary (shown as
 
 ### `web_fetch`
 
-Reads web pages as clean Markdown.
+Reads web pages as clean Markdown. To customize its fallback priority, open
+`/websearch-order` and press `tab` to switch from Search to Fetch.
 
 - **Firecrawl** (`/v2/scrape`, `onlyMainContent` on): keyed or
   [keyless](https://www.firecrawl.dev/blog/firecrawl-keyless-launch) — a real

--- a/packages/pi-web-search/index.ts
+++ b/packages/pi-web-search/index.ts
@@ -1,7 +1,9 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   AUTH_IDS,
+  FETCH_PROVIDER_ORDER,
   SEARCH_PROVIDER_ORDER,
+  availableFetchProviders,
   availableSearchProviders,
   getProviderStatuses,
   inspectOpenAICodexAuth,
@@ -19,9 +21,9 @@ import {
   writePiAuthKey,
 } from "./lib/config.ts";
 import { getMonidWallet, listMonidRuns } from "./lib/monid.ts";
-import type { WebSearchConfig, SearchProviderName } from "./lib/types.ts";
+import type { FetchProviderName, SearchProviderName, WebSearchConfig } from "./lib/types.ts";
 import { registerTools } from "./lib/tools.ts";
-import { promptProviderOrder } from "./src/order-ui.ts";
+import { completeProviderOrder, promptProviderOrder } from "./src/order-ui.ts";
 import {
   createWebSearchRuntime,
   runWebSearch,
@@ -130,7 +132,10 @@ function codexExpiryHint(): string[] {
 }
 
 /** One-line credential/config summary for the order dialog. */
-function searchProviderDetail(id: SearchProviderName, config: WebSearchConfig): string {
+function providerDetail(
+  id: SearchProviderName | FetchProviderName,
+  config: WebSearchConfig,
+): string {
   switch (id) {
     case "openai": {
       const resolved = resolveOpenAIConfig(undefined, config);
@@ -149,6 +154,8 @@ function searchProviderDetail(id: SearchProviderName, config: WebSearchConfig): 
       return resolveMonidConfig(config)?.source ?? "unconfigured";
     case "ollama":
       return resolveOllamaConfig(config).source;
+    case "direct":
+      return "built-in HTTP fallback";
   }
 }
 
@@ -252,43 +259,75 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
 
   pi.registerCommand("websearch-order", {
     description:
-      "Reorder the web search fallback chain (enter grab • ↑↓ move • enter save • esc cancel)",
+      "Reorder web search and fetch fallback chains (tab switch • enter grab • ↑↓ move • enter save)",
     handler: async (_args, ctx) => {
       if (ctx.mode !== "tui") {
         ctx.ui.notify(
-          '/websearch-order needs a TUI session — edit "searchOrder" in ~/.pi/web-search.json instead',
+          '/websearch-order needs a TUI session — edit "searchOrder" and "fetchOrder" in ~/.pi/web-search.json instead',
           "warning",
         );
         return;
       }
 
       const config = loadStoredConfig();
-      const chain = resolveSearchChain(undefined, config);
-      const available = availableSearchProviders(config);
-      const list = [...chain, ...SEARCH_PROVIDER_ORDER.filter((p) => !chain.includes(p))];
-
-      const order = await promptProviderOrder(
-        ctx,
-        "Search provider order",
-        list.map((id) => ({
-          id,
-          detail: searchProviderDetail(id, config),
-          active: available.includes(id),
-        })),
+      const searchChain = resolveSearchChain(undefined, config);
+      const fetchChain = resolveFetchChain(undefined, config);
+      const availableSearch = availableSearchProviders(config);
+      const availableFetch = availableFetchProviders(config);
+      const searchList = completeProviderOrder(
+        SEARCH_PROVIDER_ORDER,
+        searchChain,
+        config.searchProvider,
+        config.searchOrder,
       );
+      const fetchList = completeProviderOrder(
+        FETCH_PROVIDER_ORDER,
+        fetchChain,
+        config.fetchProvider,
+        config.fetchOrder,
+      );
+
+      const order = await promptProviderOrder(ctx, [
+        {
+          id: "search",
+          label: "Search",
+          items: searchList.map((id) => ({
+            id,
+            detail: providerDetail(id, config),
+            active: availableSearch.includes(id),
+          })),
+        },
+        {
+          id: "fetch",
+          label: "Fetch",
+          items: fetchList.map((id) => ({
+            id,
+            detail: providerDetail(id, config),
+            active: availableFetch.includes(id),
+          })),
+        },
+      ]);
       if (!order) return; // cancelled
-      if (order.every((id, index) => id === list[index])) {
-        ctx.ui.notify("Order unchanged", "info");
+      const searchUnchanged = order.search.every((id, index) => id === searchList[index]);
+      const fetchUnchanged = order.fetch.every((id, index) => id === fetchList[index]);
+      if (searchUnchanged && fetchUnchanged) {
+        ctx.ui.notify("Orders unchanged", "info");
         return;
       }
 
       saveStoredConfig({
         ...config,
         searchProvider: undefined,
-        searchOrder: order as SearchProviderName[],
+        fetchProvider: undefined,
+        searchOrder: order.search as SearchProviderName[],
+        fetchOrder: order.fetch as FetchProviderName[],
       });
       ctx.ui.notify(
-        `search provider order saved: ${order.join(" → ")}\n(~/.pi/web-search.json)`,
+        [
+          `search order saved: ${order.search.join(" → ")}`,
+          `fetch order saved:  ${order.fetch.join(" → ")}`,
+          "(~/.pi/web-search.json)",
+        ].join("\n"),
         "info",
       );
     },

--- a/packages/pi-web-search/package.json
+++ b/packages/pi-web-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tian.zuo/pi-web-search",
   "version": "0.5.0",
-  "description": "Web search (OpenAI Responses with simple prompt, Exa, Tavily, Firecrawl, Ollama) and web fetch for the pi coding agent.",
+  "description": "Web search and fetch with configurable fallback order across OpenAI, Exa, Tavily, Firecrawl, Monid, Ollama, and direct HTTP.",
   "type": "module",
   "keywords": [
     "pi",
@@ -15,6 +15,8 @@
     "exa",
     "tavily",
     "firecrawl",
+    "monid",
+    "tinyfish",
     "ollama"
   ],
   "author": "Tian Zuo",

--- a/packages/pi-web-search/src/order-ui.ts
+++ b/packages/pi-web-search/src/order-ui.ts
@@ -1,9 +1,6 @@
-/**
- * /websearch-order UI — grab-and-move list for the search fallback chain.
- * Keys: ↑↓ navigate (or move the grabbed item), enter grab then save,
- * space drop without saving, esc cancel. Every rendered line is
- * width-safe via truncateToWidth.
- */
+// /websearch-order UI — tabbed grab-and-move lists for the search and fetch
+// fallback chains. Tab switches tools; ↑↓ navigates or moves a grabbed item;
+// enter grabs/saves; space drops without saving; esc cancels.
 
 import type {
   ExtensionCommandContext,
@@ -17,48 +14,111 @@ export interface OrderItem {
   id: string;
   /** Short credential/config summary shown next to the name. */
   detail: string;
-  /** True when the provider currently has resolvable credentials. */
+  /** True when the provider is currently available for this tool. */
   active: boolean;
+}
+
+export interface OrderTab {
+  id: "search" | "fetch";
+  label: string;
+  items: OrderItem[];
+}
+
+export interface ProviderOrders {
+  search: string[];
+  fetch: string[];
 }
 
 const NAME_WIDTH = 11;
 
-/** Open the reorder dialog; resolves with the new id order, or null on cancel. */
+/** Build the editable full order without losing unavailable providers from a
+ * previously saved order. */
+export function completeProviderOrder<P extends string>(
+  canonical: readonly P[],
+  resolved: readonly P[],
+  configuredHead?: P,
+  configuredOrder?: readonly P[],
+): P[] {
+  const known = new Set(canonical);
+  return [
+    ...new Set([
+      ...(configuredHead && known.has(configuredHead) ? [configuredHead] : []),
+      ...(Array.isArray(configuredOrder)
+        ? configuredOrder.filter((provider) => known.has(provider))
+        : []),
+      ...resolved,
+      ...canonical,
+    ]),
+  ];
+}
+
+/** Open the tabbed reorder dialog; resolves with both orders, or null on cancel. */
 export function promptProviderOrder(
   ctx: ExtensionCommandContext,
-  title: string,
-  items: OrderItem[],
-): Promise<string[] | null> {
-  const detailById = new Map(items.map((item) => [item.id, item.detail]));
-  const activeById = new Map(items.map((item) => [item.id, item.active]));
-
-  return ctx.ui.custom<string[] | null>(
+  tabs: [OrderTab, OrderTab],
+): Promise<ProviderOrders | null> {
+  return ctx.ui.custom<ProviderOrders | null>(
     (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done) => {
-      const order = items.map((item) => item.id);
-      const initial = [...order];
-      let cursor = 0;
+      let tabIndex = 0;
       let grabbed = false;
+      const orders: ProviderOrders = {
+        search: tabs.find((tab) => tab.id === "search")?.items.map((item) => item.id) ?? [],
+        fetch: tabs.find((tab) => tab.id === "fetch")?.items.map((item) => item.id) ?? [],
+      };
+      const cursors: Record<OrderTab["id"], number> = { search: 0, fetch: 0 };
+
+      const activeTab = (): OrderTab => tabs[tabIndex];
+      const activeOrder = (): string[] => orders[activeTab().id];
 
       const move = (delta: -1 | 1): void => {
+        const tab = activeTab();
+        const order = activeOrder();
+        const cursor = cursors[tab.id];
         if (grabbed) {
           const target = cursor + delta;
           if (target < 0 || target >= order.length) return;
           [order[cursor], order[target]] = [order[target], order[cursor]];
-          cursor = target;
+          cursors[tab.id] = target;
         } else if (order.length > 0) {
-          cursor = (cursor + delta + order.length) % order.length;
+          cursors[tab.id] = (cursor + delta + order.length) % order.length;
         }
+        tui.requestRender();
+      };
+
+      const switchTab = (): void => {
+        grabbed = false;
+        tabIndex = (tabIndex + 1) % tabs.length;
         tui.requestRender();
       };
 
       const component: Component = {
         render: (width: number): string[] => {
+          const tab = activeTab();
+          const order = activeOrder();
+          const itemById = new Map(tab.items.map((item) => [item.id, item]));
+          const tabLabels = tabs
+            .map((candidate, index) => {
+              const label = ` ${candidate.label} `;
+              return index === tabIndex
+                ? theme.bg("selectedBg", theme.fg("text", theme.bold(label)))
+                : theme.fg("dim", label);
+            })
+            .join(" ");
           const help = grabbed
-            ? "↑↓ move item • space drop • enter save • esc cancel"
-            : "↑↓ navigate • enter grab • esc cancel";
-          const lines = [theme.fg("accent", theme.bold(title)), "", theme.fg("dim", help), ""];
+            ? "↑↓ move item • space drop • enter save • tab switch • esc cancel"
+            : "↑↓ navigate • enter grab • tab switch • esc cancel";
+          const lines = [
+            theme.fg("accent", theme.bold("Web provider order")),
+            "",
+            `${tabLabels}${theme.fg("dim", "  Tab switches tool")}`,
+            "",
+            theme.fg("dim", help),
+            "",
+          ];
+
           order.forEach((id, index) => {
-            const isCursor = index === cursor;
+            const item = itemById.get(id);
+            const isCursor = index === cursors[tab.id];
             const isGrabbed = isCursor && grabbed;
             const marker = isGrabbed
               ? theme.fg("accent", "● ")
@@ -67,26 +127,27 @@ export function promptProviderOrder(
                 : "  ";
             const name = isGrabbed ? theme.fg("accent", theme.bold(id)) : theme.bold(id);
             const pad = " ".repeat(Math.max(0, NAME_WIDTH - id.length));
-            const status =
-              (activeById.get(id) ?? false) ? theme.fg("success", "✓") : theme.fg("dim", "•");
-            const detail = theme.fg("muted", detailById.get(id) ?? "");
+            const status = item?.active ? theme.fg("success", "✓") : theme.fg("dim", "•");
+            const detail = theme.fg("muted", item?.detail ?? "");
             lines.push(`${marker}${name}${pad} ${status} ${detail}`);
           });
           lines.push(
             "",
             theme.fg(
               "dim",
-              "Top runs first; unconfigured (•) providers are skipped until they have credentials.",
+              "Top runs first; unavailable (•) providers keep their position and are skipped.",
             ),
           );
-          return lines.map((line) => truncateToWidth(line, width));
+          return lines.map((line) => truncateToWidth(line, Math.max(0, width)));
         },
-        invalidate: (): void => {
-          tui.requestRender();
-        },
+        invalidate: (): void => {},
         handleInput: (data: string): void => {
           if (keybindings.matches(data, "tui.select.cancel")) {
             done(null);
+            return;
+          }
+          if (keybindings.matches(data, "tui.input.tab")) {
+            switchTab();
             return;
           }
           if (keybindings.matches(data, "tui.select.up")) {
@@ -99,7 +160,7 @@ export function promptProviderOrder(
           }
           if (keybindings.matches(data, "tui.select.confirm")) {
             if (grabbed) {
-              done(order.every((id, index) => id === initial[index]) ? [...initial] : [...order]);
+              done({ search: [...orders.search], fetch: [...orders.fetch] });
               return;
             }
             grabbed = true;

--- a/packages/pi-web-search/test/order-ui.test.ts
+++ b/packages/pi-web-search/test/order-ui.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  ExtensionCommandContext,
+  KeybindingsManager,
+  Theme,
+} from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+  completeProviderOrder,
+  type OrderTab,
+  type ProviderOrders,
+  promptProviderOrder,
+} from "../src/order-ui.ts";
+
+const tabs: [OrderTab, OrderTab] = [
+  {
+    id: "search",
+    label: "Search",
+    items: [
+      { id: "firecrawl", detail: "keyless", active: true },
+      { id: "openai", detail: "not configured", active: false },
+    ],
+  },
+  {
+    id: "fetch",
+    label: "Fetch",
+    items: [
+      { id: "firecrawl", detail: "keyless", active: true },
+      { id: "direct", detail: "built-in HTTP fallback", active: true },
+    ],
+  },
+];
+
+function openDialog(): {
+  component: Component;
+  result: Promise<ProviderOrders | null>;
+  renderRequests: () => number;
+} {
+  let component: Component | undefined;
+  let finish: ((value: ProviderOrders | null) => void) | undefined;
+  let renders = 0;
+  const result = new Promise<ProviderOrders | null>((resolve) => {
+    finish = resolve;
+  });
+  const tui = {
+    requestRender: () => {
+      renders++;
+    },
+  } as unknown as TUI;
+  const theme = {
+    fg: (_color: string, value: string) => value,
+    bg: (_color: string, value: string) => value,
+    bold: (value: string) => value,
+  } as unknown as Theme;
+  const bindings: Record<string, string> = {
+    escape: "tui.select.cancel",
+    up: "tui.select.up",
+    down: "tui.select.down",
+    enter: "tui.select.confirm",
+    tab: "tui.input.tab",
+  };
+  const keybindings = {
+    matches: (data: string, id: string) => bindings[data] === id,
+  } as unknown as KeybindingsManager;
+  const ctx = {
+    ui: {
+      custom: (
+        factory: (
+          tui: TUI,
+          theme: Theme,
+          keybindings: KeybindingsManager,
+          done: typeof finish,
+        ) => Component,
+      ) => {
+        component = factory(tui, theme, keybindings, finish);
+        return result;
+      },
+    },
+  } as unknown as ExtensionCommandContext;
+
+  const returned = promptProviderOrder(ctx, tabs);
+  assert.equal(returned, result);
+  assert.ok(component);
+  return { component, result, renderRequests: () => renders };
+}
+
+test("completeProviderOrder retains unavailable providers in their saved positions", () => {
+  const canonical = ["firecrawl", "openai", "exa", "tavily"];
+  assert.deepEqual(
+    completeProviderOrder<string>(canonical, ["firecrawl", "exa"], undefined, [
+      "tavily",
+      "exa",
+      "firecrawl",
+      "unknown",
+    ]),
+    ["tavily", "exa", "firecrawl", "openai"],
+  );
+  assert.deepEqual(
+    completeProviderOrder(canonical, ["firecrawl", "exa"], undefined, "bad json" as never),
+    ["firecrawl", "exa", "openai", "tavily"],
+  );
+});
+
+test("order dialog uses Tab to switch from search to fetch", () => {
+  const dialog = openDialog();
+  const searchLines = dialog.component.render(80);
+  assert.ok(searchLines.some((line) => line.includes("firecrawl")));
+  assert.ok(searchLines.some((line) => line.includes("openai")));
+  assert.ok(!searchLines.some((line) => line.includes("direct")));
+
+  dialog.component.handleInput?.("tab");
+  const fetchLines = dialog.component.render(80);
+  assert.ok(fetchLines.some((line) => line.includes("direct")));
+  assert.ok(!fetchLines.some((line) => line.includes("openai")));
+  assert.equal(dialog.renderRequests(), 1);
+});
+
+test("order dialog preserves edits on both tabs and saves them together", async () => {
+  const dialog = openDialog();
+
+  dialog.component.handleInput?.("down");
+  dialog.component.handleInput?.("enter");
+  dialog.component.handleInput?.("up");
+  dialog.component.handleInput?.(" ");
+  dialog.component.handleInput?.("tab");
+  dialog.component.handleInput?.("enter");
+  dialog.component.handleInput?.("down");
+  dialog.component.handleInput?.("enter");
+
+  assert.deepEqual(await dialog.result, {
+    search: ["openai", "firecrawl"],
+    fetch: ["direct", "firecrawl"],
+  });
+});
+
+test("order dialog cancels without returning edits and stays width-safe", async () => {
+  const dialog = openDialog();
+  assert.ok(dialog.component.render(0).every((line) => visibleWidth(line) === 0));
+  for (const line of dialog.component.render(18)) {
+    assert.ok(visibleWidth(line) <= 18, `${visibleWidth(line)} > 18: ${line}`);
+  }
+  dialog.component.handleInput?.("tab");
+  for (const line of dialog.component.render(18)) {
+    assert.ok(visibleWidth(line) <= 18, `${visibleWidth(line)} > 18: ${line}`);
+  }
+  dialog.component.handleInput?.("escape");
+  assert.equal(await dialog.result, null);
+});


### PR DESCRIPTION
## Summary

- expand `/websearch-order` into a tabbed Search/Fetch provider-order editor
- preserve edits across tabs and save `searchOrder` and `fetchOrder` together
- retain unavailable providers in their configured positions and include direct HTTP in Fetch
- document the workflow and add a release changeset

## Testing

- `pnpm run typecheck`
- `pnpm run check`
- `pnpm test`
- `pnpm changeset status`
