### PR TITLE
feat(pi-web-search): space grabs/drops, enter always saves in /websearch-order

### DIFF
--- a/.changeset/fluffy-otters-reorder.md
+++ b/.changeset/fluffy-otters-reorder.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-web-search": minor
+---
+
+Simplify `/websearch-order` keybindings: **space** now grabs/drops an item and **enter** always saves immediately, so reordering no longer requires a second confirm keypress. `esc` still cancels.

--- a/packages/pi-web-search/src/order-ui.ts
+++ b/packages/pi-web-search/src/order-ui.ts
@@ -1,6 +1,6 @@
 // /websearch-order UI — tabbed grab-and-move lists for the search and fetch
 // fallback chains. Tab switches tools; ↑↓ navigates or moves a grabbed item;
-// enter grabs/saves; space drops without saving; esc cancels.
+// space grabs/drops an item; enter saves; esc cancels.
 
 import type {
   ExtensionCommandContext,
@@ -106,7 +106,7 @@ export function promptProviderOrder(
             .join(" ");
           const help = grabbed
             ? "↑↓ move item • space drop • enter save • tab switch • esc cancel"
-            : "↑↓ navigate • enter grab • tab switch • esc cancel";
+            : "↑↓ navigate • space grab • enter save • tab switch • esc cancel";
           const lines = [
             theme.fg("accent", theme.bold("Web provider order")),
             "",
@@ -159,12 +159,7 @@ export function promptProviderOrder(
             return;
           }
           if (keybindings.matches(data, "tui.select.confirm")) {
-            if (grabbed) {
-              done({ search: [...orders.search], fetch: [...orders.fetch] });
-              return;
-            }
-            grabbed = true;
-            tui.requestRender();
+            done({ search: [...orders.search], fetch: [...orders.fetch] });
             return;
           }
           if (data === " ") {

--- a/packages/pi-web-search/test/order-ui.test.ts
+++ b/packages/pi-web-search/test/order-ui.test.ts
@@ -121,17 +121,33 @@ test("order dialog preserves edits on both tabs and saves them together", async 
   const dialog = openDialog();
 
   dialog.component.handleInput?.("down");
-  dialog.component.handleInput?.("enter");
+  dialog.component.handleInput?.(" ");
   dialog.component.handleInput?.("up");
   dialog.component.handleInput?.(" ");
   dialog.component.handleInput?.("tab");
-  dialog.component.handleInput?.("enter");
   dialog.component.handleInput?.("down");
+  dialog.component.handleInput?.(" ");
+  dialog.component.handleInput?.("up");
+  dialog.component.handleInput?.(" ");
   dialog.component.handleInput?.("enter");
 
   assert.deepEqual(await dialog.result, {
     search: ["openai", "firecrawl"],
     fetch: ["direct", "firecrawl"],
+  });
+});
+
+test("order dialog saves immediately with enter, even while an item is grabbed", async () => {
+  const dialog = openDialog();
+
+  dialog.component.handleInput?.("down");
+  dialog.component.handleInput?.(" ");
+  dialog.component.handleInput?.("up");
+  dialog.component.handleInput?.("enter");
+
+  assert.deepEqual(await dialog.result, {
+    search: ["openai", "firecrawl"],
+    fetch: ["firecrawl", "direct"],
   });
 });
 


### PR DESCRIPTION
## Summary
- **space** now grabs/drops an item in the `/websearch-order` dialog (toggle)
- **enter** always saves immediately — reordering no longer requires a second confirm keypress
- **esc** still cancels; help text updated to match

## Test plan
- [x] `pnpm --filter @tian.zuo/pi-web-search test` — 64 passing (updated reorder flow test, added test that enter saves while an item is grabbed)
- [x] `pnpm run typecheck`
- [x] Changeset added