### PR TITLE
feat(pi-web-search): DeepSeek search provider via server-side web_search tool

### DIFF
--- a/.changeset/web-search-deepseek-provider.md
+++ b/.changeset/web-search-deepseek-provider.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-web-search": minor
+---
+
+Add DeepSeek as a search provider using the official server-side `web_search` tool on DeepSeek's Responses API. Credentials are auto-detected from your pi DeepSeek login, then `DEEPSEEK_API_KEY`, then `/websearch-auth`. Agentic multi-round search with a synthesized answer; ranks after OpenAI in the search fallback chain; `deepseek.model`/`deepseek.reasoning` (default `low`) configurable in `~/.pi/web-search.json`.

--- a/packages/pi-web-search/README.md
+++ b/packages/pi-web-search/README.md
@@ -1,7 +1,7 @@
 # @tian.zuo/pi-web-search
 
 Web search and web fetch for the [pi coding agent](https://pi.dev). Two tools,
-six providers plus a built-in keyless fetcher, automatic fallback — no single
+seven providers plus a built-in keyless fetcher, automatic fallback — no single
 point of failure. **Works with zero configuration** thanks to Firecrawl's
 keyless tier (search + fetch, no signup).
 
@@ -60,6 +60,7 @@ fallback. The default chains still apply when you do not save a custom order.
 | Variable                         | Unlocks                                                                                                                                    |
 | :------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
 | `OPENAI_API_KEY`                 | OpenAI search — your pi Codex/OpenAI login is used first; this key is only a fallback                                                      |
+| `DEEPSEEK_API_KEY`               | DeepSeek search (server-side `web_search`) — your pi DeepSeek login is used first; this key is only a fallback                             |
 | `EXA_API_KEY`                    | Exa search + fetch                                                                                                                         |
 | `FIRECRAWL_API_KEY`              | Firecrawl search + fetch — optional: without a key, the keyless tier is used (1,000 free credits/mo; set `FIRECRAWL_KEYLESS=0` to disable) |
 | `TAVILY_API_KEY`                 | Tavily search **and** fetch — one key unlocks both tools (fetch uses Tavily Extract)                                                       |
@@ -85,6 +86,11 @@ credentialed):
     "systemPrompt": "Search the web. Answer concisely and accurately; cite sources with Markdown links.",
     "reasoning": "low"
   },
+  "deepseek": {
+    "model": "deepseek-v4-flash",
+    "baseUrl": "https://api.deepseek.com/responses",
+    "reasoning": "low"
+  },
   "exa": { "baseUrl": "https://api.exa.ai" },
   "firecrawl": { "baseUrl": "https://api.firecrawl.dev/v2", "keyless": true },
   "tavily": { "baseUrl": "https://api.tavily.com" },
@@ -95,7 +101,9 @@ credentialed):
 
 `openai.reasoning` is optional: without it the search call follows the
 session's thinking level (via pi's model registry), falling back to the model
-default; set `"low"` to always search ~40% faster.
+default; set `"low"` to always search ~40% faster. `deepseek.reasoning`
+defaults to `"low"` already (agentic server-side search; `"none"` disables
+thinking entirely).
 
 Prefer the interactive route? `/websearch-order` writes complete `searchOrder`
 and `fetchOrder` arrays for you; use `tab` to switch between them.
@@ -107,7 +115,7 @@ and `fetchOrder` arrays for you; use `tab` to switch between them.
 | :----------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/web-search`      | Show provider status: detected credentials (incl. auto-detected OpenAI) and the active search/fetch fallback chains                                                         |
 | `/websearch-order` | Interactively reorder search and fetch fallback chains: tab switch • enter grab • ↑↓ move • enter save • esc cancel (saved as `searchOrder` and `fetchOrder`)                        |
-| `/websearch-auth`  | Interactive credential setup (Exa / Firecrawl / Tavily / Monid / Ollama). OpenAI is listed read-only — it's auto-detected from your pi `/login` (Codex) or `OPENAI_API_KEY` |
+| `/websearch-auth`  | Interactive credential setup (DeepSeek / Exa / Firecrawl / Tavily / Monid / Ollama). OpenAI is listed read-only — it's auto-detected from your pi `/login` (Codex) or `OPENAI_API_KEY` |
 | `/websearch-usage` | Show this session's per-provider usage (calls, failures, avg latency), providers on cooldown/blocked, and your Monid wallet balance with recent run costs                   |
 
 ## The tools
@@ -115,14 +123,18 @@ and `fetchOrder` arrays for you; use `tab` to switch between them.
 ### `web_search`
 
 Queries live web sources and returns ranked results with links and snippets.
-OpenAI and Tavily additionally return a synthesized summary (shown as
-`## Summary`).
+OpenAI, DeepSeek, and Tavily additionally return a synthesized summary (shown
+as `## Summary`).
 
 - **Firecrawl** (default): live SERP results, keyed or keyless (1,000 free
   credits/mo without a key; `FIRECRAWL_KEYLESS=0` to opt out).
 - **OpenAI**: server-side web search via the Responses API with a simple prompt;
   uses your active pi login (`openai-codex` / `openai`) first, falling back to
   `OPENAI_API_KEY`.
+- **DeepSeek**: server-side `web_search` tool on DeepSeek's Responses API —
+  agentic multi-round search with page reads and a synthesized answer. Uses
+  your pi DeepSeek login first, then `DEEPSEEK_API_KEY`. Slow (~15–40s) but
+  cheap; domain filters are not supported by the upstream tool.
 - **Exa / Tavily / Firecrawl / Monid / Ollama**: native API calls. Exa, Tavily,
   Firecrawl, and Monid keys each power **both** search and fetch.
 - **Monid** (TinyFish via [api.monid.ai](https://monid.ai), $0/call):

--- a/packages/pi-web-search/index.ts
+++ b/packages/pi-web-search/index.ts
@@ -9,6 +9,7 @@ import {
   inspectOpenAICodexAuth,
   loadProviderKey,
   loadStoredConfig,
+  resolveDeepseekConfig,
   resolveExaConfig,
   resolveFetchChain,
   resolveFirecrawlConfig,
@@ -45,6 +46,7 @@ function maskKey(key: string | undefined): string {
 
 /** Providers whose only credential is a single API key + its env var. */
 const KEY_PROVIDERS = {
+  deepseek: "DEEPSEEK_API_KEY",
   exa: "EXA_API_KEY",
   firecrawl: "FIRECRAWL_API_KEY",
   tavily: "TAVILY_API_KEY",
@@ -121,6 +123,17 @@ function openaiLine(config: WebSearchConfig): string {
   return `${label}• auto: /login with OpenAI or set OPENAI_API_KEY`;
 }
 
+/** deepseek row: auto-detected from pi's own deepseek login first, with a
+ * pastable key as fallback (unlike openai, which is fully read-only). */
+function deepseekLine(config: WebSearchConfig): string {
+  const label = "deepseek".padEnd(10);
+  const resolved = resolveDeepseekConfig(config);
+  if (resolved) {
+    return `${GREEN}${label}✓ auto: ${resolved.source}${RESET}`;
+  }
+  return `${label}• auto: /login with DeepSeek or set DEEPSEEK_API_KEY`;
+}
+
 function codexExpiryHint(): string[] {
   return inspectOpenAICodexAuth().state === "expired"
     ? [
@@ -144,6 +157,8 @@ function providerDetail(
         ? "codex login expired — re-run /login"
         : "not detected (/login or OPENAI_API_KEY)";
     }
+    case "deepseek":
+      return resolveDeepseekConfig(config)?.source ?? "unconfigured (/login or DEEPSEEK_API_KEY)";
     case "exa":
       return resolveExaConfig(config)?.source ?? "unconfigured";
     case "tavily":
@@ -248,9 +263,10 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
       lines.push(...codexExpiryHint());
       lines.push(
         "",
-        "openai is auto-detected (pi /login with OpenAI, or OPENAI_API_KEY) — it is not",
-        "listed as configurable in /websearch-auth. It ranks after keyless Firecrawl by",
-        'default; reorder the chain with /websearch-order, or set "searchProvider": "openai" in',
+        "openai and deepseek are auto-detected from your pi /login sessions",
+        '(OPENAI_API_KEY / DEEPSEEK_API_KEY env or "apiKey" in ~/.pi/web-search.json',
+        "work too). They rank after keyless Firecrawl by default; reorder with",
+        '/websearch-order, or set "searchProvider": "openai" or "deepseek" in',
         "~/.pi/web-search.json.",
       );
       ctx.ui.notify(lines.join("\n"), "info");
@@ -335,11 +351,11 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
 
   pi.registerCommand("websearch-auth", {
     description:
-      "Configure web search providers: Exa / Firecrawl / Tavily / Monid / Ollama API keys (stored in pi auth); openai is auto-detected — see /web-search",
+      "Configure web search providers: DeepSeek / Exa / Firecrawl / Tavily / Monid / Ollama API keys (stored in pi auth); openai is auto-detected — see /web-search",
     handler: async (_args, ctx) => {
       if (!ctx.hasUI) {
         ctx.ui.notify(
-          "/websearch-auth needs an interactive session — set EXA_API_KEY / FIRECRAWL_API_KEY / TAVILY_API_KEY / MONID_API_KEY / OLLAMA_API_KEY instead",
+          "/websearch-auth needs an interactive session — set DEEPSEEK_API_KEY / EXA_API_KEY / FIRECRAWL_API_KEY / TAVILY_API_KEY / MONID_API_KEY / OLLAMA_API_KEY instead",
           "warning",
         );
         return;
@@ -348,6 +364,7 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
       const config = loadStoredConfig();
       const provider = await ctx.ui.select("Configure provider:", [
         openaiLine(config),
+        deepseekLine(config),
         providerLine("exa", config),
         providerLine("firecrawl", config),
         providerLine("tavily", config),
@@ -356,9 +373,9 @@ export default function webSearchExtension(pi: ExtensionAPI): void {
       ]);
       if (!provider) return;
       // Lines may start with an ANSI code; match on the provider name.
-      const name = (["openai", "exa", "firecrawl", "tavily", "monid", "ollama"] as const).find(
-        (n) => provider.includes(n),
-      );
+      const name = (
+        ["openai", "deepseek", "exa", "firecrawl", "tavily", "monid", "ollama"] as const
+      ).find((n) => provider.includes(n));
       if (!name) return;
 
       if (name === "openai") {

--- a/packages/pi-web-search/lib/config.ts
+++ b/packages/pi-web-search/lib/config.ts
@@ -17,6 +17,8 @@ const LEGACY_CONFIG_PATH = path.join(os.homedir(), ".config", "pi-web-search", "
 const PI_AUTH_FILE = path.join(os.homedir(), ".pi", "agent", "auth.json");
 
 export const DEFAULT_OPENAI_MODEL = "gpt-5.6-luna";
+export const DEFAULT_DEEPSEEK_MODEL = "deepseek-v4-flash";
+export const DEFAULT_DEEPSEEK_API_URL = "https://api.deepseek.com/responses";
 export const DEFAULT_OLLAMA_HOST = "http://localhost:11434";
 export const DEFAULT_EXA_API_URL = "https://api.exa.ai";
 export const DEFAULT_FIRECRAWL_API_URL = "https://api.firecrawl.dev/v2";
@@ -71,6 +73,7 @@ export function readPiAuthData(): PiAuthData {
 
 /** Provider ids used for API keys inside pi's ~/.pi/agent/auth.json. */
 export const AUTH_IDS = {
+  deepseek: "websearch-deepseek",
   exa: "websearch-exa",
   firecrawl: "websearch-firecrawl",
   tavily: "websearch-tavily",
@@ -86,7 +89,7 @@ function piAuthKey(id: AuthProviderId): string | undefined {
 
 /** Stored API key for a provider, read from pi's auth.json. */
 export function loadProviderKey(
-  name: "exa" | "firecrawl" | "tavily" | "ollama" | "monid",
+  name: "deepseek" | "exa" | "firecrawl" | "tavily" | "ollama" | "monid",
 ): string | undefined {
   return piAuthKey(AUTH_IDS[name]);
 }
@@ -262,6 +265,58 @@ export function inspectOpenAICodexAuth(): { state: OpenAICodexAuthState; expires
   return { state: "fresh", expires: entry.expires };
 }
 
+export interface ResolvedDeepseekConfig {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  systemPrompt: string;
+  reasoning: "none" | "low" | "medium" | "high";
+  source: string;
+}
+
+/** Normalize a DeepSeek base URL to the full /responses endpoint. */
+function deepseekEndpoint(raw: string): string {
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  return trimmed.endsWith("/responses") ? trimmed : `${trimmed}/responses`;
+}
+
+/** DeepSeek search credentials. Priority: pi's own deepseek login (API key
+ * entry, read-only reuse), then DEEPSEEK_API_KEY env, then the key stored
+ * via /websearch-auth, then the config file. */
+export function resolveDeepseekConfig(config = loadStoredConfig()): ResolvedDeepseekConfig | null {
+  const piLoginKey = readPiAuthData().deepseek?.key?.trim();
+  const envKey = process.env.DEEPSEEK_API_KEY?.trim();
+  const storedKey = piAuthKey(AUTH_IDS.deepseek);
+  const fileKey = config.deepseek?.apiKey?.trim();
+  const apiKey = piLoginKey || envKey || storedKey || fileKey;
+  if (!apiKey) return null;
+  const source = piLoginKey
+    ? "~/.pi/agent/auth.json (deepseek login)"
+    : envKey
+      ? "DEEPSEEK_API_KEY env"
+      : storedKey
+        ? "~/.pi/agent/auth.json (websearch-deepseek)"
+        : "config file";
+
+  const baseUrlRaw =
+    process.env.DEEPSEEK_BASE_URL?.trim() || config.deepseek?.baseUrl?.trim() || undefined;
+
+  return {
+    apiKey,
+    baseUrl: baseUrlRaw ? deepseekEndpoint(baseUrlRaw) : DEFAULT_DEEPSEEK_API_URL,
+    model:
+      process.env.DEEPSEEK_SEARCH_MODEL?.trim() ||
+      config.deepseek?.model?.trim() ||
+      DEFAULT_DEEPSEEK_MODEL,
+    systemPrompt:
+      process.env.DEEPSEEK_SEARCH_SYSTEM_PROMPT?.trim() ||
+      config.deepseek?.systemPrompt?.trim() ||
+      DEFAULT_OPENAI_SYSTEM_PROMPT,
+    reasoning: config.deepseek?.reasoning ?? "low",
+    source,
+  };
+}
+
 export interface ResolvedExaConfig {
   apiKey: string;
   baseUrl: string;
@@ -408,6 +463,7 @@ export function resolveMonidConfig(config = loadStoredConfig()): ResolvedMonidCo
 export function getProviderStatuses(ctx?: ExtensionContext): ProviderStatus[] {
   const config = loadStoredConfig();
   const openai = resolveOpenAIConfig(ctx, config);
+  const deepseek = resolveDeepseekConfig(config);
   const exa = resolveExaConfig(config);
   const firecrawl = resolveFirecrawlConfig(config);
   const tavily = resolveTavilyConfig(config);
@@ -422,6 +478,14 @@ export function getProviderStatuses(ctx?: ExtensionContext): ProviderStatus[] {
       source: openai?.source,
       baseUrl: openai?.baseUrl,
       model: openai?.model,
+    },
+    {
+      name: "deepseek",
+      label: "DeepSeek (server-side web_search)",
+      configured: !!deepseek,
+      source: deepseek?.source,
+      baseUrl: deepseek?.baseUrl,
+      model: deepseek?.model,
     },
     {
       name: "exa",
@@ -488,6 +552,7 @@ export function resolveFetchProvider(
 export const SEARCH_PROVIDER_ORDER: readonly SearchProviderName[] = [
   "firecrawl",
   "openai",
+  "deepseek",
   "exa",
   "tavily",
   "ollama",
@@ -510,6 +575,7 @@ export function availableSearchProviders(config = loadStoredConfig()): SearchPro
   const list: SearchProviderName[] = [];
   if (resolveFirecrawlConfig(config)) list.push("firecrawl");
   if (resolveOpenAIConfig(undefined, config)) list.push("openai");
+  if (resolveDeepseekConfig(config)) list.push("deepseek");
   if (resolveExaConfig(config)) list.push("exa");
   if (resolveTavilyConfig(config)) list.push("tavily");
   list.push("ollama");

--- a/packages/pi-web-search/lib/deepseek.ts
+++ b/packages/pi-web-search/lib/deepseek.ts
@@ -1,0 +1,123 @@
+import { resolveDeepseekConfig } from "./config.ts";
+import { extractAnswer, parseOpenAIResponse } from "./openai.ts";
+import type { SearchOptions, SearchResponse, SearchResult } from "./types.ts";
+
+/** Agentic server-side search: DeepSeek's Responses API runs the built-in
+ * `web_search` tool on their servers (multi-round search + page reads, up to
+ * 10 rounds), so allow more time than direct search APIs. */
+const SEARCH_TIMEOUT_MS = 90_000;
+
+/** Strip DeepSeek's internal `#ws_call_id=...` fragment from open_page URLs. */
+function cleanUrl(rawUrl: string): string {
+  return rawUrl.replace(/#ws_call_id=[^#]*$/, "");
+}
+
+function addResult(results: SearchResult[], seen: Set<string>, url: string, title?: string): void {
+  const cleaned = cleanUrl(url);
+  if (!cleaned || seen.has(cleaned)) return;
+  seen.add(cleaned);
+  results.push({
+    title: title?.trim() || cleaned,
+    url: cleaned,
+    snippet: "",
+  });
+}
+
+/** DeepSeek does not return OpenAI-style `url_citation` annotations or a
+ * per-call source list (`include` is unsupported); instead the cited sources
+ * appear as Markdown links in the answer text, and every page the model
+ * opened shows up as a `web_search_call` item with an `open_page` action. */
+function extractSearchResults(output: unknown[], answerText: string): SearchResult[] {
+  const results: SearchResult[] = [];
+  const seen = new Set<string>();
+
+  for (const match of answerText.matchAll(/\[([^\]]{0,300})\]\((https?:\/\/[^)\s]+)\)/g)) {
+    addResult(results, seen, match[2], match[1]);
+  }
+
+  for (const item of output) {
+    if (
+      !item ||
+      typeof item !== "object" ||
+      (item as { type?: unknown }).type !== "web_search_call"
+    ) {
+      continue;
+    }
+    const action = (item as { action?: unknown }).action;
+    if (!action || typeof action !== "object") continue;
+    const record = action as { type?: unknown; url?: unknown };
+    if (record.type === "open_page" && typeof record.url === "string") {
+      addResult(results, seen, record.url);
+    }
+  }
+
+  return results;
+}
+
+export async function searchDeepseek(
+  query: string,
+  options: SearchOptions = {},
+): Promise<SearchResponse> {
+  const config = resolveDeepseekConfig();
+  if (!config) {
+    throw new Error(
+      "DeepSeek credentials not found. /login with DeepSeek in pi, set DEEPSEEK_API_KEY, or run /websearch-auth.",
+    );
+  }
+
+  const body: Record<string, unknown> = {
+    model: config.model,
+    instructions: config.systemPrompt,
+    input: [
+      {
+        role: "user",
+        content: [{ type: "input_text", text: query }],
+      },
+    ],
+    tools: [{ type: "web_search" }],
+    tool_choice: { type: "web_search" },
+    reasoning: { effort: config.reasoning },
+    stream: true,
+  };
+
+  const timeoutSignal = AbortSignal.timeout(SEARCH_TIMEOUT_MS);
+  const combinedSignal = options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
+
+  const response = await fetch(config.baseUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: combinedSignal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new Error(
+      `DeepSeek Responses API error (${response.status} ${response.statusText}): ${errorText.slice(0, 300)}`,
+    );
+  }
+
+  const parsed = await parseOpenAIResponse(response);
+  const answer = extractAnswer(parsed.output);
+  let results = extractSearchResults(parsed.output, answer);
+
+  if (
+    typeof options.numResults === "number" &&
+    Number.isFinite(options.numResults) &&
+    options.numResults > 0
+  ) {
+    results = results.slice(0, Math.min(Math.floor(options.numResults), 20));
+  }
+
+  return {
+    query,
+    results,
+    answer: answer || undefined,
+    provider: "deepseek",
+  };
+}

--- a/packages/pi-web-search/lib/openai.ts
+++ b/packages/pi-web-search/lib/openai.ts
@@ -172,7 +172,9 @@ function extractSearchResults(
   return { results: sliced, internalSources: [...internalSources] };
 }
 
-function extractAnswer(output: unknown[]): string {
+/** Concatenate the assistant message text across output items. Exported for
+ * the DeepSeek provider (same output shape). */
+export function extractAnswer(output: unknown[]): string {
   const parts: string[] = [];
   for (const item of output) {
     if (!item || typeof item !== "object" || (item as { type?: unknown }).type !== "message")
@@ -191,7 +193,10 @@ function extractAnswer(output: unknown[]): string {
   return parts.join("\n\n").trim();
 }
 
-async function parseOpenAIResponse(response: Response): Promise<{ output: unknown[] }> {
+/** Parse a Responses API reply: either a JSON body or an SSE stream
+ * (OpenAI and DeepSeek both speak this shape). Exported for the DeepSeek
+ * provider, which uses the same wire format. */
+export async function parseOpenAIResponse(response: Response): Promise<{ output: unknown[] }> {
   const text = await response.text();
   const trimmed = text.trim();
 
@@ -203,7 +208,7 @@ async function parseOpenAIResponse(response: Response): Promise<{ output: unknow
       return { output: [] };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`OpenAI API returned invalid JSON: ${message}`);
+      throw new Error(`Responses API returned invalid JSON: ${message}`);
     }
   }
 
@@ -241,7 +246,7 @@ async function parseOpenAIResponse(response: Response): Promise<{ output: unknow
     return { output: outputItems };
   }
 
-  throw new Error("OpenAI API returned no parseable response output");
+  throw new Error("Responses API returned no parseable response output");
 }
 
 export async function searchOpenAI(

--- a/packages/pi-web-search/lib/types.ts
+++ b/packages/pi-web-search/lib/types.ts
@@ -44,7 +44,14 @@ export interface FetchResponse {
   fallbacks?: ProviderFallback[];
 }
 
-export type SearchProviderName = "openai" | "exa" | "tavily" | "firecrawl" | "ollama" | "monid";
+export type SearchProviderName =
+  | "openai"
+  | "deepseek"
+  | "exa"
+  | "tavily"
+  | "firecrawl"
+  | "ollama"
+  | "monid";
 export type FetchProviderName = "firecrawl" | "exa" | "tavily" | "ollama" | "monid" | "direct";
 
 export interface ProviderStatus {
@@ -75,6 +82,16 @@ export interface WebSearchConfig {
      * with neither, the model default (medium) applies. "low" is ~40%
      * faster and usually plenty for search queries. */
     reasoning?: "low" | "medium" | "high";
+  };
+  deepseek?: {
+    apiKey?: string;
+    baseUrl?: string;
+    model?: string;
+    systemPrompt?: string;
+    /** Responses API reasoning effort for the server-side web_search tool.
+     * Defaults to "low": fast and cheap for search queries. "none" disables
+     * thinking mode entirely. */
+    reasoning?: "none" | "low" | "medium" | "high";
   };
   exa?: {
     baseUrl?: string;

--- a/packages/pi-web-search/src/runtime.ts
+++ b/packages/pi-web-search/src/runtime.ts
@@ -23,6 +23,7 @@ import {
   SynchronizedRef,
 } from "effect";
 import { resolveFetchChain, resolveSearchChain } from "../lib/config.ts";
+import { searchDeepseek } from "../lib/deepseek.ts";
 import { fetchDirect } from "../lib/direct-fetch.ts";
 import { fetchExa, searchExa } from "../lib/exa.ts";
 import { fetchFirecrawl, searchFirecrawl } from "../lib/firecrawl.ts";
@@ -316,6 +317,8 @@ const makeWebSearchRuntime = Effect.gen(function* () {
             switch (provider) {
               case "openai":
                 return await searchOpenAI(query, searchOpts, ctx);
+              case "deepseek":
+                return await searchDeepseek(query, searchOpts);
               case "exa":
                 return await searchExa(query, searchOpts);
               case "tavily":

--- a/packages/pi-web-search/test/config.test.ts
+++ b/packages/pi-web-search/test/config.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_OPENAI_SYSTEM_PROMPT,
   getProviderStatuses,
   inspectOpenAICodexAuth,
+  resolveDeepseekConfig,
   resolveExaConfig,
   resolveFetchProvider,
   resolveFirecrawlConfig,
@@ -103,6 +104,63 @@ test("resolveOpenAIConfig respects OPENAI_API_KEY environment variable", () => {
       process.env.OPENAI_API_KEY = originalEnv;
     } else {
       delete process.env.OPENAI_API_KEY;
+    }
+  }
+});
+
+test("resolveDeepseekConfig prefers pi's deepseek login and normalizes base URLs", () => {
+  const originalEnv = process.env.DEEPSEEK_API_KEY;
+  const restoreFs = stubPiAuthData({
+    deepseek: { type: "api_key", key: "sk-pi-deepseek-key" },
+  });
+  try {
+    process.env.DEEPSEEK_API_KEY = "sk-env-key";
+    const res = resolveDeepseekConfig({});
+    assert.ok(res);
+    assert.equal(res.apiKey, "sk-pi-deepseek-key");
+    assert.equal(res.source, "~/.pi/agent/auth.json (deepseek login)");
+    assert.equal(res.baseUrl, "https://api.deepseek.com/responses");
+    assert.equal(res.model, "deepseek-v4-flash");
+    assert.equal(res.reasoning, "low");
+    assert.equal(res.systemPrompt, DEFAULT_OPENAI_SYSTEM_PROMPT);
+
+    // A bare base URL is extended to the /responses endpoint.
+    assert.equal(
+      resolveDeepseekConfig({ deepseek: { baseUrl: "https://proxy.example.com/v1/" } })?.baseUrl,
+      "https://proxy.example.com/v1/responses",
+    );
+  } finally {
+    restoreFs();
+    if (originalEnv !== undefined) {
+      process.env.DEEPSEEK_API_KEY = originalEnv;
+    } else {
+      delete process.env.DEEPSEEK_API_KEY;
+    }
+  }
+});
+
+test("resolveDeepseekConfig falls back to env key and config overrides", () => {
+  const originalEnv = process.env.DEEPSEEK_API_KEY;
+  const restoreFs = hidePiAuthFile();
+  try {
+    process.env.DEEPSEEK_API_KEY = "sk-env-key";
+    const res = resolveDeepseekConfig({
+      deepseek: { model: "deepseek-v4-pro", reasoning: "none" },
+    });
+    assert.ok(res);
+    assert.equal(res.apiKey, "sk-env-key");
+    assert.equal(res.source, "DEEPSEEK_API_KEY env");
+    assert.equal(res.model, "deepseek-v4-pro");
+    assert.equal(res.reasoning, "none");
+
+    delete process.env.DEEPSEEK_API_KEY;
+    assert.equal(resolveDeepseekConfig({}), null);
+  } finally {
+    restoreFs();
+    if (originalEnv !== undefined) {
+      process.env.DEEPSEEK_API_KEY = originalEnv;
+    } else {
+      delete process.env.DEEPSEEK_API_KEY;
     }
   }
 });
@@ -295,8 +353,17 @@ test("resolveMonidConfig respects MONID_API_KEY environment variable", () => {
   }
 });
 
-test("getProviderStatuses lists all 7 supported providers", () => {
+test("getProviderStatuses lists all 8 supported providers", () => {
   const statuses = getProviderStatuses();
   const names = statuses.map((s) => s.name);
-  assert.deepEqual(names, ["openai", "exa", "tavily", "firecrawl", "monid", "ollama", "direct"]);
+  assert.deepEqual(names, [
+    "openai",
+    "deepseek",
+    "exa",
+    "tavily",
+    "firecrawl",
+    "monid",
+    "ollama",
+    "direct",
+  ]);
 });

--- a/packages/pi-web-search/test/fallback.test.ts
+++ b/packages/pi-web-search/test/fallback.test.ts
@@ -18,6 +18,8 @@ import {
 
 const ENV_KEYS = [
   "OPENAI_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "DEEPSEEK_BASE_URL",
   "EXA_API_KEY",
   "FIRECRAWL_API_KEY",
   "FIRECRAWL_KEYLESS",
@@ -125,6 +127,7 @@ test("provider chains put the requested provider first and dedupe", () => {
     delete process.env.FIRECRAWL_API_KEY;
     delete process.env.TAVILY_API_KEY;
     delete process.env.MONID_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.OLLAMA_HOST;
 
     // Firecrawl becomes "available" purely through its env key.
@@ -164,6 +167,7 @@ test("tavily joins search and fetch chains when configured", () => {
     delete process.env.FIRECRAWL_API_KEY;
     delete process.env.TAVILY_API_KEY;
     delete process.env.MONID_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.OLLAMA_HOST;
 
     process.env.TAVILY_API_KEY = "tvly-key";
@@ -203,6 +207,7 @@ test("searchOrder and fetchOrder configure the fallback sequence", () => {
     delete process.env.FIRECRAWL_API_KEY;
     delete process.env.TAVILY_API_KEY;
     delete process.env.MONID_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.OLLAMA_HOST;
 
     process.env.EXA_API_KEY = "exa-key";
@@ -241,6 +246,7 @@ test("order entries without credentials or with unknown names are dropped", () =
     delete process.env.FIRECRAWL_API_KEY;
     delete process.env.TAVILY_API_KEY;
     delete process.env.MONID_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.OLLAMA_HOST;
 
     process.env.TAVILY_API_KEY = "tvly-key";
@@ -271,6 +277,7 @@ test("usage counters track per-provider attempts for /websearch-usage", async ()
     process.env.FIRECRAWL_API_KEY = "fc-key";
     delete process.env.TAVILY_API_KEY;
     delete process.env.MONID_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.OLLAMA_HOST;
     installFetchMock(control);
 
@@ -313,6 +320,7 @@ test("search: quota-exhausted provider is skipped for the rest of the session", 
     process.env.FIRECRAWL_API_KEY = "fc-key";
     delete process.env.TAVILY_API_KEY;
     delete process.env.MONID_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.OLLAMA_HOST;
     installFetchMock(control);
 
@@ -360,6 +368,7 @@ test("search: walks the whole chain and reports an aggregated error", async () =
     process.env.FIRECRAWL_API_KEY = "fc-key";
     delete process.env.TAVILY_API_KEY;
     delete process.env.MONID_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.OLLAMA_HOST;
     installFetchMock(control);
 
@@ -401,6 +410,7 @@ test("fetch: falls back through firecrawl -> exa -> direct within one call", asy
     process.env.FIRECRAWL_API_KEY = "fc-key";
     delete process.env.TAVILY_API_KEY;
     delete process.env.MONID_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.OLLAMA_HOST;
 
     globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -478,6 +488,7 @@ test("fallback chain follows searchOrder/fetchOrder sequence including monid", (
   const restoreFs = hidePiAuthFile();
   try {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
     delete process.env.OLLAMA_HOST;
     process.env.EXA_API_KEY = "exa-key";
     process.env.TAVILY_API_KEY = "tvly-key";

--- a/packages/pi-web-search/test/providers.test.ts
+++ b/packages/pi-web-search/test/providers.test.ts
@@ -6,6 +6,7 @@ import { resetFirecrawlKeylessState, searchFirecrawl, fetchFirecrawl } from "../
 import { searchMonid, fetchMonid, getMonidWallet, listMonidRuns } from "../lib/monid.ts";
 import { searchOllama, fetchOllama } from "../lib/ollama.ts";
 import { searchOpenAI } from "../lib/openai.ts";
+import { searchDeepseek } from "../lib/deepseek.ts";
 import { resolveOpenAIConfig } from "../lib/config.ts";
 import { searchTavily, fetchTavily } from "../lib/tavily.ts";
 
@@ -174,6 +175,125 @@ test("resolveOpenAIConfig derives reasoning from the session thinking level", ()
   } finally {
     process.env.OPENAI_API_KEY = originalKey;
     if (originalReasoning !== undefined) process.env.OPENAI_SEARCH_REASONING = originalReasoning;
+  }
+});
+
+test("searchDeepseek extracts sources from markdown citations and open_page calls", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.DEEPSEEK_API_KEY;
+  const restoreFs = hidePiAuthFile();
+
+  try {
+    process.env.DEEPSEEK_API_KEY = "sk-test-deepseek";
+
+    let sentBody: Record<string, unknown> | undefined;
+    let sentAuth: string | undefined;
+    let sentUrl: string | undefined;
+    globalThis.fetch = async (input, init) => {
+      sentUrl = String(input);
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      sentAuth = headers.Authorization;
+      sentBody = JSON.parse(String(init?.body));
+      return new Response(
+        JSON.stringify({
+          output: [
+            {
+              type: "web_search_call",
+              action: { type: "search", queries: ["typescript 7 release"] },
+            },
+            {
+              type: "web_search_call",
+              action: {
+                type: "open_page",
+                url: "https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#ws_call_id=call_01_abc",
+              },
+            },
+            {
+              type: "web_search_call",
+              action: {
+                type: "open_page",
+                url: "https://www.npmjs.com/package/typescript#ws_call_id=call_02_def",
+              },
+            },
+            {
+              type: "message",
+              content: [
+                {
+                  type: "output_text",
+                  text: "TypeScript 7.0 is out. See the [announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/) and [typescript on npm](https://www.npmjs.com/package/typescript).",
+                  annotations: [],
+                },
+              ],
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    const res = await searchDeepseek("typescript 7", { numResults: 5 });
+    assert.equal(res.provider, "deepseek");
+    assert.match(res.answer ?? "", /TypeScript 7\.0 is out/);
+
+    // Request shape: forced server-side web_search, low reasoning default.
+    assert.equal(sentUrl, "https://api.deepseek.com/responses");
+    assert.equal(sentAuth, "Bearer sk-test-deepseek");
+    assert.deepEqual(sentBody?.tools, [{ type: "web_search" }]);
+    assert.deepEqual(sentBody?.tool_choice, { type: "web_search" });
+    assert.deepEqual(sentBody?.reasoning, { effort: "low" });
+    assert.equal(sentBody?.stream, true);
+
+    // Markdown-cited sources come first (with titles), open_page URLs are
+    // appended and the ws_call_id fragment is stripped; deduped by URL.
+    assert.deepEqual(
+      res.results.map((r) => ({ title: r.title, url: r.url })),
+      [
+        {
+          title: "announcement",
+          url: "https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/",
+        },
+        { title: "typescript on npm", url: "https://www.npmjs.com/package/typescript" },
+      ],
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFs();
+    if (originalKey !== undefined) {
+      process.env.DEEPSEEK_API_KEY = originalKey;
+    } else {
+      delete process.env.DEEPSEEK_API_KEY;
+    }
+  }
+});
+
+test("searchDeepseek surfaces API errors and missing credentials", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.DEEPSEEK_API_KEY;
+  const restoreFs = hidePiAuthFile();
+
+  try {
+    delete process.env.DEEPSEEK_API_KEY;
+    await assert.rejects(() => searchDeepseek("q"), /DeepSeek credentials not found/);
+
+    process.env.DEEPSEEK_API_KEY = "sk-test-deepseek";
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ error: { message: "Authentication Fails" } }), {
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "Content-Type": "application/json" },
+      });
+    await assert.rejects(
+      () => searchDeepseek("q"),
+      (err: Error) => /DeepSeek Responses API error \(401/.test(err.message),
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFs();
+    if (originalKey !== undefined) {
+      process.env.DEEPSEEK_API_KEY = originalKey;
+    } else {
+      delete process.env.DEEPSEEK_API_KEY;
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Adds **DeepSeek** as a `web_search` provider using DeepSeek's official server-side `web_search` tool on their [Responses API](https://api-docs.deepseek.com/guides/responses_api/) (`POST https://api.deepseek.com/responses`) — agentic multi-round search with page reads and a synthesized answer, executed entirely on DeepSeek's servers (auto-continuation up to 10 rounds).

Validated live against the real API during development.

## How it works

- **Request**: `tools: [{ "type": "web_search" }]` + forced `tool_choice`, streamed, 90s timeout, `reasoning.effort: "low"` by default (measured ~2× cheaper/faster than default thinking: ~19k vs ~45k input tokens per search)
- **Source extraction** — DeepSeek differs from OpenAI here (no `url_citation` annotations, `include` unsupported, no per-call source list), so sources come from:
  1. Markdown-link citations in the answer text (our default system prompt already asks for exactly this)
  2. `web_search_call` items with `action.type === "open_page"` → `action.url`, with DeepSeek's `#ws_call_id=...` fragment stripped, deduped by URL
- Reuses the Responses-API SSE/JSON parser and answer extractor from `lib/openai.ts` (now exported)

## Credentials (auto-detected, zero-config for pi DeepSeek users)

Priority: pi's own `deepseek` login in `~/.pi/agent/auth.json` (read-only reuse, same pattern as `openai-codex`) → `DEEPSEEK_API_KEY` env → `/websearch-auth` pasted key → config file.

## Changes

- `lib/deepseek.ts` — new provider (search-only; DeepSeek has no fetch endpoint)
- `lib/types.ts`, `lib/config.ts` — provider name, `deepseek` config block (`model`, `reasoning`, `baseUrl` auto-appends `/responses`, `systemPrompt`), auth ID `websearch-deepseek`, status entry, chain registration
- `lib/openai.ts` — export shared `parseOpenAIResponse` / `extractAnswer`
- `src/runtime.ts` — search dispatch case
- `index.ts` — `deepseekLine` in `/websearch-auth` (pastable key + auto-detect status), order-dialog detail, `/web-search` help text
- Ranks **after `openai`** in `SEARCH_PROVIDER_ORDER`; joins the chain only when credentialed; `domainFilter` ignored (unsupported upstream, same as firecrawl/ollama)
- Tests: provider extraction/dedupe/request-shape/error paths, config resolution incl. pi-login priority, hermetic deepseek env handling in chain tests (67/67 pass)
- README + changeset (minor)

## Verification

- `pnpm run typecheck` ✅
- `pnpm run check` ✅
- `pnpm test` ✅ (full monorepo, 0 failures)
- `biome check .` ✅ (no new issues)
- Live end-to-end smoke test with real credentials ✅ (answer + titled sources, fragments stripped)
