### PR TITLE
feat(pi-find): bound searches with a 30s timeout and 4MB file cap

### DIFF
--- a/.changeset/lucky-pandas-search.md
+++ b/.changeset/lucky-pandas-search.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-find": minor
+---
+
+Harden grep/find against pathological searches: every rg/fd run now has a 30s wall-clock budget (SIGKILL on expiry, partial results kept with a "timed out, narrow the path" notice — never reported as a clean empty result), and rg skips files over 4MB during directory traversal so giant cache/bundle blobs can no longer turn a broad search into an overnight scan.

--- a/packages/pi-find/lib/prompt.ts
+++ b/packages/pi-find/lib/prompt.ts
@@ -3,8 +3,11 @@
 export const GREP_RESULT_LIMIT = 100;
 export const FIND_RESULT_LIMIT = 200;
 
+/** Wall-clock budget for one rg/fd run; a search should finish well under it. */
+export const SEARCH_TIMEOUT_MS = 30_000;
+
 export const GREP_TOOL_DESCRIPTION =
-  "Search file contents with a case-sensitive regex; respects .gitignore.";
+  "Search file contents with a case-sensitive regex; respects .gitignore; 30s timeout.";
 export const GREP_PROMPT_SNIPPET = "Search file contents with a regex";
 
 export const GREP_PARAMETER_DESCRIPTIONS = {
@@ -13,7 +16,7 @@ export const GREP_PARAMETER_DESCRIPTIONS = {
   glob: "Optional file glob, for example '*.ts' or '**/*.test.ts'.",
 };
 
-export const FIND_TOOL_DESCRIPTION = "Find files with a glob; respects .gitignore.";
+export const FIND_TOOL_DESCRIPTION = "Find files with a glob; respects .gitignore; 30s timeout.";
 export const FIND_PROMPT_SNIPPET = "Find files with a glob";
 
 export const FIND_PARAMETER_DESCRIPTIONS = {
@@ -50,4 +53,9 @@ export function resultLimitNotice(kind: "matches" | "files", limit: number): str
 export function outputLimitNotice(kind: "grep" | "find"): string {
   const unit = kind === "grep" ? "matches" : "files";
   return `[Output limit reached; narrow the search to see the omitted ${unit}.]`;
+}
+
+export function searchTimeoutNotice(timeoutMs: number): string {
+  const seconds = Math.round(timeoutMs / 1000);
+  return `[Search timed out after ${seconds}s; results are partial. Narrow the path, pattern, or glob.]`;
 }

--- a/packages/pi-find/lib/tools.ts
+++ b/packages/pi-find/lib/tools.ts
@@ -23,6 +23,8 @@ import {
   NO_GREP_MATCHES,
   outputLimitNotice,
   resultLimitNotice,
+  SEARCH_TIMEOUT_MS,
+  searchTimeoutNotice,
 } from "./prompt.ts";
 import {
   type GrepOutcome,
@@ -58,6 +60,7 @@ export interface SearchDetails {
   readonly resultCount: number;
   readonly fileCount: number;
   readonly truncated: boolean;
+  readonly timedOut: boolean;
 }
 
 export function renderGrepLines(outcome: GrepOutcome): string[] {
@@ -121,7 +124,13 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
       );
 
       const matchCount = outcome.matches.length;
-      if (matchCount === 0) {
+      const notices = [
+        ...(outcome.truncated ? [resultLimitNotice("matches", GREP_RESULT_LIMIT)] : []),
+        ...(outcome.timedOut ? [searchTimeoutNotice(SEARCH_TIMEOUT_MS)] : []),
+      ];
+      // A timed-out search must never read as a completed empty one: the
+      // notice travels even when nothing was gathered.
+      if (matchCount === 0 && notices.length === 0) {
         return {
           content: [{ type: "text" as const, text: NO_GREP_MATCHES }],
           details: {
@@ -130,15 +139,15 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
             resultCount: 0,
             fileCount: 0,
             truncated: false,
+            timedOut: false,
           } satisfies SearchDetails,
         };
       }
 
       const body = boundedBody(renderGrepLines(outcome), "grep");
       const fileCount = countFiles(outcome);
-      const notices = outcome.truncated ? [resultLimitNotice("matches", GREP_RESULT_LIMIT)] : [];
       const text = [
-        grepResultHeader(matchCount, fileCount),
+        matchCount === 0 ? NO_GREP_MATCHES : grepResultHeader(matchCount, fileCount),
         "",
         body.text,
         ...notices.flatMap((notice) => ["", notice]),
@@ -152,6 +161,7 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
           resultCount: matchCount,
           fileCount,
           truncated: outcome.truncated || body.truncated,
+          timedOut: outcome.timedOut,
         } satisfies SearchDetails,
       };
     },
@@ -191,7 +201,7 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
         { signal },
       );
 
-      if (outcome.files.length === 0) {
+      if (outcome.files.length === 0 && !outcome.timedOut) {
         return {
           content: [{ type: "text" as const, text: NO_FILES_FOUND }],
           details: {
@@ -200,15 +210,19 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
             resultCount: 0,
             fileCount: 0,
             truncated: false,
+            timedOut: false,
           } satisfies SearchDetails,
         };
       }
 
       const body = boundedBody(outcome.files, "find");
       const count = outcome.files.length;
-      const notices = outcome.truncated ? [resultLimitNotice("files", FIND_RESULT_LIMIT)] : [];
+      const notices = [
+        ...(outcome.truncated ? [resultLimitNotice("files", FIND_RESULT_LIMIT)] : []),
+        ...(outcome.timedOut ? [searchTimeoutNotice(SEARCH_TIMEOUT_MS)] : []),
+      ];
       const text = [
-        findResultHeader(count),
+        count === 0 && !outcome.timedOut ? NO_FILES_FOUND : findResultHeader(count),
         "",
         body.text,
         ...notices.flatMap((notice) => ["", notice]),
@@ -222,6 +236,7 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
           resultCount: count,
           fileCount: count,
           truncated: outcome.truncated || body.truncated,
+          timedOut: outcome.timedOut,
         } satisfies SearchDetails,
       };
     },
@@ -294,7 +309,9 @@ function renderSearchResult(
     details.kind === "find"
       ? ""
       : ` in ${details.fileCount} file${details.fileCount === 1 ? "" : "s"}`;
-  const more = details.truncated ? theme.fg("warning", " (truncated)") : "";
+  const more =
+    (details.truncated ? theme.fg("warning", " (truncated)") : "") +
+    (details.timedOut ? theme.fg("warning", " (timed out)") : "");
   const summary =
     theme.fg("success", "✓ ") + theme.fg("muted", `${details.resultCount} ${unit}${scope}`) + more;
   return expandedResult(summary, output, options.expanded, theme);

--- a/packages/pi-find/src/runtime.ts
+++ b/packages/pi-find/src/runtime.ts
@@ -33,6 +33,7 @@ export interface GrepMatch {
 export interface GrepOutcome {
   readonly matches: readonly GrepMatch[];
   readonly truncated: boolean;
+  readonly timedOut: boolean;
 }
 
 export interface FindRequest {
@@ -45,6 +46,7 @@ export interface FindRequest {
 export interface FindOutcome {
   readonly files: readonly string[];
   readonly truncated: boolean;
+  readonly timedOut: boolean;
 }
 
 export interface SearchRuntimeShape {
@@ -105,8 +107,11 @@ function isExplicitHiddenPath(searchPath: string | undefined): boolean {
     .some((segment) => segment.startsWith(".") && segment !== "." && segment !== "..");
 }
 
+/** Files larger than this are skipped: giant blobs (caches, bundles, sourcemaps) are what turns a broad search into an overnight scan. Matches OMP's native grep ceiling. */
+const GREP_MAX_FILESIZE = "4M";
+
 export function buildRgArgs(request: GrepRequest, searchRoot: string): string[] {
-  const args = ["--json", "--line-number", "--color=never"];
+  const args = ["--json", "--line-number", "--color=never", "--max-filesize", GREP_MAX_FILESIZE];
   if (!isInsideGitRepository(searchRoot)) args.push("--no-require-git");
   if (request.glob !== undefined) {
     args.push("--type-add", `pifind:${request.glob}`, "--type", "pifind");
@@ -162,6 +167,7 @@ const makeSearchRuntime = Effect.gen(function* () {
             ({
               matches,
               truncated: sawOverflow || result.stoppedEarly,
+              timedOut: result.timedOut,
             }) satisfies GrepOutcome,
         ),
       );
@@ -198,6 +204,7 @@ const makeSearchRuntime = Effect.gen(function* () {
             ({
               files,
               truncated: sawOverflow || result.stoppedEarly,
+              timedOut: result.timedOut,
             }) satisfies FindOutcome,
         ),
       );

--- a/packages/pi-find/src/stream.ts
+++ b/packages/pi-find/src/stream.ts
@@ -11,6 +11,7 @@ import { spawn } from "node:child_process";
 import { statSync } from "node:fs";
 import { createInterface } from "node:readline";
 import { Effect } from "effect";
+import { SEARCH_TIMEOUT_MS } from "../lib/prompt.ts";
 import { missingBinaryMessage, resolveBinary, type SearchBinary } from "./binaries.ts";
 import { SearchAbortedError, SearchProcessError, SearchToolMissingError } from "./errors.ts";
 
@@ -24,22 +25,31 @@ export interface StreamRequest {
    */
   readonly onLine: (line: string) => boolean;
   readonly signal?: AbortSignal;
+  /** Wall-clock budget; defaults to SEARCH_TIMEOUT_MS. Overridable for tests. */
+  readonly timeoutMs?: number;
 }
 
 export interface StreamResult {
   /** True when onLine asked to stop, meaning more output was available. */
   readonly stoppedEarly: boolean;
+  /** True when the wall-clock budget killed the child; gathered output is partial. */
+  readonly timedOut: boolean;
   readonly exitCode: number | null;
 }
 
 /**
  * Exit codes that are not failures. rg uses 1 for "no matches", which is a
  * perfectly good answer; fd uses 0 even when nothing matched. A killed child
- * reports null, which is expected whenever we stop early.
+ * reports null, which is expected whenever we stop early or time out.
  */
-function isBenignExit(binary: SearchBinary, code: number | null, stoppedEarly: boolean): boolean {
+function isBenignExit(
+  binary: SearchBinary,
+  code: number | null,
+  stoppedEarly: boolean,
+  timedOut: boolean,
+): boolean {
   if (code === 0 || code === null) return true;
-  if (stoppedEarly) return true;
+  if (stoppedEarly || timedOut) return true;
   return binary === "rg" && code === 1;
 }
 
@@ -96,11 +106,13 @@ export function streamLines(
     const reader = createInterface({ input: child.stdout });
     let stderr = "";
     let stoppedEarly = false;
+    let timedOut = false;
     let settled = false;
     let aborted = false;
 
     const cleanup = () => {
       reader.close();
+      clearTimeout(timeoutId);
       outerSignal?.removeEventListener("abort", onAbort);
       effectSignal.removeEventListener("abort", onAbort);
     };
@@ -117,9 +129,9 @@ export function streamLines(
       resume(effect);
     };
 
-    const stopChild = () => {
+    const stopChild = (signal: NodeJS.Signals = "SIGTERM") => {
       if (child.exitCode === null && child.signalCode === null) {
-        child.kill("SIGTERM");
+        child.kill(signal);
       }
     };
 
@@ -127,6 +139,14 @@ export function streamLines(
       aborted = true;
       stopChild();
     }
+
+    // A search should finish in well under the budget; the timer only bounds a
+    // pathological hang (huge tree, network mount, FIFO) so it can never run
+    // for a night. SIGKILL like Maka/Grok: a wedged child must not linger.
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      stopChild("SIGKILL");
+    }, request.timeoutMs ?? SEARCH_TIMEOUT_MS);
 
     outerSignal?.addEventListener("abort", onAbort, { once: true });
     effectSignal.addEventListener("abort", onAbort, { once: true });
@@ -179,7 +199,7 @@ export function streamLines(
         );
         return;
       }
-      if (!isBenignExit(request.binary, code, stoppedEarly)) {
+      if (!isBenignExit(request.binary, code, stoppedEarly, timedOut)) {
         const detail = stderr.trim().split("\n")[0] ?? "";
         settle(
           new SearchProcessError({
@@ -193,7 +213,7 @@ export function streamLines(
         );
         return;
       }
-      settle(Effect.succeed({ stoppedEarly, exitCode: code }));
+      settle(Effect.succeed({ stoppedEarly, timedOut, exitCode: code }));
     });
 
     // Interruption path: kill the child so a cancelled turn leaves nothing behind.

--- a/packages/pi-find/test/search.test.ts
+++ b/packages/pi-find/test/search.test.ts
@@ -3,7 +3,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { after, before, test } from "node:test";
+import { spawnSync } from "node:child_process";
+import { Effect } from "effect";
 import { resolveBinary } from "../src/binaries.ts";
+import { streamLines } from "../src/stream.ts";
 import { FIND_RESULT_LIMIT, GREP_RESULT_LIMIT } from "../lib/prompt.ts";
 import {
   buildFdArgs,
@@ -147,6 +150,38 @@ test("grep stops after the fixed result limit and reports truncation", {
   const outcome = await grep({ pattern: "hit", path: "many.txt" });
   assert.equal(outcome.matches.length, GREP_RESULT_LIMIT);
   assert.equal(outcome.truncated, true);
+  assert.equal(outcome.timedOut, false);
+});
+
+test("grep skips oversized files during directory traversal", { skip: !hasRg }, async () => {
+  const bigDir = path.join(root, "big-dir");
+  mkdirSync(bigDir);
+  writeFileSync(path.join(bigDir, "oversized.txt"), `needle\n${"x".repeat(5 * 1024 * 1024)}\n`);
+  writeFileSync(path.join(bigDir, "small.txt"), "needle\n");
+  const outcome = await grep({ pattern: "needle", path: "big-dir" });
+  assert.deepEqual(
+    outcome.matches.map((match) => match.path),
+    ["big-dir/small.txt"],
+  );
+  assert.equal(outcome.timedOut, false);
+});
+
+test("a wedged search is killed at the wall-clock budget and stays partial", {
+  skip: !hasRg || process.platform === "win32",
+}, async () => {
+  const fifo = path.join(root, "stuck-pipe");
+  spawnSync("mkfifo", [fifo]);
+  const result = await Effect.runPromise(
+    streamLines({
+      binary: "rg",
+      args: ["--regexp", "needle", "--", fifo],
+      cwd: root,
+      timeoutMs: 150,
+      onLine: () => true,
+    }),
+  );
+  assert.equal(result.timedOut, true);
+  assert.equal(result.stoppedEarly, false);
 });
 
 test("find uses one glob under one directory", { skip: !hasFd }, async () => {
@@ -212,6 +247,8 @@ test("engine arguments contain only the fixed simple behavior", () => {
   assert.ok(rg.includes("--regexp"));
   assert.ok(rg.includes("--type-add"));
   assert.ok(rg.includes("pifind:*.ts"));
+  assert.ok(rg.includes("--max-filesize"));
+  assert.ok(rg.includes("4M"));
   assert.ok(!rg.includes("--hidden"));
   assert.ok(!rg.includes("--smart-case"));
   assert.ok(!rg.includes("--fixed-strings"));

--- a/packages/pi-find/test/tools.test.ts
+++ b/packages/pi-find/test/tools.test.ts
@@ -10,6 +10,7 @@ import {
   GREP_TOOL_DESCRIPTION,
   outputLimitNotice,
   resultLimitNotice,
+  searchTimeoutNotice,
 } from "../lib/prompt.ts";
 import type { GrepOutcome } from "../src/runtime.ts";
 
@@ -17,6 +18,7 @@ function outcome(matches: ReadonlyArray<[string, number, string]>): GrepOutcome 
   return {
     matches: matches.map(([path, lineNumber, text]) => ({ path, lineNumber, text })),
     truncated: false,
+    timedOut: false,
   };
 }
 
@@ -67,4 +69,11 @@ test("model-facing metadata stays concise and describes the fixed semantics", ()
 test("fixed limit notices tell the caller to narrow the search", () => {
   assert.match(resultLimitNotice("matches", 100), /narrow pattern, path, or glob/);
   assert.match(outputLimitNotice("find"), /omitted files/);
+});
+
+test("timeout notices say the results are partial and how to narrow", () => {
+  const notice = searchTimeoutNotice(30_000);
+  assert.match(notice, /timed out after 30s/);
+  assert.match(notice, /partial/);
+  assert.match(notice, /narrow the path, pattern, or glob/i);
 });


### PR DESCRIPTION
## Summary

Hardens pi-find's grep/find so a pathological search can never hang a session again. This came out of a real incident: `grep rotate-cw in /Users/tian` ran for **8h48m** and only ended when manually aborted — rg was regex-scanning `~/Library` giant blobs (Chromium profiles, pnpm store) end-to-end, the 100-match early exit never triggered (sparse pattern), and nothing else bounded the run.

- **30s wall-clock budget per rg/fd run** (`SEARCH_TIMEOUT_MS`): timer SIGKILLs the child (Maka/Grok style), partial results are kept, and the outcome carries `timedOut`
- **Timeout notices never read as a clean empty result**: a timed-out search with 0 matches still returns `[Search timed out after 30s; results are partial. Narrow the path, pattern, or glob.]` (lesson from Maka: never let a failure read as "pattern is absent")
- **`--max-filesize 4M`** on rg (matches OMP's native grep ceiling): files over 4MB are skipped during directory traversal, so cache/bundle/sourcemap blobs can't dominate a scan; explicitly named files are still searched in full, bounded by the timeout
- Tool descriptions now advertise the `30s timeout`; renderer shows `(timed out)`; `SearchDetails` gained `timedOut`

## Tests

- New: a wedged search (rg on a FIFO) is killed at the budget and settles as partial (`timedOut: true`)
- New: oversized files are skipped during directory traversal, small siblings still match
- New: build args include `--max-filesize 4M`; timeout notice wording assertions
- Existing: 34/34 pass, workspace typecheck + full test suite green, no new biome warnings

## Context

Surveyed how other agents guard this (Apache Maka: 120s SIGKILL + sandbox path containment; xAI Grok Build: 20s timeout + line-budget early kill + 5MB stdout cap; oh-my-pi: 30s + 4MB per-file cap; Codex grep_files: 30s + limit clamp). This PR adopts the common core: hard timeout + per-file size cap + action-oriented timeout copy.
