### PR TITLE
fix(pi-antigravity): preserve string prompts and extension context

### DIFF
--- a/.changeset/quiet-prompts-travel.md
+++ b/.changeset/quiet-prompts-travel.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-antigravity": patch
+---
+
+Fix print-mode string prompts and preserve consecutive user messages so extension-added context no longer replaces the caller's request. Use the same request boundary when restoring history and retain string-form historical messages.

--- a/packages/pi-antigravity/lib/prompt.ts
+++ b/packages/pi-antigravity/lib/prompt.ts
@@ -16,6 +16,10 @@
 export const WRAPPER_TOOL_NAME = "antigravity";
 export const WRAPPER_TOOL_DESCRIPTION = "";
 
+export function omittedImagesPrompt(images: number): string {
+  return `(${images} image(s) omitted — the agy print interface is text-only)`;
+}
+
 /** Rehydrate a fresh agy conversation from the active branch of a pi session. */
 export function restoredPiContextPrompt(transcript: string): string {
   return [

--- a/packages/pi-antigravity/src/provider.ts
+++ b/packages/pi-antigravity/src/provider.ts
@@ -33,7 +33,7 @@ import { readAgyProcessProfile, type AgyProcessProfile } from "../lib/agy-profil
 import type { AgyActivity, AgyUsage } from "../lib/reducer.ts";
 import type { AgyReplayStore } from "../lib/replay.ts";
 import { mapAgyToolToNative } from "../lib/native-tools.ts";
-import { restoredPiContextPrompt, WRAPPER_TOOL_NAME } from "../lib/prompt.ts";
+import { omittedImagesPrompt, restoredPiContextPrompt, WRAPPER_TOOL_NAME } from "../lib/prompt.ts";
 import {
   AntigravityRuntime,
   createAntigravityRuntime,
@@ -51,27 +51,48 @@ interface ImagePart {
   [k: string]: unknown;
 }
 
-/** Extract the latest user message text (plus an image-omitted note). */
-export function latestUserPrompt(context: Context): { prompt: string; images: number } {
-  let images = 0;
+/**
+ * Pi Context has no caller/extension provenance. Preserve the latest contiguous
+ * user-message batch in order, rather than letting its last message replace
+ * the caller's request. Trailing assistant/tool messages are tool-loop re-entry.
+ * Skip wholly empty batches, using the same boundary for history restoration.
+ */
+function latestUserBatch(context: Context): { start: number; prompt: string; images: number } {
   for (let i = context.messages.length - 1; i >= 0; i--) {
-    const message = context.messages[i] as { role?: string; content?: unknown };
-    if (message.role !== "user") continue;
-    const parts = Array.isArray(message.content) ? message.content : [];
-    let text = "";
-    for (const part of parts as (TextPart | ImagePart)[]) {
-      if (part && typeof part === "object" && part.type === "text") {
-        text += (text ? "\n" : "") + part.text;
-      } else if (part && typeof part === "object" && part.type === "image") {
-        images += 1;
+    if (context.messages[i].role !== "user") continue;
+    const end = i + 1;
+    while (i > 0 && context.messages[i - 1].role === "user") i--;
+    const texts: string[] = [];
+    let images = 0;
+    for (const message of context.messages.slice(i, end)) {
+      if (typeof message.content === "string") {
+        if (message.content.trim()) texts.push(message.content);
+        continue;
+      }
+      const parts = Array.isArray(message.content) ? message.content : [];
+      for (const part of parts as (TextPart | ImagePart)[]) {
+        if (part?.type === "text" && typeof part.text === "string" && part.text.trim()) {
+          texts.push(part.text);
+        } else if (part?.type === "image") {
+          images += 1;
+        }
       }
     }
-    if (images > 0) {
-      text += `\n(${images} image(s) omitted — the agy print interface is text-only)`;
-    }
-    return { prompt: text, images };
+    if (texts.length === 0 && images === 0) continue;
+    const prompt = texts.join("\n");
+    return {
+      start: i,
+      prompt: prompt + (images ? `\n${omittedImagesPrompt(images)}` : ""),
+      images,
+    };
   }
-  return { prompt: "", images: 0 };
+  return { start: -1, prompt: "", images: 0 };
+}
+
+/** Extract all text in the latest user batch (plus an image-omitted note). */
+export function latestUserPrompt(context: Context): { prompt: string; images: number } {
+  const { prompt, images } = latestUserBatch(context);
+  return { prompt, images };
 }
 
 // A fresh fallback conversation can safely receive roughly 60k transcript
@@ -82,13 +103,7 @@ const MAX_RESTORED_HISTORY_CHARS = 240_000;
 
 /** Serialize the active pi branch before its latest user request. */
 export function piHistoryBootstrap(context: Context): string | undefined {
-  let latestUser = -1;
-  for (let i = context.messages.length - 1; i >= 0; i--) {
-    if ((context.messages[i] as { role?: string }).role === "user") {
-      latestUser = i;
-      break;
-    }
-  }
+  const { start: latestUser } = latestUserBatch(context);
   if (latestUser <= 0) return undefined;
 
   const entries: string[] = [];
@@ -99,7 +114,8 @@ export function piHistoryBootstrap(context: Context): string | undefined {
       content?: unknown;
     };
     const parts = Array.isArray(message.content) ? message.content : [];
-    const rendered: string[] = [];
+    const rendered: string[] =
+      typeof message.content === "string" && message.content.trim() ? [message.content] : [];
     for (const part of parts as Array<Record<string, unknown>>) {
       if (part?.type === "text" && typeof part.text === "string" && part.text.trim()) {
         rendered.push(part.text);

--- a/packages/pi-antigravity/test/provider.test.ts
+++ b/packages/pi-antigravity/test/provider.test.ts
@@ -37,6 +37,79 @@ test("latestUserPrompt extracts the last user text", () => {
   assert.equal(images, 0);
 });
 
+test("latestUserPrompt accepts print-mode strings and skips empty user content", () => {
+  for (const content of ["", "  ", [], [{ type: "text", text: "" }], undefined]) {
+    assert.deepEqual(
+      latestUserPrompt(
+        contextWith([
+          { role: "user", content: "Reply with exactly: PONG" },
+          { role: "user", content },
+        ]),
+      ),
+      { prompt: "Reply with exactly: PONG", images: 0 },
+    );
+  }
+});
+
+test("latestUserPrompt preserves caller text alongside extension-added user messages", () => {
+  for (const content of [
+    "Reply with exactly: PONG",
+    [{ type: "text", text: "Reply with exactly: PONG" }],
+  ]) {
+    const ctx = contextWith([
+      { role: "user", content: "Old question" },
+      { role: "assistant", content: [{ type: "text", text: "Old answer" }] },
+      { role: "user", content },
+      { role: "user", content: "Context-mode is active. Session mode: implement." },
+      { role: "user", content: [{ type: "text", text: "Additional extension context" }] },
+    ]);
+    assert.equal(
+      latestUserPrompt(ctx).prompt,
+      "Reply with exactly: PONG\nContext-mode is active. Session mode: implement.\nAdditional extension context",
+    );
+    const history = piHistoryBootstrap(ctx);
+    assert.ok(history);
+    assert.match(history, /Old question/);
+    assert.doesNotMatch(history, /PONG|Context-mode|Additional extension/);
+    ctx.messages.push(
+      ...contextWith([
+        { role: "assistant", content: [{ type: "toolCall", name: "read" }] },
+        { role: "toolResult", content: [{ type: "text", text: "tool output" }] },
+      ]).messages,
+    );
+    assert.match(latestUserPrompt(ctx).prompt, /^Reply with exactly: PONG\nContext-mode/);
+  }
+});
+
+test("latestUserPrompt skips empty batches and does not carry images from history", () => {
+  const ctx = contextWith([
+    { role: "user", content: [{ type: "image", data: "old" }] },
+    { role: "assistant", content: [] },
+    { role: "user", content: "current" },
+    { role: "assistant", content: [] },
+    { role: "user", content: [] },
+  ]);
+  assert.deepEqual(latestUserPrompt(ctx), { prompt: "current", images: 0 });
+  assert.doesNotMatch(piHistoryBootstrap(ctx) ?? "", /current/);
+  assert.match(
+    latestUserPrompt(contextWith([{ role: "user", content: [{ type: "image", data: "only" }] }]))
+      .prompt,
+    /1 image\(s\) omitted/,
+  );
+});
+
+test("piHistoryBootstrap excludes the entire first-turn user batch", () => {
+  assert.equal(
+    piHistoryBootstrap(
+      contextWith([
+        { role: "user", content: "Reply with exactly: PONG" },
+        { role: "user", content: "Extension context" },
+      ]),
+    ),
+    undefined,
+  );
+});
+
 test("latestUserPrompt notes omitted images", () => {
   const ctx = contextWith([
     {
@@ -162,13 +235,17 @@ test("agyIncompleteToolError explains agy background tasks for run_command", () 
 });
 
 /** Harness for stream-level tests: a turn controller behind a fake runtime. */
-function makeStreamHarness(options: { prompt?: string; createIsolatedRuntime?: () => any } = {}) {
+function makeStreamHarness(
+  options: { prompt?: string; context?: Context; createIsolatedRuntime?: () => any } = {},
+) {
   const prompt = options.prompt ?? "hello";
   const controller = new AgyTurnController(prompt);
   let sharedBeginCount = 0;
+  let request: { prompt: string; historyBootstrap?: string } | undefined;
   const fakeService = {
-    beginStreamTurn: () =>
+    beginStreamTurn: (input: { prompt: string; historyBootstrap?: string }) =>
       Effect.sync(() => {
+        request = input;
         sharedBeginCount += 1;
         return controller;
       }),
@@ -209,7 +286,7 @@ function makeStreamHarness(options: { prompt?: string; createIsolatedRuntime?: (
 
   const createStream = () => {
     const ctx = contextWith([{ role: "user", content: [{ type: "text", text: prompt }] }]);
-    return streamFn(model, ctx);
+    return streamFn(model, options.context ?? ctx);
   };
   /** Start a turn; resolves with all events once the stream ends. */
   const collect = async (): Promise<any[]> => {
@@ -223,6 +300,7 @@ function makeStreamHarness(options: { prompt?: string; createIsolatedRuntime?: (
     createStream,
     replay,
     getSharedBeginCount: () => sharedBeginCount,
+    getRequest: () => request,
   };
 }
 
@@ -346,6 +424,28 @@ test("streamAntigravity isolates pi summarization from the resumed agy conversat
   assert.equal(done?.message.usage.totalTokens, 0);
   await new Promise<void>((resolve) => setImmediate(resolve));
   assert.equal(disposed, true);
+});
+
+test("streamAntigravity sends print-mode caller text with appended extension context", async () => {
+  for (const injected of [[], [{ role: "user", content: "Context-mode is active." }]]) {
+    const harness = makeStreamHarness({
+      context: contextWith([{ role: "user", content: "Reply with exactly: PONG" }, ...injected]),
+    });
+    harness.controller.push({
+      type: "result",
+      status: "OK",
+      error: undefined,
+      response: "PONG",
+      usage: undefined,
+    });
+    const events = await harness.collect();
+    assert.equal(events.at(-1)?.type, "done");
+    assert.equal(
+      harness.getRequest()?.prompt,
+      "Reply with exactly: PONG" + (injected.length ? "\nContext-mode is active." : ""),
+    );
+    assert.equal(harness.getRequest()?.historyBootstrap, undefined);
+  }
 });
 
 test("streamAntigravity renders a pending bash card on run_command ACTIVE", async () => {


### PR DESCRIPTION
## Summary

- Accept plain-string user content from `pi -p`, as well as text-part arrays; skip empty user batches.
- Preserve the latest contiguous user-message batch in order so appended extension context does not replace the caller's prompt. This does not guess message provenance or special-case context-mode.
- Use the same batch boundary for history restoration, preserving string-form historical messages and keeping the current request out of restored history.
- Add regression coverage and a patch changeset.

Fixes #33
Fixes #34

## Verification

- `pnpm run typecheck`
- `pnpm run check`
- `pnpm test`
- Focused provider tests: 33 passed
- `git diff --check`

All passed. The checks emit an unrelated, non-blocking Effect suggestion in `pi-vscode-bridge`. Live agy/context-mode end-to-end verification was not run.
