### PR TITLE
fix(pi-background-terminals): terminal lifecycle, cancellation, and viewer paging

### DIFF
--- a/.changeset/tidy-terminal-lifecycle.md
+++ b/.changeset/tidy-terminal-lifecycle.md
@@ -1,0 +1,7 @@
+---
+"@tian.zuo/pi-background-terminals": patch
+---
+
+Reap redirected POSIX descendants on natural exit and shutdown, prevent pre-spawn cancellation from executing commands, and scope terminal/archive IDs to a unique runtime so stale references cannot read unrelated logs.
+
+Fix UTF-8 spill paging and window bounds, and pause live following immediately when scrolling through either retained or archived output. Keep disk paging available when pausing before the initial window loads or when retention overflows during a pause. Classify aborted spawns as unsafe for fallback. Centralize model-facing errors, correct documentation, and add regression coverage with forced test exit disabled.

--- a/packages/pi-background-terminals/README.md
+++ b/packages/pi-background-terminals/README.md
@@ -35,7 +35,7 @@ Parameters:
 - `title` — optional short `/ps` label. The default strips common leading
   `D=/path;` or `cd /path &&` setup and preserves both ends when bounding a long
   command, so repeated setup prefixes do not hide the actual work.
-- `yield-time_ms` — optional initial wait, default **10 seconds**. Integer values
+- `yield_time_ms` — optional initial wait, default **10 seconds**. Integer values
   are clamped to **250–30,000 ms** rather than rejected when out of range.
 
 Behavior:
@@ -51,7 +51,7 @@ Behavior:
 4. If it exits during `yield_time_ms`, return its final status and bounded
    head+tail output to the model. Non-zero exits and hard timeouts are Bash tool
    errors. The TUI keeps the quick command visibly distinct from background work.
-5. If it remains alive, return an id such as `bt-1`. Only then does the row
+5. If it remains alive, return an id such as `bt-a12b34c56d78ef90-1`. Only then does the row
    collapse to compact background-terminal status. The model should continue
    rather than poll. Nearby exits share one compact follow-up after a 1,000 ms
    sliding quiet window, with a 3,000 ms maximum hold. An isolated exit keeps
@@ -64,11 +64,14 @@ read-only `terminal_log_read` tool only pages an opaque archive ref emitted by
 per agent run. The user still owns terminal inspection and termination through
 `/ps`.
 
-To prevent an agent from spending an entire run on recursive shell searches,
-the extension counts recognized read-only Bash inspection commands across the
-whole agent run. It starts adding a model-facing synthesis warning at call 6 and
-blocks call 9 (limit 8) before spawn. The counter resets for the next agent run;
-normal builds, tests, and other unrecognized execution commands are not counted.
+Terminal IDs include a random runtime identifier, so archive references from
+before `/reload` or `/resume` cannot resolve to a different command's output.
+Old references become unavailable rather than being reused. The read budgets
+apply only to `terminal_log_read`, not to Bash inspection commands.
+
+Cancellation before spawn prevents execution (including foreground fallback).
+Once a command has started, cancellation only ends the initial wait; the command
+continues in the background and remains eligible for its completion message.
 
 ### Safe foreground fallback
 
@@ -94,9 +97,10 @@ While at least one terminal runs, a one-line widget renders above the editor.
    `←/→`, or `h`/`l` switches tabs. Output tabs support live tailing, scrolling
    (`↑/↓`, `PgUp/PgDn`, `g`/`G`), and `x` to stop. Once a stream outgrows its
    in-memory retention the viewer reads the **complete on-disk log** instead:
-   scrolling past the top of the loaded window pulls in earlier bytes, `G`
-   returns to the live tail. The note row shows how much is loaded, how much
-   lies on either side, and the log's path.
+   scrolling up immediately pauses live following and freezes the reading
+   position (including retained output). Scrolling past the top of the loaded
+   window pulls in earlier bytes; `G` returns to the live tail. The note row
+   shows how much is loaded, how much lies on either side, and the log's path.
 
 ## Design
 
@@ -142,6 +146,8 @@ While at least one terminal runs, a one-line widget renders above the editor.
   transport may receive the script over stdin, but that pipe is closed
   immediately and cannot be used interactively.
 - **Process-tree termination.** POSIX children use their own process group.
+  Cleanup checks that group independently of stdio closure, so descendants with
+  redirected output are also reaped on natural shell exit and shutdown.
   On Windows the manager creates a dedicated Job Object before starting a
   terminal, and a pre-shell launcher joins it before Bash can run; every
   descendant therefore inherits `KILL_ON_JOB_CLOSE` membership without an
@@ -179,6 +185,9 @@ cd packages/pi-background-terminals
 pnpm run check
 pnpm test
 ```
+
+Tests run without forced process exit, including lifecycle regressions for
+redirected descendants, pre-spawn cancellation, and runtime-scoped archive IDs.
 
 ## Credits
 

--- a/packages/pi-background-terminals/command-shape.test.ts
+++ b/packages/pi-background-terminals/command-shape.test.ts
@@ -1,11 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  duplicateCommandError,
-  findDuplicateRunning,
-  isStateOnlyCommand,
-  stateOnlyCommandError,
-} from "./src/command-shape.ts";
+import { findDuplicateRunning, isStateOnlyCommand } from "./src/command-shape.ts";
+import { duplicateCommandError, stateOnlyCommandError } from "./src/prompt.ts";
 import type { OutputView, TerminalSnapshot } from "./src/domain.ts";
 
 function view(): OutputView {

--- a/packages/pi-background-terminals/docs/implementation-guide.md
+++ b/packages/pi-background-terminals/docs/implementation-guide.md
@@ -127,13 +127,14 @@ immediately. Neither path provides an interactive input surface.
 ```text
 index.ts                    Pi boundary, bash override, fallback, /ps
 src/command-shape.ts        Pre-spawn guards: state-only and duplicate commands
+src/constants.ts            Shared execution and output limits
 src/domain.ts               Snapshot/status/error types
 src/manager.ts              Effect service and process lifecycle
 src/output.ts               Bounded head+tail stream retention
 src/process-tracker.ts      Synchronous abnormal-exit process-tree safety net
 src/win32-job.ts            Native named Job Object creation and membership
 src/win32-child.mjs         Plain-JS pre-shell launcher that joins the job first
-src/prompt.ts               Tool metadata and model-facing formatting
+src/prompt.ts               Tool metadata, validation/errors, model-facing formatting
 src/result-delivery.ts      Drain-once completion delivery map
 src/runtime.ts              ManagedRuntime and Effect→Promise boundary
 src/ui/output-view.ts       ANSI-safe wrapped output rendering
@@ -158,7 +159,7 @@ running ── /ps stop / session teardown ────────► killed
 
 A snapshot includes:
 
-- stable `bt-N` id;
+- stable `bt-<16-hex-runtime-id>-N` id, never reused across runtime recreation;
 - exact model command, bounded title, absolute cwd, and pid;
 - timestamps, optional timeout, and final exit code or signal;
 - separate stdout/stderr `OutputView` values;
@@ -204,14 +205,19 @@ at most four source lines. Quick final results show at most six; yielded results
 collapse to compact terminal status with `/ps`. Exceptions thrown by the display
 callback are ignored; presentation cannot affect process execution.
 
-The initial wait is abortible. Aborting it does not kill the process. The error
+Cancellation is checked before initialization, after initialization, and at the
+spawn boundary (after any asynchronous Windows job setup). A pre-spawn abort
+never runs the command or invokes foreground fallback. Abort-related spawn
+errors carry `fallbackSafe: false`, independently of the tool boundary's own
+cancellation checks. Once spawned, the initial
+wait is abortible. Aborting it does not kill the process. The error
 identifies the terminal id, and eventual settlement remains eligible for an
 automatic follow-up.
 
 The returned result has two forms:
 
 - **Final:** status/output are returned directly, without presenting the
-  manager's internal `bt-N` identity as background work, and any deferred
+  manager's internal terminal identity as background work, and any deferred
   completion for the tiny start→wait race is consumed. Failed, killed, and
   timed-out final states throw so Pi marks the Bash result as an error.
 - **Yielded:** status is `running`, the id and captured startup output are
@@ -424,7 +430,7 @@ terminal status.
 ### Model-facing archive reads
 
 `terminal_log_read` is the only model-facing path into a complete spill. It
-accepts the opaque `bt-N:stdout` or `bt-N:stderr` reference emitted by Bash,
+accepts the opaque `bt-<runtime-id>-N:stdout` or `bt-<runtime-id>-N:stderr` reference emitted by Bash,
 plus a byte `offset` and bounded `limit`. The manager resolves the reference
 against the live session registry rather than exposing a filesystem path. Each
 read returns `settled`, `complete`, the current file size, and `next_offset`;
@@ -433,7 +439,8 @@ poll operation. Pages are capped at 64 KiB, and the extension permits 256 KiB
 and 8 archive reads per agent run. Both budgets are required: the byte budget
 bounds full-page firehosing, and the call budget bounds a `limit: 1` polling
 loop that would otherwise spend almost no bytes. Pruned entries return an
-expired/unavailable error.
+expired/unavailable error. Every manager has a fresh random 64-bit runtime id;
+refs from a previous runtime cannot alias terminals after reload/resume.
 
 A byte offset chosen by the model can land inside a code point, so both window
 edges are snapped to UTF-8 boundaries before decoding: leading continuation
@@ -474,14 +481,18 @@ Exit metadata is recorded on Node's `exit` event, but settlement occurs on
 `close` so output has reached EOF. If descendants inherit the pipes and hold
 them open after the shell exits, bounded cleanup closes the entry scope and
 reaps the process group — on Windows, closing the job kills the survivors and
-releases the pipes they hold.
+releases the pipes they hold. Closed pipes alone are not proof of tree exit:
+redirected descendants may still be alive in the POSIX process group. Natural
+settlement and explicit termination both reap that group with bounded
+SIGTERM→SIGKILL escalation. A group remains in the abnormal-exit tracker until
+it is gone; disposal sweeps any residual group.
 
 The entry scope is the single cleanup path for `/ps` stop, hard timeout,
 pruning, internal kill calls, and runtime disposal.
 
 Pi's detached-child tracker is internal and not exported. The manager therefore
 registers its own synchronous Node `exit` listener while live, tracks every
-spawned pid and open job until close/scope cleanup, and closes every tracked job
+spawned process group and open job until confirmed tree cleanup, and closes every tracked job
 object followed by a best-effort process-tree SIGKILL (`taskkill /F /T` on
 Windows) if an uncaught crash or emergency terminal exit bypasses
 `session_shutdown`. Closed jobs are untracked immediately, so long sessions do
@@ -545,9 +556,14 @@ seekAfter   next window starts exactly where the current one ended → viewer
 The two exact anchors are why paging needs no line arithmetic: a re-anchored
 window shares a byte boundary with the window it replaces, so reading continues
 without a gap or overlap in either direction. `follow` runs only while the
-viewer is *following* (bottom-pinned and untouched by backwards paging), so a
-reader in history is never yanked to EOF; `G` restores following. A pruned or
-unreadable spill records a bounded error and the view degrades to the retained
+viewer is *following*. Any upward scroll, Page Up, or `g` pauses following
+immediately, not just when a disk page is loaded. Retained in-memory text is
+frozen while paused, so its rolling tail cannot move the reading position.
+The first disk window may still load while paused; pausing before its async
+read commits must not disable archive paging. If retention overflows during a
+memory pause, explicit backward paging switches to the spill without requiring
+`G` or a tab switch. Returning to the bottom or pressing `G` restores following.
+A pruned or unreadable spill records a bounded error and the view degrades to the retained
 buffer with a note.
 
 ## 16. Session teardown
@@ -589,7 +605,10 @@ The package test suite covers:
 - pre-spawn blocking and next-run reset for state-only and duplicate commands;
 - hard timeout status and tree termination;
 - Bash-specific syntax on the resolved shell;
-- abort leaving eventual completion deliverable;
+- pre-spawn cancellation preventing execution and fallback, including during initialization;
+- post-spawn abort leaving eventual completion deliverable;
+- redirected SIGTERM-resistant descendants reaped on natural exit and disposal;
+- archive refs from an old runtime rejected after recreation;
 - process-tree kill, pre-shell Windows job membership, reload-safe native FFI,
   SIGKILL escalation, and abnormal process-exit cleanup;
 - session disposal, spill-directory cleanup, and per-entry pruning cleanup;
@@ -604,13 +623,19 @@ The package test suite covers:
 - spill-window follow/backfill/re-anchor anchoring, UTF-8 boundaries, and
   degradation when the log becomes unreadable.
 
+The suite runs without `--test-force-exit`, so leaked handles cannot be hidden
+by forcibly exiting the test runner. Unicode paging tests cover three- and
+four-byte characters at non-aligned window boundaries, and `/ps` component
+interaction tests verify that scrolling pauses both memory and disk output.
+
 Validation commands:
 
 ```bash
-npm run check --workspace @tian.zuo/pi-background-terminals
-npm test --workspace @tian.zuo/pi-background-terminals
-npm run typecheck
-npm pack --dry-run --workspace @tian.zuo/pi-background-terminals
+pnpm --filter @tian.zuo/pi-background-terminals run check
+pnpm --filter @tian.zuo/pi-background-terminals test
+pnpm run typecheck
+pnpm run check
+pnpm test
 ```
 
 The publish workflow runs both typechecks and the package test suite before its

--- a/packages/pi-background-terminals/index.test.ts
+++ b/packages/pi-background-terminals/index.test.ts
@@ -91,6 +91,79 @@ async function pollUntil(
   return true;
 }
 
+test("a pre-aborted Bash call does not initialize or spawn", async () => {
+  let initialized = false;
+  const app = harness(
+    createBackgroundTerminalsExtension({
+      resolveShellSettings: () => ({}),
+      createRuntime: () => {
+        initialized = true;
+        throw new Error("must not initialize");
+      },
+      createForegroundBash: () => {
+        throw new Error("must not fall back");
+      },
+    }),
+  );
+  const controller = new AbortController();
+  controller.abort();
+  try {
+    await assert.rejects(
+      app.tools
+        .get("bash")
+        .execute("aborted", { command: "echo forbidden" }, controller.signal, undefined, app.ctx),
+      { name: "AbortError" },
+    );
+    assert.equal(initialized, false);
+  } finally {
+    await app.shutdown();
+  }
+});
+
+test("cancellation during manager initialization prevents spawn and fallback", async () => {
+  const { createTerminalRuntime } = await import("./src/runtime.ts");
+  const { TerminalManager } = await import("./src/manager.ts");
+  const runtime = createTerminalRuntime();
+  const controller = new AbortController();
+  const manager = await runtime.runPromise(TerminalManager);
+  const abortingRuntime = new Proxy(runtime, {
+    get(target, property, receiver) {
+      if (property !== "runPromise") return Reflect.get(target, property, receiver);
+      return (effect: Parameters<typeof runtime.runPromise>[0]) => {
+        const result = runtime.runPromise(effect);
+        controller.abort();
+        return result;
+      };
+    },
+  });
+  const app = harness(
+    createBackgroundTerminalsExtension({
+      resolveShellSettings: () => ({}),
+      createRuntime: () => abortingRuntime,
+      createForegroundBash: () => {
+        throw new Error("must not fall back");
+      },
+    }),
+  );
+  try {
+    await assert.rejects(
+      app.tools
+        .get("bash")
+        .execute(
+          "aborted-init",
+          { command: "echo forbidden" },
+          controller.signal,
+          undefined,
+          app.ctx,
+        ),
+      { name: "AbortError" },
+    );
+    assert.equal(manager.view.size(), 0);
+  } finally {
+    await app.shutdown();
+  }
+});
+
 test("extension overrides bash, adds log reading, and keeps the user /ps command", async () => {
   const app = harness(backgroundTerminals);
   try {
@@ -165,7 +238,7 @@ test("terminal_log_read resolves an opaque ref from bash", async () => {
       undefined,
       app.ctx,
     );
-    const ref = /archive ref (bt-\d+:stdout)/.exec(result.content[0].text)?.[1];
+    const ref = /archive ref (bt-[a-f0-9]{16}-\d+:stdout)/.exec(result.content[0].text)?.[1];
     assert.ok(ref, result.content[0].text);
 
     const page = await app.tools
@@ -193,7 +266,7 @@ test("terminal_log_read is bounded by a per-run call budget", async () => {
       undefined,
       app.ctx,
     );
-    const ref = /archive ref (bt-\d+:stdout)/.exec(result.content[0].text)?.[1];
+    const ref = /archive ref (bt-[a-f0-9]{16}-\d+:stdout)/.exec(result.content[0].text)?.[1];
     assert.ok(ref, result.content[0].text);
 
     const read = (id: string) =>
@@ -263,8 +336,8 @@ test("renderers distinguish quick bash from actually yielded terminals", async (
           {
             type: "text",
             text: [
-              'Command is still running as background terminal bt-9 "server".',
-              'bt-9 [running] "server" (pid 99)',
+              'Command is still running as background terminal bt-0123456789abcdef-9 "server".',
+              'bt-0123456789abcdef-9 [running] "server" (pid 99)',
               "",
               "stdout:",
               "startup-output",
@@ -277,7 +350,7 @@ test("renderers distinguish quick bash from actually yielded terminals", async (
       { isError: false },
     );
     const renderedYielded = yielded.render(120).join("\n").trimEnd();
-    assert.match(renderedYielded, /terminal bt-9 running.*\/ps to inspect/);
+    assert.match(renderedYielded, /terminal bt-0123456789abcdef-9 running.*\/ps to inspect/);
     assert.doesNotMatch(renderedYielded, /stdout|startup-output|server"/);
 
     const completionRenderer = app.messageRenderers.get("background-terminal-result");
@@ -388,7 +461,7 @@ test("re-running a still-running command is refused instead of duplicating it", 
         undefined,
         app.ctx,
       ),
-      /already running as background terminal bt-\d+.*has not failed/is,
+      /already running as background terminal bt-[a-f0-9]{16}-\d+.*has not failed/is,
     );
   } finally {
     await app.shutdown();
@@ -691,7 +764,7 @@ test("a yielded hard timeout sends exactly one timed-out completion", async () =
       undefined,
       app.ctx,
     );
-    assert.match(result.content[0].text, /background terminal bt-\d+/);
+    assert.match(result.content[0].text, /background terminal bt-[a-f0-9]{16}-\d+/);
     assert.equal(
       await pollUntil(() => app.messages.length === 1),
       true,
@@ -730,7 +803,7 @@ test("failed result delivery does not write directly to the TUI terminal", async
       undefined,
       app.ctx,
     );
-    assert.match(result.content[0].text, /background terminal bt-\d+/);
+    assert.match(result.content[0].text, /background terminal bt-[a-f0-9]{16}-\d+/);
     assert.equal(await pollUntil(() => deliveryAttempts === 1), true, "delivery was attempted");
     assert.deepEqual(consoleErrors, []);
   } finally {
@@ -756,7 +829,7 @@ test("yielded command returns an id then sends exactly one completion", async ()
     );
 
     assert.equal(result.details, undefined);
-    assert.match(result.content[0].text, /background terminal bt-\d+/);
+    assert.match(result.content[0].text, /background terminal bt-[a-f0-9]{16}-\d+/);
     assert.match(result.content[0].text, /do not poll/);
 
     assert.equal(
@@ -800,7 +873,7 @@ test("near-simultaneous yielded completions share one follow-up", async () => {
       ),
     );
     const ids = results.map((result) => {
-      const id = /background terminal (bt-\d+)/.exec(result.content[0].text)?.[1];
+      const id = /background terminal (bt-[a-f0-9]{16}-\d+)/.exec(result.content[0].text)?.[1];
       assert.ok(id, result.content[0].text);
       return id;
     });

--- a/packages/pi-background-terminals/index.ts
+++ b/packages/pi-background-terminals/index.ts
@@ -35,22 +35,26 @@ import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { createCompletionBatchScheduler } from "./src/completion-batcher.ts";
 import { SpawnError, type TerminalSnapshot, type TerminalStatus } from "./src/domain.ts";
-import {
-  duplicateCommandError,
-  findDuplicateRunning,
-  isStateOnlyCommand,
-  stateOnlyCommandError,
-} from "./src/command-shape.ts";
+import { findDuplicateRunning, isStateOnlyCommand } from "./src/command-shape.ts";
 import {
   DEFAULT_YIELD_TIME_MS,
   MAX_RUNTIME_TIMEOUT_SECONDS,
   MAX_TERMINAL_LOG_READ_BYTES,
+  TERMINAL_LOG_READ_RUN_BUDGET,
+  TERMINAL_LOG_READ_RUN_CALLS,
+} from "./src/constants.ts";
+import {
   TerminalManager,
   type SettlementWaitResult,
   type TerminalLogReadResult,
   type TerminalManagerShape,
 } from "./src/manager.ts";
 import {
+  TERMINAL_ERRORS,
+  foregroundFallbackWarning,
+  formatTerminalLogRead,
+  duplicateCommandError,
+  stateOnlyCommandError,
   BASH_PARAMETER_DESCRIPTIONS,
   BASH_PROMPT_SNIPPET,
   BASH_TOOL_DESCRIPTION,
@@ -79,26 +83,13 @@ const SESSION_ENV_KEYS = [
 
 type CompactTerminalStatus = TerminalStatus | "starting";
 
-const TERMINAL_LOG_READ_RUN_BUDGET = MAX_TERMINAL_LOG_READ_BYTES * 4;
-/** A byte budget alone cannot stop `limit: 1` polling; bound the calls too. */
-const TERMINAL_LOG_READ_RUN_CALLS = 8;
-
 function parseTerminalLogRef(ref: string) {
-  const match = /^(bt-\d+):(stdout|stderr)$/.exec(ref);
+  const match = /^(bt-[a-f0-9]{16}-\d+):(stdout|stderr)$/.exec(ref);
   if (!match) return undefined;
   return {
     id: match[1],
     stream: match[2] as "stdout" | "stderr",
   };
-}
-
-function formatTerminalLogRead(result: TerminalLogReadResult) {
-  const range = result.bytesRead === 0 ? "empty" : `${result.offset}-${result.nextOffset - 1}`;
-  return [
-    `${result.id}:${result.stream} bytes ${range} of ${result.size}; ` +
-      `settled: ${result.settled ? "yes" : "no"}; complete: ${result.complete ? "yes" : "no"}; next_offset: ${result.nextOffset}`,
-    result.text || "(empty)",
-  ].join("\n");
 }
 
 /** Extract manager-owned status from a model-facing Bash result. Output is
@@ -109,8 +100,10 @@ function compactTerminalState(
   isError: boolean,
 ): { readonly id?: string; readonly status: CompactTerminalStatus } {
   const metadata = text.split("\n\nstdout:", 1)[0] ?? "";
-  const described = metadata.match(/\b(bt-\d+) \[(running|done|failed|timed_out|killed)\]/);
-  const id = described?.[1] ?? metadata.match(/\bterminal (bt-\d+)\b/i)?.[1];
+  const described = metadata.match(
+    /\b(bt-[a-f0-9]{16}-\d+) \[(running|done|failed|timed_out|killed)\]/,
+  );
+  const id = described?.[1] ?? metadata.match(/\bterminal (bt-[a-f0-9]{16}-\d+)\b/i)?.[1];
   const describedStatus = described?.[2] as TerminalStatus | undefined;
 
   if (describedStatus) return { id, status: describedStatus };
@@ -462,10 +455,11 @@ export function createBackgroundTerminalsExtension(
         return text;
       },
       async execute(toolCallId, params, signal, onUpdate, ctx) {
+        signal?.throwIfAborted();
         // Preserve the exact command text. Trimming here can break heredocs and
         // multiline scripts; trim only for validation and the display title.
         const command = params.command;
-        if (!command.trim()) throw new Error("command must not be empty.");
+        if (!command.trim()) throw new Error(TERMINAL_ERRORS.emptyCommand);
 
         // The shell is discarded at exit, so a command that only mutates shell
         // state cannot affect anything. Left to run it would exit 0 and let the
@@ -478,9 +472,7 @@ export function createBackgroundTerminalsExtension(
             params.timeout <= 0 ||
             params.timeout > MAX_RUNTIME_TIMEOUT_SECONDS)
         ) {
-          throw new Error(
-            `timeout must be a finite number of seconds in (0, ${MAX_RUNTIME_TIMEOUT_SECONDS}].`,
-          );
+          throw new Error(TERMINAL_ERRORS.invalidTimeout);
         }
 
         const cwd = path.resolve(ctx.cwd, params.working_dir ?? ".");
@@ -489,7 +481,7 @@ export function createBackgroundTerminalsExtension(
             throw new Error("not a directory");
           }
         } catch {
-          throw new Error(`working_dir is not a directory: ${cwd}`);
+          throw new Error(TERMINAL_ERRORS.invalidDirectory(cwd));
         }
 
         // Preserve Pi's built-in shellPath and shellCommandPrefix settings even
@@ -502,16 +494,16 @@ export function createBackgroundTerminalsExtension(
         const title = deriveCommandTitle(command, params.title);
 
         const runForegroundFallback = async (reason: unknown, resetManagedRuntime: boolean) => {
+          signal?.throwIfAborted();
           if (resetManagedRuntime) {
             const brokenRuntime = runtime;
             runtime = undefined;
             managerPromise = undefined;
             await brokenRuntime?.dispose().catch(() => {});
           }
+          signal?.throwIfAborted();
           const reasonText = reason instanceof Error ? reason.message : String(reason);
-          const warning =
-            `[Managed bash unavailable before spawn; using Pi's foreground bash fallback — ` +
-            `no auto-yield or /ps tracking for this call. Reason: ${reasonText.slice(0, 500)}]`;
+          const warning = foregroundFallbackWarning(reasonText);
           if (ctx.hasUI) ctx.ui.notify(warning, "warning");
 
           const fallback = makeForegroundBash(cwd, {
@@ -544,6 +536,8 @@ export function createBackgroundTerminalsExtension(
           return await runForegroundFallback(managerError, true);
         }
 
+        signal?.throwIfAborted();
+
         // Re-issuing a command that is still running is the one mistake the model
         // gets no feedback on: the duplicate repeats every side effect and both
         // copies report success. Refuse instead of spawning it twice.
@@ -563,6 +557,7 @@ export function createBackgroundTerminalsExtension(
         if (thinkingLevel) env.PI_REASONING_LEVEL = thinkingLevel;
 
         let started: TerminalSnapshot;
+        signal?.throwIfAborted();
         try {
           started = await runTool(
             getRuntime(),
@@ -573,6 +568,7 @@ export function createBackgroundTerminalsExtension(
               title,
               cwd,
               env,
+              signal,
               timeoutMs: params.timeout === undefined ? undefined : params.timeout * 1000,
             }),
           );
@@ -633,7 +629,7 @@ export function createBackgroundTerminalsExtension(
         try {
           waited = await runTool(getRuntime(), waitForSettlement(), {
             signal,
-            interruptMessage: `Initial wait aborted; ${started.id} continues in the background and will report when it exits.`,
+            interruptMessage: TERMINAL_ERRORS.initialWaitAborted(started.id),
           });
         } finally {
           unsubscribe();
@@ -715,9 +711,7 @@ export function createBackgroundTerminalsExtension(
       async execute(_toolCallId, params) {
         const parsed = parseTerminalLogRef(params.ref);
         if (!parsed) {
-          throw new Error(
-            `Invalid terminal log ref "${params.ref}"; expected bt-N:stdout or bt-N:stderr.`,
-          );
+          throw new Error(TERMINAL_ERRORS.invalidRef(params.ref));
         }
         const limit = Math.min(
           MAX_TERMINAL_LOG_READ_BYTES,
@@ -726,16 +720,10 @@ export function createBackgroundTerminalsExtension(
         // Two budgets, because either one alone is escapable: bytes bound a
         // firehose of full pages, calls bound a tiny-limit polling loop.
         if (terminalLogReadCalls >= TERMINAL_LOG_READ_RUN_CALLS) {
-          throw new Error(
-            `terminal_log_read budget exhausted for this agent run (maximum ${TERMINAL_LOG_READ_RUN_CALLS} reads). ` +
-              "Work with the output you already have; the user can inspect the full log with /ps.",
-          );
+          throw new Error(TERMINAL_ERRORS.readCalls);
         }
         if (terminalLogReadBytes + limit > TERMINAL_LOG_READ_RUN_BUDGET) {
-          throw new Error(
-            `terminal_log_read budget exhausted for this agent run (maximum ${TERMINAL_LOG_READ_RUN_BUDGET} bytes). ` +
-              "Work with the output you already have; the user can inspect the full log with /ps.",
-          );
+          throw new Error(TERMINAL_ERRORS.readBytes);
         }
         terminalLogReadCalls++;
         const manager = await getManager();

--- a/packages/pi-background-terminals/lifecycle.test.ts
+++ b/packages/pi-background-terminals/lifecycle.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import { TerminalManager } from "./src/manager.ts";
+import { SpawnError } from "./src/domain.ts";
+import { createTerminalRuntime, runTool } from "./src/runtime.ts";
+
+function command(script: string) {
+  return `node -e "eval(Buffer.from('${Buffer.from(script).toString("base64")}','base64').toString())"`;
+}
+
+function running(pid: number) {
+  const result = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf8" });
+  return result.status === 0 && !result.stdout.trim().startsWith("Z");
+}
+
+for (const shutdown of [false, true]) {
+  test(`redirected SIGTERM-resistant descendants are reaped on ${shutdown ? "disposal" : "natural exit"}`, {
+    skip: process.platform === "win32",
+    timeout: 20_000,
+  }, async () => {
+    const runtime = createTerminalRuntime();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bt-lifecycle-"));
+    const ready = path.join(dir, "ready");
+    let pid: number | undefined;
+    try {
+      const manager = await runtime.runPromise(TerminalManager);
+      const childScript = `process.on('SIGTERM', () => {}); require('node:fs').writeFileSync(${JSON.stringify(ready)}, String(process.pid)); setInterval(() => {}, 1000);`;
+      const script = `
+          const fs = require('node:fs');
+          const child = require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });
+          child.unref();
+          const timer = setInterval(() => {
+            if (!fs.existsSync(${JSON.stringify(ready)})) return;
+            console.log(child.pid);
+            clearInterval(timer);
+            ${shutdown ? "setInterval(() => {}, 1000);" : ""}
+          }, 10);
+        `;
+      const snap = await runtime.runPromise(
+        manager.start({ command: command(script), cwd: dir, title: "redirected tree" }),
+      );
+      const deadline = Date.now() + 5_000;
+      while (!fs.existsSync(ready) && Date.now() < deadline)
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      pid = Number(fs.readFileSync(ready, "utf8"));
+      assert.ok(Number.isSafeInteger(pid) && pid > 0);
+      if (shutdown) {
+        await runtime.dispose();
+      } else {
+        const result = await runtime.runPromise(manager.waitForSettlement(snap.id, 10_000));
+        assert.equal(result.settled, true);
+        assert.equal(result.snapshot.status, "done");
+      }
+      assert.equal(running(pid), false, `descendant ${pid} survived cleanup`);
+    } finally {
+      if (pid && running(pid)) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {}
+      }
+      await runtime.dispose();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+test("archive identities never alias after runtime recreation", async () => {
+  let oldId = "";
+  for (const text of ["old", "new"]) {
+    const runtime = createTerminalRuntime();
+    try {
+      const manager = await runtime.runPromise(TerminalManager);
+      const snap = await runtime.runPromise(
+        manager.start({ command: `printf ${text}`, cwd: process.cwd(), title: text }),
+      );
+      await runtime.runPromise(manager.waitForSettlement(snap.id, 5_000));
+      if (oldId) {
+        assert.notEqual(snap.id, oldId);
+        await assert.rejects(
+          runTool(runtime, manager.readLog({ id: oldId, stream: "stdout", offset: 0, limit: 64 })),
+          /Unknown terminal id/,
+        );
+      }
+      const page = await runtime.runPromise(
+        manager.readLog({ id: snap.id, stream: "stdout", offset: 0, limit: 64 }),
+      );
+      assert.equal(page.text, text);
+      oldId = snap.id;
+    } finally {
+      await runtime.dispose();
+    }
+  }
+});
+
+test("manager checks cancellation at the spawn boundary", async () => {
+  const runtime = createTerminalRuntime();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bt-cancel-"));
+  try {
+    const manager = await runtime.runPromise(TerminalManager);
+    const controller = new AbortController();
+    controller.abort();
+    await assert.rejects(
+      runTool(
+        runtime,
+        manager.start({
+          command: "echo forbidden > marker",
+          cwd: dir,
+          title: "cancelled",
+          signal: controller.signal,
+        }),
+      ),
+      (error: unknown) => {
+        assert.ok(error instanceof SpawnError);
+        assert.match(error.message, /aborted/i);
+        assert.equal(error.fallbackSafe, false, "an abort must never authorize fallback");
+        return true;
+      },
+    );
+    assert.equal(manager.view.size(), 0);
+    assert.equal(fs.existsSync(path.join(dir, "marker")), false);
+  } finally {
+    await runtime.dispose();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/pi-background-terminals/manager.test.ts
+++ b/packages/pi-background-terminals/manager.test.ts
@@ -21,9 +21,8 @@ import {
   MAX_RUNNING,
   MAX_TRACKED,
   RETAINED_PER_STREAM,
-  TerminalManager,
-  type TerminalManagerShape,
-} from "./src/manager.ts";
+} from "./src/constants.ts";
+import { TerminalManager, type TerminalManagerShape } from "./src/manager.ts";
 import { createTerminalRuntime, runTool } from "./src/runtime.ts";
 
 const cwd = process.cwd();
@@ -1125,7 +1124,7 @@ test("status returns the snapshot and rejects unknown ids with the known list", 
     assert.equal(seen.id, snap.id);
     await assert.rejects(
       runTool(runtime, manager.status("bt-999")),
-      /Unknown terminal id "bt-999"\. Known: bt-1\./,
+      /Unknown terminal id "bt-999"\. Known: bt-[a-f0-9]{16}-1\./,
     );
   });
 });

--- a/packages/pi-background-terminals/package.json
+++ b/packages/pi-background-terminals/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "check": "tsc --noEmit -p .",
     "prepare": "effect-tsgo patch",
-    "test": "node --test --test-force-exit --test-concurrency=1 --experimental-strip-types index.test.ts manager.test.ts output.test.ts prompt.test.ts command-shape.test.ts completion-batcher.test.ts result-delivery.test.ts ps.test.ts spill-source.test.ts"
+    "test": "node --test --test-concurrency=1 --experimental-strip-types index.test.ts manager.test.ts lifecycle.test.ts output.test.ts prompt.test.ts command-shape.test.ts completion-batcher.test.ts result-delivery.test.ts ps.test.ts spill-source.test.ts"
   },
   "dependencies": {
     "effect": "4.0.0-beta.101",

--- a/packages/pi-background-terminals/ps.test.ts
+++ b/packages/pi-background-terminals/ps.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
+  openTerminalPicker,
   buildTerminalInvocationInfo,
   cycleTerminalDetailTab,
   DEFAULT_TERMINAL_DETAIL_TAB,
@@ -8,6 +12,207 @@ import {
   type DashboardSelection,
 } from "./src/ui/ps.ts";
 import { buildOutputLines, createOutputLineCache, sanitizeText } from "./src/ui/output-view.ts";
+
+for (const diskBacked of [false, true]) {
+  test(`detail scrolling freezes ${diskBacked ? "spill" : "retained"} output until G`, async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "bt-view-test-"));
+    const file = path.join(dir, "output");
+    const original = Array.from({ length: 2000 }, (_, i) => `line-${i}`).join("\n") + "\n";
+    await fs.writeFile(file, original);
+    const output = {
+      text: original,
+      head: original,
+      tail: "",
+      totalBytes: original.length,
+      truncatedBytes: diskBacked ? 1 : 0,
+      spillPath: diskBacked ? file : undefined,
+    };
+    const snap = {
+      id: "bt-0123456789abcdef-1",
+      command: "test",
+      title: "test",
+      cwd: dir,
+      createdAt: Date.now(),
+      status: "running" as const,
+      stdout: output,
+      stderr: output,
+    };
+    const view = {
+      size: () => 1,
+      list: () => [snap],
+      get: () => snap,
+      subscribe: () => () => {},
+      subscribeTo: () => () => {},
+      requestKill: () => {},
+      setOnSettled: () => {},
+    };
+    let customCalls = 0;
+    const ctx = {
+      ui: {
+        custom: async (factory: any) => {
+          const component = factory(
+            { terminal: { rows: 30 }, requestRender() {} },
+            { fg: (_: string, text: string) => text, bold: (text: string) => text },
+            { matches: () => false, getKeys: () => [] },
+            () => {},
+          );
+          try {
+            if (++customCalls !== 2) return customCalls === 1 ? snap.id : null;
+            component.handleInput("t");
+            const deadline = Date.now() + 3000;
+            while (diskBacked && !component.render(100).join("\n").includes("full log (live)")) {
+              assert.ok(Date.now() < deadline, "spill loaded");
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+            component.render(100);
+            component.handleInput("k");
+            const visible = () =>
+              component.render(100).filter((line: string) => /^ {2}(line-|new-)/.test(line));
+            const before = visible();
+            assert.ok(before.length > 0);
+            const growth = Array.from({ length: 100 }, (_, i) => `new-${i}`).join("\n") + "\n";
+            output.text += growth;
+            output.totalBytes += growth.length;
+            await fs.appendFile(file, growth);
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+            assert.deepEqual(visible(), before, "reading position must remain stable");
+            component.handleInput("G");
+            const resumedDeadline = Date.now() + 3000;
+            while (!visible().some((line: string) => line.includes("new-99"))) {
+              assert.ok(Date.now() < resumedDeadline, "G resumes live output");
+              await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+            return null;
+          } finally {
+            component.dispose();
+          }
+        },
+      },
+    } as unknown as Parameters<typeof openTerminalPicker>[0];
+    try {
+      await openTerminalPicker(ctx, view);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+for (const transition of ["initial-load", "retention-overflow"] as const) {
+  test(`paused ${transition} still permits complete spill paging`, async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "bt-paused-paging-"));
+    const file = path.join(dir, "output");
+    const complete = Array.from(
+      { length: 12_000 },
+      (_, i) => `archive-${i}: ${"x".repeat(200)}\n`,
+    ).join("");
+    const retained = complete.split("\n").slice(-100).join("\n");
+    const initial = "retained line\n".repeat(100);
+    await fs.writeFile(file, transition === "initial-load" ? complete : initial);
+    const output = {
+      text: transition === "initial-load" ? retained : initial,
+      head: "",
+      tail: "",
+      totalBytes: transition === "initial-load" ? complete.length : initial.length,
+      truncatedBytes: transition === "initial-load" ? complete.length - retained.length : 0,
+      spillPath: file,
+    };
+    const snap = {
+      id: "bt-0123456789abcdef-1",
+      command: "test",
+      title: "test",
+      cwd: dir,
+      createdAt: Date.now(),
+      status: "running" as const,
+      stdout: output,
+      stderr: output,
+    };
+    const view = {
+      size: () => 1,
+      list: () => [snap],
+      get: () => snap,
+      subscribe: () => () => {},
+      subscribeTo: () => () => {},
+      requestKill: () => {},
+      setOnSettled: () => {},
+    };
+    let customCalls = 0;
+    const ctx = {
+      ui: {
+        custom: async (factory: any) => {
+          const component = factory(
+            { terminal: { rows: 30 }, requestRender() {} },
+            { fg: (_: string, text: string) => text, bold: (text: string) => text },
+            { matches: () => false, getKeys: () => [] },
+            () => {},
+          );
+          try {
+            if (++customCalls !== 2) return customCalls === 1 ? snap.id : null;
+            const render = (): string => component.render(250).join("\n");
+            const until = async (predicate: () => boolean, label: string) => {
+              const deadline = Date.now() + 5000;
+              while (!predicate()) {
+                assert.ok(Date.now() < deadline, label);
+                await new Promise((resolve) => setTimeout(resolve, 10));
+              }
+            };
+            component.handleInput("t");
+            render();
+            // No await: k always arrives before the initial asynchronous window commits.
+            component.handleInput("k");
+            render();
+            if (transition === "retention-overflow") {
+              await fs.writeFile(file, complete);
+              output.text = retained;
+              output.totalBytes = complete.length;
+              output.truncatedBytes = complete.length - retained.length;
+            }
+            component.handleInput("g");
+            await until(
+              () => render().includes("full log · showing"),
+              "paused initial disk load completes",
+            );
+            assert.doesNotMatch(render(), /full log \(live\)/);
+            // g can keep walking backward from the loaded window to byte zero,
+            // without G or tab switching and without exposing only the retained tail.
+            for (let page = 0; page < 5 && !render().includes("archive-0:"); page++) {
+              const range = () =>
+                render()
+                  .split("\n")
+                  .find((line) => line.includes("full log · showing"));
+              const before = range();
+              component.handleInput("g");
+              await until(
+                () => range() !== before || render().includes("archive-0:"),
+                "backward paging advances",
+              );
+            }
+            assert.match(render(), /archive-0:/);
+            assert.doesNotMatch(render(), /full log \(live\)/);
+            const beforeGrowth = render()
+              .split("\n")
+              .filter((line) => line.startsWith("  archive-"));
+            await fs.appendFile(file, "later output\n".repeat(100));
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+            assert.deepEqual(
+              render()
+                .split("\n")
+                .filter((line) => line.startsWith("  archive-")),
+              beforeGrowth,
+            );
+            return null;
+          } finally {
+            component.dispose();
+          }
+        },
+      },
+    } as unknown as Parameters<typeof openTerminalPicker>[0];
+    try {
+      await openTerminalPicker(ctx, view);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+}
 
 test("dashboard selection follows its terminal id and falls back by row", () => {
   const selection: DashboardSelection = { id: "bt-7", index: 6 };

--- a/packages/pi-background-terminals/spill-source.test.ts
+++ b/packages/pi-background-terminals/spill-source.test.ts
@@ -115,8 +115,8 @@ test("loadEarlier stops at byte zero and seekAfter pages forward from the window
 });
 
 test("window boundaries never split a multi-byte code point", async () => {
-  // 2-byte code points: every 1024-byte window boundary lands mid-character
-  // unless it is snapped forward.
+  // Baseline two-byte coverage. The forward-page test below deliberately
+  // uses non-aligned window sizes and three-/four-byte characters.
   const file = await spillFile("é".repeat(4000));
   const source = createSpillSource(file, () => {}, OPTIONS);
 
@@ -132,6 +132,84 @@ test("window boundaries never split a multi-byte code point", async () => {
   assert.equal(state.text, "é".repeat(state.text.length));
 
   source.dispose();
+});
+
+test("forward Unicode pages are byte-contiguous and respect the window cap", async () => {
+  for (const character of ["€", "😀"]) {
+    const content = `${character}a`.repeat(10_000);
+    const file = await spillFile(content);
+    const source = createSpillSource(file, () => {}, {
+      tailBytes: 1025,
+      windowBytes: 4097,
+      chunkBytes: 1025,
+    });
+    try {
+      await source.follow();
+      while (source.state().start > 0) {
+        await source.loadEarlier();
+        assert.ok(source.state().end - source.state().start <= 4097);
+        assert.ok(!source.state().text.includes("\uFFFD"));
+      }
+      let joined = source.state().text;
+      let end = source.state().end;
+      while (end < source.state().size) {
+        assert.equal(await source.seekAfter(), true);
+        const page = source.state();
+        assert.equal(page.start, end);
+        assert.ok(page.end > end);
+        assert.ok(!page.text.includes("\uFFFD"));
+        joined += page.text;
+        end = page.end;
+      }
+      assert.equal(joined, content);
+    } finally {
+      source.dispose();
+      await fs.rm(path.dirname(file), { recursive: true, force: true });
+    }
+  }
+});
+
+test("pausing during a follow read discards the pending window update", async () => {
+  for (const alreadyLoaded of [false, true]) {
+    const file = await spillFile("initial\n");
+    const source = createSpillSource(file, () => {}, OPTIONS);
+    try {
+      if (alreadyLoaded) await source.follow();
+      const before = source.state();
+      await fs.appendFile(file, "later\n");
+      let checks = 0;
+      assert.equal(await source.follow(() => ++checks === 1), false);
+      assert.equal(checks, 2, "permission is checked after stat and after reading");
+      assert.equal(source.state().text, before.text);
+      assert.equal(source.state().start, before.start);
+      assert.equal(source.state().end, before.end);
+      assert.equal(await source.follow(), true);
+      assert.equal(source.state().text, "initial\nlater\n");
+    } finally {
+      source.dispose();
+      await fs.rm(path.dirname(file), { recursive: true, force: true });
+    }
+  }
+});
+
+test("follow retries an incomplete UTF-8 suffix when the rest arrives", async () => {
+  const file = await spillFile("prefix");
+  const source = createSpillSource(file, () => {}, OPTIONS);
+  try {
+    await source.follow();
+    const euro = Buffer.from("€");
+    await fs.appendFile(file, euro.subarray(0, 1));
+    assert.equal(await source.follow(), false);
+    assert.equal(source.state().text, "prefix");
+    assert.equal(source.state().end, 6);
+    await fs.appendFile(file, euro.subarray(1));
+    assert.equal(await source.follow(), true);
+    assert.equal(source.state().text, "prefix€");
+    assert.equal(source.state().end, 9);
+  } finally {
+    source.dispose();
+    await fs.rm(path.dirname(file), { recursive: true, force: true });
+  }
 });
 
 test("an unreadable spill reports an error instead of throwing", async () => {

--- a/packages/pi-background-terminals/src/command-shape.ts
+++ b/packages/pi-background-terminals/src/command-shape.ts
@@ -10,7 +10,7 @@
  * first line happens to be `cd` is not a state-only command.
  */
 
-import { formatElapsed, type TerminalSnapshot } from "./domain.ts";
+import type { TerminalSnapshot } from "./domain.ts";
 
 const ASSIGNMENT = /^(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)$/;
 const BARE_CD = /^cd(?:\s|$)/i;
@@ -32,14 +32,6 @@ export function isStateOnlyCommand(command: string) {
   return segments.every((segment) => ASSIGNMENT.test(segment) || BARE_CD.test(segment));
 }
 
-export function stateOnlyCommandError() {
-  return (
-    "This command only changes shell state (cd/export/assignment) in a shell discarded on exit, " +
-    "so it cannot affect any later call; it was not executed. Use working_dir to choose the " +
-    "directory, or combine setup and work in one command: `cd packages/x && npm test`."
-  );
-}
-
 /**
  * An already-running terminal for the identical command in the identical
  * directory. Same command in another directory, or one that already settled,
@@ -52,15 +44,5 @@ export function findDuplicateRunning(
 ) {
   return snapshots.find(
     (snap) => snap.status === "running" && snap.command === command && snap.cwd === cwd,
-  );
-}
-
-export function duplicateCommandError(snap: TerminalSnapshot) {
-  return (
-    `This exact command is already running as background terminal ${snap.id} ` +
-    `(started ${formatElapsed(snap)} ago, pid ${snap.pid ?? "?"}). It has not failed: yielded commands ` +
-    "keep running and report back on exit. This second copy was not executed — re-running it would " +
-    "repeat its side effects. Wait for that result, or stop it from /ps. To run it again on purpose, " +
-    "change the command text or use a different working_dir."
   );
 }

--- a/packages/pi-background-terminals/src/constants.ts
+++ b/packages/pi-background-terminals/src/constants.ts
@@ -1,0 +1,15 @@
+export const MAX_RUNNING = 8;
+export const MAX_TRACKED = 32;
+export const DEFAULT_YIELD_TIME_MS = 10_000;
+export const MIN_YIELD_TIME_MS = 250;
+export const MAX_YIELD_TIME_MS = 30_000;
+/** Node timer maximum, shared with Pi's built-in Bash timeout. */
+export const MAX_RUNTIME_TIMEOUT_MS = 2_147_483_647;
+export const MAX_RUNTIME_TIMEOUT_SECONDS = MAX_RUNTIME_TIMEOUT_MS / 1000;
+/** In-memory retained cap and startup prefix per stream. */
+export const RETAINED_PER_STREAM = 2 * 1024 * 1024;
+export const HEAD_RETAINED_PER_STREAM = 256 * 1024;
+export const MAX_SPILL_BYTES_PER_STREAM = 256 * 1024 * 1024;
+export const MAX_TERMINAL_LOG_READ_BYTES = 64 * 1024;
+export const TERMINAL_LOG_READ_RUN_BUDGET = MAX_TERMINAL_LOG_READ_BYTES * 4;
+export const TERMINAL_LOG_READ_RUN_CALLS = 8;

--- a/packages/pi-background-terminals/src/manager.ts
+++ b/packages/pi-background-terminals/src/manager.ts
@@ -13,6 +13,7 @@
  */
 
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -33,23 +34,18 @@ import { createDetachedChildTracker } from "./process-tracker.ts";
 import { createChildJob, preloadChildJobSupport, type ChildJobHandle } from "./win32-job.ts";
 import { codePointStart, completeCodePointEnd } from "./utf8.ts";
 
-export const MAX_RUNNING = 8;
-export const MAX_TRACKED = 32;
-export const DEFAULT_YIELD_TIME_MS = 10_000;
-export const MIN_YIELD_TIME_MS = 250;
-export const MAX_YIELD_TIME_MS = 30_000;
-/** Same upper bound as Pi's built-in bash timeout (Node timer maximum). */
-export const MAX_RUNTIME_TIMEOUT_MS = 2_147_483_647;
-export const MAX_RUNTIME_TIMEOUT_SECONDS = MAX_RUNTIME_TIMEOUT_MS / 1000;
+import {
+  MAX_RUNNING,
+  MAX_TRACKED,
+  MIN_YIELD_TIME_MS,
+  MAX_YIELD_TIME_MS,
+  RETAINED_PER_STREAM,
+  HEAD_RETAINED_PER_STREAM,
+  MAX_SPILL_BYTES_PER_STREAM,
+  MAX_TERMINAL_LOG_READ_BYTES,
+} from "./constants.ts";
+import { TERMINAL_ERRORS } from "./prompt.ts";
 const MAX_SETTLED_HISTORY = MAX_TRACKED * 4;
-/** In-memory retained cap per stream. */
-export const RETAINED_PER_STREAM = 2 * 1024 * 1024;
-/** Stable startup prefix within the retained cap; the remainder is rolling tail. */
-export const HEAD_RETAINED_PER_STREAM = 256 * 1024;
-/** Private full-log spills are bounded so a firehose cannot fill the temp disk. */
-export const MAX_SPILL_BYTES_PER_STREAM = 256 * 1024 * 1024;
-/** Maximum bytes exposed by one model-facing archive read. */
-export const MAX_TERMINAL_LOG_READ_BYTES = 64 * 1024;
 const STOP_TIMEOUT_MS = 5_000;
 /** SIGTERM is normally enough; the second deadline covers a wedged process. */
 const FORCE_KILL_AFTER_MS = 2_000;
@@ -189,6 +185,8 @@ export interface StartOptions {
   readonly shellPath?: string;
   /** Environment resolved at the tool boundary, including current PI_* state. */
   readonly env?: NodeJS.ProcessEnv;
+  /** Cancellation prevents spawn, but never kills an already-started command. */
+  readonly signal?: AbortSignal;
   /** Optional hard total runtime timeout. The yield wait is independent. */
   readonly timeoutMs?: number;
 }
@@ -349,6 +347,19 @@ function killTree(child: ChildProcess, signal: NodeJS.Signals) {
   }
 }
 
+/** Stdio closure does not imply that redirected descendants have exited.
+ * POSIX probing/signaling assumes the reaped leader's PGID has not been reused
+ * between exit and bounded cleanup; signal-zero probes cannot establish identity. */
+function processGroupAlive(child: ChildProcess) {
+  if (process.platform === "win32" || !child.pid) return false;
+  try {
+    process.kill(-child.pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
 /** Await stdio closure without retaining a listener after interruption. */
 function awaitChildClose(child: ChildProcess, closed: () => boolean) {
   return Effect.callback<void>((resume) => {
@@ -374,23 +385,26 @@ function terminateChild(
   onSignal: () => void,
   onEscalation: () => void,
 ) {
+  const treeGone = () => closed() && !processGroupAlive(child);
+  const awaitTree = () =>
+    Effect.gen(function* () {
+      yield* awaitChildClose(child, closed);
+      while (processGroupAlive(child)) yield* Effect.sleep(25);
+    });
   return Effect.suspend(() => {
-    if (closed()) return Effect.void;
+    if (treeGone()) return Effect.void;
     return Effect.gen(function* () {
       yield* Effect.sync(() => {
         onSignal();
         killTree(child, "SIGTERM");
       });
-      yield* awaitChildClose(child, closed).pipe(
-        Effect.timeout(FORCE_KILL_AFTER_MS),
-        Effect.ignore,
-      );
-      if (closed()) return;
+      yield* awaitTree().pipe(Effect.timeout(FORCE_KILL_AFTER_MS), Effect.ignore);
+      if (treeGone()) return;
       yield* Effect.sync(() => {
         killTree(child, "SIGKILL");
         onEscalation();
       });
-      yield* awaitChildClose(child, closed).pipe(Effect.timeout(500), Effect.ignore);
+      yield* awaitTree().pipe(Effect.timeout(500), Effect.ignore);
     });
   });
 }
@@ -425,6 +439,7 @@ const makeManager = Effect.gen(function* () {
   const settlementWaiters = new Map<string, Set<{ consumed: boolean }>>();
   const listeners = new Set<() => void>();
   const idListeners = new Map<string, Set<() => void>>();
+  const runtimeId = randomBytes(8).toString("hex");
   let counter = 0;
   let reserved = 0;
   let disposed = false;
@@ -553,8 +568,7 @@ const makeManager = Effect.gen(function* () {
           Effect.sync(() => {
             entry.stdoutBuf.spillPath = undefined;
             entry.stderrBuf.spillPath = undefined;
-            entry.snapshot.errorText ??=
-              "Full-log spill flush timed out; full output may be incomplete";
+            entry.snapshot.errorText ??= TERMINAL_ERRORS.spillFlush;
           }),
       }),
       Effect.andThen(Effect.sync(() => markArchiveCompleteness(entry))),
@@ -596,6 +610,9 @@ const makeManager = Effect.gen(function* () {
     for (const waiter of waiters ?? []) waiter.consumed = true;
     const consumed = (killInterest.get(s.id) ?? 0) > 0 || (waiters?.size ?? 0) > 0;
     Deferred.doneUnsafe(entry.settled, Effect.void);
+    if (entry.child.pid && !processGroupAlive(entry.child)) {
+      detachedChildren.untrack(entry.child.pid);
+    }
     // The tree is final: close the Windows job so detached descendants that
     // no PID path can reach are reaped now rather than at Pi exit.
     entry.childJob?.close();
@@ -617,7 +634,17 @@ const makeManager = Effect.gen(function* () {
   const settleAfterFlush = (entry: Entry) => {
     if (entry.settling || entry.snapshot.status !== "running") return;
     entry.settling = true;
-    runCleanup(flushSpillStreams(entry).pipe(Effect.andThen(Effect.sync(() => settle(entry)))));
+    runCleanup(
+      terminateChild(
+        entry.child,
+        () => entry.stdioClosed,
+        () => {}, // Natural exit/spawn failure retains its truthful status.
+        () => entry.childJob?.close(),
+      ).pipe(
+        Effect.andThen(flushSpillStreams(entry)),
+        Effect.andThen(Effect.sync(() => settle(entry))),
+      ),
+    );
   };
 
   const scheduleExitCleanup = (entry: Entry) => {
@@ -675,7 +702,7 @@ const makeManager = Effect.gen(function* () {
           const buf = stream === "stdout" ? current.stdoutBuf : current.stderrBuf;
           buf.spillPath = undefined;
           current.snapshot.errorText ??= bounded(
-            `Full-log spill failed: ${boundedSpillError(error, spillPath)}`,
+            TERMINAL_ERRORS.spillFailed(boundedSpillError(error, spillPath)),
           );
         }
       });
@@ -693,9 +720,7 @@ const makeManager = Effect.gen(function* () {
             if (current) {
               const buf = stream === "stdout" ? current.stdoutBuf : current.stderrBuf;
               buf.spillPath = undefined;
-              current.snapshot.errorText ??= bounded(
-                `${stream} full-log spill reached the ${MAX_SPILL_BYTES_PER_STREAM}-byte safety limit`,
-              );
+              current.snapshot.errorText ??= bounded(TERMINAL_ERRORS.spillCapped(stream));
             }
             return true;
           }
@@ -717,13 +742,13 @@ const makeManager = Effect.gen(function* () {
       yield* Effect.suspend((): Effect.Effect<void, SpawnError | ConcurrencyLimitError> => {
         if (disposed) {
           return new SpawnError({
-            message: "Background terminal manager is shutting down.",
+            message: TERMINAL_ERRORS.shuttingDown,
             fallbackSafe: false,
           });
         }
         if (runningCount() + reserved >= MAX_RUNNING) {
           return new ConcurrencyLimitError({
-            message: `Max ${MAX_RUNNING} background terminals can run concurrently. Stop one from /ps before starting another.`,
+            message: TERMINAL_ERRORS.concurrency,
           });
         }
         reserved++;
@@ -737,7 +762,7 @@ const makeManager = Effect.gen(function* () {
           catch: (error) =>
             new SpawnError({
               message: boundedError(error),
-              fallbackSafe: true,
+              fallbackSafe: !options.signal?.aborted,
             }),
         });
         // Create the Windows kill switch before any process in the command
@@ -750,6 +775,7 @@ const makeManager = Effect.gen(function* () {
 
         const child = yield* Effect.try({
           try: () => {
+            options.signal?.throwIfAborted();
             const env = options.env ?? process.env;
             const spawned = childJob
               ? spawn(process.execPath, [WIN32_CHILD_PATH, childJob.name], {
@@ -794,7 +820,7 @@ const makeManager = Effect.gen(function* () {
             if (childJob) detachedChildren.untrackJob(childJob);
             return new SpawnError({
               message: boundedError(error),
-              fallbackSafe: true,
+              fallbackSafe: !options.signal?.aborted,
             });
           },
         });
@@ -802,7 +828,7 @@ const makeManager = Effect.gen(function* () {
         const childPid = child.pid;
         if (childPid) detachedChildren.track(childPid);
 
-        const id = `bt-${++counter}`;
+        const id = `bt-${runtimeId}-${++counter}`;
         const entryRef = () => entries.get(id);
         const stdoutSpill = makeSpill(entryRef, id, "stdout", () => child.stdout?.resume());
         const stderrSpill = makeSpill(entryRef, id, "stderr", () => child.stderr?.resume());
@@ -895,7 +921,6 @@ const makeManager = Effect.gen(function* () {
           scheduleExitCleanup(entry);
         });
         child.once("close", (code, signal) => {
-          if (childPid) detachedChildren.untrack(childPid);
           entry.exited = true;
           entry.stdioClosed = true;
           // Only trust close's code/signal when 'exit' never fired (a spawn
@@ -939,8 +964,7 @@ const makeManager = Effect.gen(function* () {
                 // SPILL_FLUSH_TIMEOUT_MS) — settling here first would cite a
                 // spill file that is still being flushed.
                 if (!entry.stdioClosed) {
-                  entry.snapshot.errorText ??=
-                    "stdio did not close after termination; output may be incomplete";
+                  entry.snapshot.errorText ??= TERMINAL_ERRORS.incompleteStdio;
                 }
                 entry.settling = true;
                 yield* flushSpillStreams(entry);
@@ -951,7 +975,7 @@ const makeManager = Effect.gen(function* () {
               // PID-based kills cannot reach the re-parented survivors.
               entry.childJob?.close();
               if (entry.childJob) detachedChildren.untrackJob(entry.childJob);
-              if (childPid) detachedChildren.untrack(childPid);
+              if (childPid && !processGroupAlive(child)) detachedChildren.untrack(childPid);
             }),
           ),
           scope,
@@ -963,12 +987,13 @@ const makeManager = Effect.gen(function* () {
         if (disposed) {
           yield* closeEntryScope(entry);
           return yield* new SpawnError({
-            message: "Background terminal manager shut down while starting.",
+            message: TERMINAL_ERRORS.shutDownDuringStart,
             fallbackSafe: false,
           });
         }
         entries.set(id, entry);
-        if (options.timeoutMs !== undefined) {
+        const timeoutMs = options.timeoutMs;
+        if (timeoutMs !== undefined) {
           entry.timeoutHandle = setTimeout(() => {
             if (entry.snapshot.status !== "running") return;
             // Preserve a natural exit that already won but whose descendants
@@ -976,10 +1001,10 @@ const makeManager = Effect.gen(function* () {
             // but must not rewrite the truthful final status.
             entry.timedOut ||= !entry.exited;
             if (entry.timedOut) {
-              entry.snapshot.errorText ??= `Command exceeded its ${options.timeoutMs}-ms runtime timeout`;
+              entry.snapshot.errorText ??= TERMINAL_ERRORS.runtimeTimeout(timeoutMs);
             }
             runCleanup(closeEntryScope(entry).pipe(Effect.timeout(STOP_TIMEOUT_MS), Effect.ignore));
-          }, options.timeoutMs);
+          }, timeoutMs);
           entry.timeoutHandle.unref();
         }
         notify(id);
@@ -1006,7 +1031,7 @@ const makeManager = Effect.gen(function* () {
       if (!entry) {
         const known = [...entries.keys()];
         return new UnknownTerminalError({
-          message: `Unknown terminal id "${id}". Known: ${known.join(", ") || "none"}.`,
+          message: TERMINAL_ERRORS.unknownTerminal(id, known),
         });
       }
       if (entry.snapshot.status !== "running") {
@@ -1056,7 +1081,7 @@ const makeManager = Effect.gen(function* () {
       if (!entry) {
         const known = [...entries.keys()];
         return new UnknownTerminalError({
-          message: `Unknown terminal id "${id}". Known: ${known.join(", ") || "none"}.`,
+          message: TERMINAL_ERRORS.unknownTerminal(id, known),
         });
       }
       return Effect.succeed(entry.snapshot as TerminalSnapshot);
@@ -1074,24 +1099,22 @@ const makeManager = Effect.gen(function* () {
           if (tombstone) {
             if (tombstone[request.stream].archived) {
               return new TerminalLogUnavailableError({
-                message:
-                  `Archive ${request.id}:${request.stream} expired when the terminal was pruned from the ${MAX_TRACKED}-entry retention cap. ` +
-                  "It cannot be recovered. Work with the output already available or re-run the command.",
+                message: TERMINAL_ERRORS.expiredArchive(`${request.id}:${request.stream}`),
               });
             }
             return new TerminalLogUnavailableError({
-              message: `Archive ${request.id}:${request.stream} is unavailable; its output was small enough that the terminal result already contains all of it.`,
+              message: TERMINAL_ERRORS.smallArchive(`${request.id}:${request.stream}`),
             });
           }
           return new UnknownTerminalError({
-            message: `Unknown terminal id "${request.id}"; no terminal with that id is tracked in this session.`,
+            message: TERMINAL_ERRORS.unknownArchive(request.id),
           });
         }
         const buffer = request.stream === "stdout" ? entry.stdoutBuf : entry.stderrBuf;
         const spillPath = buffer.spillPath;
         if (!spillPath) {
           return new TerminalLogUnavailableError({
-            message: `Archive ${request.id}:${request.stream} is unavailable.`,
+            message: TERMINAL_ERRORS.unavailableArchive(`${request.id}:${request.stream}`),
           });
         }
         const offset = Number.isFinite(request.offset)
@@ -1142,7 +1165,7 @@ const makeManager = Effect.gen(function* () {
           },
           catch: () =>
             new TerminalLogUnavailableError({
-              message: `Archive ${request.id}:${request.stream} could not be read.`,
+              message: TERMINAL_ERRORS.unreadableArchive(`${request.id}:${request.stream}`),
             }),
         });
       },

--- a/packages/pi-background-terminals/src/prompt.ts
+++ b/packages/pi-background-terminals/src/prompt.ts
@@ -14,7 +14,13 @@ import {
   MAX_RUNNING,
   MAX_YIELD_TIME_MS,
   MIN_YIELD_TIME_MS,
-} from "./manager.ts";
+  MAX_TRACKED,
+  MAX_RUNTIME_TIMEOUT_SECONDS,
+  MAX_SPILL_BYTES_PER_STREAM,
+  TERMINAL_LOG_READ_RUN_BUDGET,
+  TERMINAL_LOG_READ_RUN_CALLS,
+} from "./constants.ts";
+import type { TerminalLogReadResult } from "./manager.ts";
 
 /** Output returned by the initial bash call. */
 export const BASH_STDOUT_MAX = 16 * 1024;
@@ -57,10 +63,74 @@ export const TERMINAL_LOG_READ_TOOL_DESCRIPTION =
 export const TERMINAL_LOG_READ_PROMPT_SNIPPET = "Read a terminal archive page";
 
 export const TERMINAL_LOG_READ_PARAMETER_DESCRIPTIONS = {
-  ref: "Bash archive ref, e.g. bt-3:stdout.",
+  ref: "Exact Bash archive ref (runtime-scoped).",
   offset: "Start byte; default 0.",
   limit: "Page bytes; default maximum.",
 };
+
+export const TERMINAL_ERRORS = {
+  emptyCommand: "command must not be empty.",
+  invalidTimeout: `timeout must be a finite number of seconds in (0, ${MAX_RUNTIME_TIMEOUT_SECONDS}].`,
+  invalidDirectory: (cwd: string) => `working_dir is not a directory: ${cwd}`,
+  shuttingDown: "Background terminal manager is shutting down.",
+  shutDownDuringStart: "Background terminal manager shut down while starting.",
+  concurrency: `Max ${MAX_RUNNING} background terminals can run concurrently. Stop one from /ps before starting another.`,
+  spillFlush: "Full-log spill flush timed out; full output may be incomplete",
+  spillFailed: (error: string) => `Full-log spill failed: ${error}`,
+  spillCapped: (stream: string) =>
+    `${stream} full-log spill reached the ${MAX_SPILL_BYTES_PER_STREAM}-byte safety limit`,
+  incompleteStdio: "stdio did not close after termination; output may be incomplete",
+  runtimeTimeout: (ms: number) => `Command exceeded its ${ms}-ms runtime timeout`,
+  unknownTerminal: (id: string, known: readonly string[]) =>
+    `Unknown terminal id "${id}". Known: ${known.join(", ") || "none"}.`,
+  expiredArchive: (ref: string) =>
+    `Archive ${ref} expired when the terminal was pruned from the ${MAX_TRACKED}-entry retention cap. ` +
+    "It cannot be recovered. Work with the output already available or re-run the command.",
+  smallArchive: (ref: string) =>
+    `Archive ${ref} is unavailable; its output was small enough that the terminal result already contains all of it.`,
+  unknownArchive: (id: string) =>
+    `Unknown terminal id "${id}"; no terminal with that id is tracked in this session.`,
+  unavailableArchive: (ref: string) => `Archive ${ref} is unavailable.`,
+  unreadableArchive: (ref: string) => `Archive ${ref} could not be read.`,
+  invalidRef: (ref: string) =>
+    `Invalid terminal log ref "${ref}"; use the exact runtime-scoped ref emitted by Bash.`,
+  readCalls: `terminal_log_read budget exhausted for this agent run (maximum ${TERMINAL_LOG_READ_RUN_CALLS} reads). Work with the output you already have; the user can inspect the full log with /ps.`,
+  readBytes: `terminal_log_read budget exhausted for this agent run (maximum ${TERMINAL_LOG_READ_RUN_BUDGET} bytes). Work with the output you already have; the user can inspect the full log with /ps.`,
+  interrupted: "Operation was aborted.",
+  initialWaitAborted: (id: string) =>
+    `Initial wait aborted; ${id} continues in the background and will report when it exits.`,
+};
+
+export function foregroundFallbackWarning(reason: string) {
+  return `[Managed bash unavailable before spawn; using Pi's foreground bash fallback — no auto-yield or /ps tracking for this call. Reason: ${reason.slice(0, 500)}]`;
+}
+
+export function formatTerminalLogRead(result: TerminalLogReadResult) {
+  const range = result.bytesRead === 0 ? "empty" : `${result.offset}-${result.nextOffset - 1}`;
+  return [
+    `${result.id}:${result.stream} bytes ${range} of ${result.size}; ` +
+      `settled: ${result.settled ? "yes" : "no"}; complete: ${result.complete ? "yes" : "no"}; next_offset: ${result.nextOffset}`,
+    result.text || "(empty)",
+  ].join("\n");
+}
+
+export function stateOnlyCommandError() {
+  return (
+    "This command only changes shell state (cd/export/assignment) in a shell discarded on exit, " +
+    "so it cannot affect any later call; it was not executed. Use working_dir to choose the " +
+    "directory, or combine setup and work in one command: `cd packages/x && npm test`."
+  );
+}
+
+export function duplicateCommandError(snap: TerminalSnapshot) {
+  return (
+    `This exact command is already running as background terminal ${snap.id} ` +
+    `(started ${formatElapsed(snap)} ago, pid ${snap.pid ?? "?"}). It has not failed: yielded commands ` +
+    "keep running and report back on exit. This second copy was not executed — re-running it would " +
+    "repeat its side effects. Wait for that result, or stop it from /ps. To run it again on purpose, " +
+    "change the command text or use a different working_dir."
+  );
+}
 
 const LEADING_SETUP =
   /^(?:(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^;\s]+)\s*;\s*)+/;
@@ -85,7 +155,7 @@ export function deriveCommandTitle(command: string, explicitTitle?: string) {
   return truncateTitle(withoutSetup || normalized || "command");
 }
 
-/** One metadata line: `bt-1 [running] "dev server" (pid 12345, 3m12s, exit -, /path)`. */
+/** One metadata line: `bt-<runtime-id>-1 [running] "dev server" (pid 12345, 3m12s, exit -, /path)`. */
 export function describeTerminal(snap: TerminalSnapshot) {
   const details = [
     `pid ${snap.pid ?? "?"}`,

--- a/packages/pi-background-terminals/src/runtime.ts
+++ b/packages/pi-background-terminals/src/runtime.ts
@@ -6,6 +6,7 @@
 
 import { Cause, Exit, ManagedRuntime, Result, type Effect } from "effect";
 import { TerminalManagerLive } from "./manager.ts";
+import { TERMINAL_ERRORS } from "./prompt.ts";
 
 export function createTerminalRuntime() {
   return ManagedRuntime.make(TerminalManagerLive);
@@ -29,7 +30,7 @@ export async function runTool<A, E>(
   );
   if (Exit.isSuccess(exit)) return exit.value;
   if (Cause.hasInterruptsOnly(exit.cause)) {
-    throw new Error(options.interruptMessage ?? "Operation was aborted.");
+    throw new Error(options.interruptMessage ?? TERMINAL_ERRORS.interrupted);
   }
   // Preserve typed Effect failures so callers can make narrow, safety-aware
   // decisions (notably: foreground fallback only when SpawnError proves that

--- a/packages/pi-background-terminals/src/ui/ps.ts
+++ b/packages/pi-background-terminals/src/ui/ps.ts
@@ -411,6 +411,8 @@ class TerminalDetailView implements Component {
   /** False once the reader pages away from EOF: the spill window must not be
    * yanked forward under someone reading history. `G` restores it. */
   private following = true;
+  /** Freeze retained output too: its rolling tail would otherwise move under readers. */
+  private pausedMemoryText?: string;
   /** Whether the last render had the viewport clamped to the top of the window. */
   private atWindowTop = false;
   private unsubscribe: () => void;
@@ -458,7 +460,7 @@ class TerminalDetailView implements Component {
    */
   private activeSource(snap: TerminalSnapshot): SpillSource | undefined {
     const stream = this.activeStream();
-    if (!stream) return undefined;
+    if (!stream || this.pausedMemoryText !== undefined) return undefined;
     const view = stream === "stdout" ? snap.stdout : snap.stderr;
     if (!view.spillPath || view.truncatedBytes === 0) return undefined;
     const existing = this.sources.get(stream);
@@ -481,14 +483,44 @@ class TerminalDetailView implements Component {
     const state = source.state();
     const unloaded = state.end === 0 && state.error === undefined;
     if (!this.following && !unloaded) return;
-    void source.follow();
+    const tab = this.tab;
+    // A paused reader still needs its first disk window; only later EOF growth
+    // is conditional on following. Otherwise early scrolling blocks all paging.
+    const initial = unloaded;
+    void source.follow(() => !this.closed && this.tab === tab && (initial || this.following));
+  }
+
+  private pauseFollowing() {
+    if (!this.following) return;
+    const snap = this.snap();
+    const stream = this.activeStream();
+    if (snap && stream) {
+      const buffer = snap[stream];
+      if (buffer.spillPath === undefined || buffer.truncatedBytes === 0) {
+        this.pausedMemoryText = buffer.text;
+        this.lineCache = createOutputLineCache();
+      }
+    }
+    this.following = false;
   }
 
   /** Extend the window backwards. `force` covers an explicit jump-to-top. */
   private loadEarlier(force: boolean) {
+    if (!force && !this.atWindowTop) return;
+    const snap = this.snap();
+    const stream = this.activeStream();
+    if (this.pausedMemoryText !== undefined && snap && stream) {
+      const buffer = snap[stream];
+      if (buffer.spillPath !== undefined && buffer.truncatedBytes > 0) {
+        // Retention may overflow while paused. Explicit backward paging opts
+        // into the disk archive rather than dead-ending in the frozen view.
+        this.pausedMemoryText = undefined;
+        this.lineCache = createOutputLineCache();
+      }
+    }
     const source = this.currentSource();
     if (!source) return;
-    if (!force && !this.atWindowTop) return;
+    this.pumpSpill();
     if (source.state().start === 0) return;
     this.following = false;
     void source.loadEarlier().then((outcome) => {
@@ -502,8 +534,12 @@ class TerminalDetailView implements Component {
 
   /** Reached the bottom of the viewport: follow EOF, or page one window on. */
   private reachedBottom(wasAtBottom: boolean) {
+    this.pausedMemoryText = undefined;
     const source = this.currentSource();
-    if (!source) return;
+    if (!source) {
+      this.following = true;
+      return;
+    }
     const state = source.state();
     if (state.end >= state.size) {
       this.following = true;
@@ -549,6 +585,7 @@ class TerminalDetailView implements Component {
   private switchTab(tab: TerminalDetailTab) {
     if (tab === this.tab) return;
     this.tab = tab;
+    this.pausedMemoryText = undefined;
     this.lineCache = createOutputLineCache();
     this.scrollOffset = tab === "info" ? Number.MAX_SAFE_INTEGER : 0;
     this.following = true;
@@ -583,6 +620,7 @@ class TerminalDetailView implements Component {
       return;
     }
     if (this.keybindings.matches(data, "tui.editor.cursorUp") || data === "k") {
+      this.pauseFollowing();
       this.scrollOffset += OUTPUT_SCROLL_STEP;
       this.loadEarlier(false);
       this.tui.requestRender();
@@ -596,6 +634,7 @@ class TerminalDetailView implements Component {
       return;
     }
     if (this.keybindings.matches(data, "tui.editor.pageUp")) {
+      this.pauseFollowing();
       this.scrollOffset += this.viewportHeight();
       this.loadEarlier(false);
       this.tui.requestRender();
@@ -609,12 +648,14 @@ class TerminalDetailView implements Component {
       return;
     }
     if (data === "g") {
+      this.pauseFollowing();
       this.scrollOffset = Number.MAX_SAFE_INTEGER; // clamped to top in render
       this.loadEarlier(true);
       this.tui.requestRender();
       return;
     }
     if (data === "G") {
+      this.pausedMemoryText = undefined;
       this.scrollOffset = 0;
       this.following = true;
       this.pumpSpill();
@@ -694,8 +735,16 @@ class TerminalDetailView implements Component {
       const version =
         // totalBytes is a monotonically increasing proxy for a source version.
         // Namespacing prevents retained/spill windows from sharing stale wraps.
-        useSpill ? `spill:${spill.version}` : `mem:${buffer.totalBytes}`;
-      output = this.lineCache.get(useSpill ? spill.text : buffer.text, version, width - 2);
+        useSpill
+          ? `spill:${spill.version}`
+          : this.pausedMemoryText !== undefined
+            ? "paused-memory"
+            : `mem:${buffer.totalBytes}`;
+      output = this.lineCache.get(
+        useSpill ? spill.text : (this.pausedMemoryText ?? buffer.text),
+        version,
+        width - 2,
+      );
 
       if (snap.errorText) {
         noteRows.push(

--- a/packages/pi-background-terminals/src/ui/spill-source.ts
+++ b/packages/pi-background-terminals/src/ui/spill-source.ts
@@ -23,6 +23,7 @@
  */
 
 import * as fs from "node:fs/promises";
+import { completeCodePointEnd } from "../utf8.ts";
 
 /** Live-tail window: what `follow` retains while pinned to EOF. */
 export const SPILL_TAIL_BYTES = 1024 * 1024;
@@ -53,8 +54,8 @@ export type EarlierOutcome = "noop" | "prepended" | "reanchored";
 export interface SpillSource {
   readonly path: string;
   state(): SpillWindowState;
-  /** Initial tail load, then EOF growth. Safe to call on a timer. */
-  follow(): Promise<boolean>;
+  /** Initial tail load, then EOF growth. Recheck permission before committing async reads. */
+  follow(isFollowing?: () => boolean): Promise<boolean>;
   loadEarlier(): Promise<EarlierOutcome>;
   /** Page one window forward. Resolves true when the window moved. */
   seekAfter(): Promise<boolean>;
@@ -105,13 +106,16 @@ export function createSpillSource(
     }
   };
 
-  /** Replace the window with [from, to), snapped forward off a split char. */
-  const readWindow = async (from: number, to: number) => {
+  /** Snap both edges inward; the next page retries any incomplete suffix. */
+  const readWindow = async (from: number, to: number, canCommit = () => true) => {
     const raw = await readRange(from, to);
+    if (disposed || !canCommit()) return false;
     const offset = from === 0 ? 0 : leadingBoundary(raw);
-    window = Buffer.from(raw.subarray(offset));
+    const body = raw.subarray(offset);
+    window = Buffer.from(body.subarray(0, completeCodePointEnd(body)));
     start = from + offset;
-    end = from + raw.length;
+    end = start + window.length;
+    return true;
   };
 
   const trimFront = (limit: number) => {
@@ -156,31 +160,35 @@ export function createSpillSource(
     return changed;
   };
 
-  const follow = () =>
+  const follow = (isFollowing = () => true) =>
     run(async () => {
       const stat = await fs.stat(spillPath);
+      if (disposed || !isFollowing()) return false;
       size = stat.size;
       // Fresh tail load when nothing is loaded, the file was replaced/truncated,
       // or the viewer fell so far behind that appending would blow the window.
       if (window.length === 0 || end > size || size - end > tailBytes) {
         if (size === 0 && window.length === 0) return false;
-        await readWindow(Math.max(0, size - tailBytes), size);
-        return true;
+        return readWindow(Math.max(0, size - tailBytes), size, isFollowing);
       }
       if (size === end) return false;
       const raw = await readRange(end, size);
-      if (raw.length === 0) return false;
-      window = Buffer.concat([window, raw]);
-      end += raw.length;
+      if (disposed || !isFollowing() || raw.length === 0) return false;
+      const combined = Buffer.concat([window, raw]);
+      const complete = completeCodePointEnd(combined);
+      const added = complete - window.length;
+      window = combined.subarray(0, complete);
+      end += added;
       trimFront(tailBytes);
-      return true;
+      return added > 0;
     });
 
   const loadEarlier = async () => {
     if (disposed || loading || start === 0) return "noop" as const;
     let outcome: EarlierOutcome = "noop";
     await run(async () => {
-      if (window.length >= windowBytes) {
+      // Up to three spare bytes may be unusable for the next UTF-8 character.
+      if (window.length >= windowBytes - 3) {
         // Window cap reached: page backwards, ending exactly where the current
         // window began, so upward reading loses nothing.
         const to = start;
@@ -188,7 +196,7 @@ export function createSpillSource(
         outcome = "reanchored";
         return true;
       }
-      const from = Math.max(0, start - chunkBytes);
+      const from = Math.max(0, start - Math.min(chunkBytes, windowBytes - window.length));
       const raw = await readRange(from, start);
       if (raw.length === 0) return false;
       const offset = from === 0 ? 0 : leadingBoundary(raw);


### PR DESCRIPTION
## Summary

Terminal lifecycle hardening for `pi-background-terminals`, plus UTF-8 paging fixes and a `/ps` viewer pause fix. Reviewed end to end (two bugs found during review were fixed in-branch with regression coverage).

### Process lifecycle
- **Reap redirected POSIX descendants on natural exit and shutdown.** Stdio closure no longer implies the tree is gone: settlement and explicit termination now probe and reap the process group independently, with the existing bounded SIGTERM→SIGKILL escalation. The abnormal-exit tracker keeps covering a group until it is confirmed gone.
- **Pre-spawn cancellation** (AbortSignal plumbed into `manager.start`) prevents execution at the spawn boundary and is never classified as a fallback-safe spawn failure, so a cancelled call cannot reach the foreground fallback.
- **Runtime-scoped terminal IDs** (`bt-<random16>-N`): archive refs from before `/reload` or `/resume` can no longer alias a different runtime's output.

### /ps viewer
- **Scrolling up pauses live following immediately** — including retained output, whose rolling tail previously moved under a reader. The first disk window may still load while paused (anchored at the pause point), and paging past the top of frozen retained text opts into the on-disk archive instead of dead-ending.
- **UTF-8 spill paging fixed**: windows snap both edges to code-point boundaries (previously the trailing edge could split a character), `follow` retries an incomplete UTF-8 suffix once the rest arrives, and backwards window math respects the cap.

### Internal
- Shared limits extracted to `src/constants.ts`; model-facing error text centralized in `TERMINAL_ERRORS` (`src/prompt.ts`).
- Tests run without `--test-force-exit`, so leaked handles can no longer hide behind a forced runner exit.

## Testing

- `pnpm run typecheck`, `pnpm run check` ✅
- `pnpm --filter @tian.zuo/pi-background-terminals test`: **123 tests, 121 pass** (2 skips are pre-existing Windows-only), clean exit in ~74s
- New coverage: redirected SIGTERM-resistant descendants (natural exit + disposal), runtime-recreation archive identity, spawn-boundary cancellation, paused spill paging (initial-load and retention-overflow transitions), byte-contiguous Unicode forward paging, follow commit-guard and incomplete-suffix retry
