### PR TITLE
fix(pi-antigravity): steady turns, history restore, and instruction relay

### DIFF
--- a/.changeset/steady-antigravity-turns.md
+++ b/.changeset/steady-antigravity-turns.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-antigravity": patch
+---
+
+Restore Pi history on the first Antigravity handoff while preserving explicit reset behavior, relay and synchronize Pi instructions through agy's text interface without dropping pending instruction or skill updates on stall retries, prevent cancelled startup from submitting prompts, and track overlapping native tool steps correctly. Enforce a single logical-turn deadline across startup, retries, and backoff, and clarify that native agy operations bypass Pi's permission hooks.

--- a/packages/pi-antigravity/README.md
+++ b/packages/pi-antigravity/README.md
@@ -44,6 +44,16 @@ Claude and GPT models
   Weekly limit:     [████████████████████] 100% left · resets 15:08 on 4 Sep
 ```
 
+## Context and permissions
+
+The first agy turn receives the active Pi conversation history, including earlier work with another provider. `/agy reset` deliberately starts fresh without replaying that history; it does not delete the Pi transcript. A later provider switch or branch move can restore the active history again.
+
+Pi's current system instructions (including project guidance and extension additions) are relayed on the first native turn, after a native conversation restore, and when they change. Unchanged instructions are not repeated on each turn or tool-loop re-entry; removing them sends an explicit clearing notice. Unacknowledged instruction and skill-catalog updates are retained across stall retries. Disposable summaries receive their own instructions without changing the live conversation.
+
+**This is a text adapter, not a native system role.** agy's CLI has no system-prompt input, so Pi instructions are included as a labeled user-prompt snapshot. They cannot override agy's native system instructions. Forwarding Pi tool references does not make those tools available: agy uses its actual native and bridge schemas.
+
+**Native agy tools bypass Pi's pre-execution permission hooks.** Both execution modes always pass `--dangerously-skip-permissions` because headless agy otherwise denies permission prompts. Native commands, file edits, browser actions, and reads execute inside agy; their Pi cards are replayed afterward. Blocking or disabling a Pi tool cannot prevent a native operation that already happened. Only tools routed through the Pi bridge execute under Pi's hooks and permissions. Use this extension only where you trust agy's access to the workspace; the replay UI is not a security boundary.
+
 ## Commands
 
 | Command          | What it does                                                                                                    |
@@ -66,7 +76,7 @@ Claude and GPT models
 | `PI_ANTIGRAVITY_AGENT=<name>`            | Select a custom agy agent. Empty, control-character-containing, and overlong values are rejected before spawn.                               |
 | `PI_ANTIGRAVITY_MODE=plan\|accept-edits` | Select agy's stable CLI execution mode. Other values fail before spawn.                                                                      |
 | `AGY_BINARY=/path/to/agy`                | Strictly use a specific agy binary; no fallback if it fails.                                                                                 |
-| `AGY_TURN_TIMEOUT_MS=600000`             | Pi-owned overall budget per active agy turn. Persistent mode intentionally does not pass `--print-timeout`.                                  |
+| `AGY_TURN_TIMEOUT_MS=600000`             | Pi-owned overall budget for one logical turn, including startup, fallback, stall retries, and backoff. Retries receive only the remaining budget. Persistent mode does not pass `--print-timeout`.                                  |
 | `AGY_STALL_TIMEOUT_MS=120000`            | Kill the turn when the stream produces no bytes for this long and retry by resuming the conversation. `0` disables the watchdog.             |
 | `AGY_TOOL_STALL_TIMEOUT_MS=300000`       | Stall budget while a tool step is ACTIVE — a quiet foreground tool is legitimate, so silence inside a tool gets a longer leash.              |
 | `AGY_STALL_RETRY_BACKOFF_MS=3000`        | Pause before each stall retry. Stalls retry at most twice, rendered as a collapsed "agy stream stalled … restarting the turn" thinking line. |

--- a/packages/pi-antigravity/lib/agy-client.ts
+++ b/packages/pi-antigravity/lib/agy-client.ts
@@ -13,6 +13,7 @@ import { killAgyTree, trackAgyChild, untrackAgyChild } from "./agy-children.ts";
 import { getAgyBinary } from "./agy-diagnostics.ts";
 import type { AgyExecutionMode } from "./agy-profile.ts";
 import { parseAgyLine } from "./events.ts";
+import { trackActiveToolStep } from "./tool-steps.ts";
 import { applyEvent, newTurnOutcome, type AgyActivity, type AgyTurnOutcome } from "./reducer.ts";
 
 /** agy reasoning effort, as accepted by `agy --effort`. */
@@ -166,8 +167,7 @@ export async function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcom
     const outcome = newTurnOutcome();
     let stdoutBuf = "";
     let stderrBuf = "";
-    /** True between a tool_start activity and its terminal event. */
-    let toolActive = false;
+    const activeTools = new Set<string>();
 
     let settled = false;
     let untracked = false;
@@ -215,12 +215,12 @@ export async function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcom
       const armStall = () => {
         if (settled || outcome.finished) return;
         if (stallTimer !== undefined) clearTimeout(stallTimer);
-        const budgetMs = toolActive ? stallToolMs : stallBaseMs;
+        const budgetMs = activeTools.size > 0 ? stallToolMs : stallBaseMs;
         stallTimer = setTimeout(() => {
           killAgyTree(child);
           untrack();
           finishLogical(() => {
-            reject(new AgyStallError(budgetMs, toolActive));
+            reject(new AgyStallError(budgetMs, activeTools.size > 0));
           });
         }, budgetMs);
       };
@@ -260,9 +260,7 @@ export async function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcom
         }
       }
       for (const activity of applyEvent(outcome, parsed)) {
-        if (activity.type === "tool_start") toolActive = true;
-        else if (activity.type === "tool_done" || activity.type === "tool_error")
-          toolActive = false;
+        trackActiveToolStep(activeTools, activity);
         request.onActivity?.(activity);
       }
       if (outcome.finished) {
@@ -275,7 +273,7 @@ export async function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcom
       }
       // A tool-start/done flip changes the stall budget (the liveness
       // listener re-armed before this parse ran), so re-arm with the new
-      // toolActive state.
+      // active-tool state.
       rearmStall();
     };
 
@@ -339,5 +337,8 @@ export async function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcom
         );
       });
     });
+    // Abort can happen during spawn, before the listener above is installed.
+    // Attach child error/close handlers first so the killed child remains observed.
+    if (request.signal?.aborted) abortHandler();
   });
 }

--- a/packages/pi-antigravity/lib/agy-driver.ts
+++ b/packages/pi-antigravity/lib/agy-driver.ts
@@ -9,6 +9,7 @@ import {
 import { killAgyTree, signalAgyTree, trackAgyChild, untrackAgyChild } from "./agy-children.ts";
 import { AgyCompatibilityError, checkAgyBinary } from "./agy-diagnostics.ts";
 import { parseAgyLine } from "./events.ts";
+import { trackActiveToolStep } from "./tool-steps.ts";
 import { applyEvent, newTurnOutcome, type AgyTurnOutcome } from "./reducer.ts";
 
 export type AgyDriverState = "idle" | "starting" | "ready" | "running" | "stopping" | "dead";
@@ -70,7 +71,7 @@ interface ActiveTurn {
   generation: number;
   request: AgyTurnRequest;
   outcome: AgyTurnOutcome;
-  toolActive: boolean;
+  activeTools: Set<string>;
   conversationReported: boolean;
   overallTimer?: NodeJS.Timeout;
   stallTimer?: NodeJS.Timeout;
@@ -235,6 +236,8 @@ export class AgyDriverSession implements AgyTurnExecutor {
 
   async #runExclusive(request: AgyTurnRequest): Promise<AgyTurnOutcome> {
     const checked = request.binary ? undefined : await checkAgyBinary();
+    if (request.signal?.aborted) return abortOutcome();
+    if (this.#shutdown) throw new AgySpawnError("agy driver is shut down.", this.#stderrTail);
     if (checked && !checked.ok) throw new AgyCompatibilityError(checked);
     const binary = request.binary ?? checked?.binary;
     if (!binary) throw new AgySpawnError("agy binary resolution returned no executable.", "");
@@ -244,7 +247,13 @@ export class AgyDriverSession implements AgyTurnExecutor {
       if (cause) await this.close("recycle", cause);
       else this.#reusedTurns += 1;
     }
+    if (request.signal?.aborted) return abortOutcome();
+    if (this.#shutdown) throw new AgySpawnError("agy driver is shut down.", this.#stderrTail);
     if (!this.#child) await this.#start(request, nextConfig);
+    if (request.signal?.aborted) {
+      await this.close("abort");
+      return abortOutcome();
+    }
     const child = this.#child;
     if (!child) throw new AgySpawnError("agy driver failed to start.", this.#stderrTail);
 
@@ -258,6 +267,7 @@ export class AgyDriverSession implements AgyTurnExecutor {
     this.#submittedTurns += 1;
     this.#currentProcessTurns += 1;
     this.#armTurnTimers(turn);
+    if (this.#active !== turn) return outcomePromise;
     try {
       await this.#writeUserEvent(child, request.prompt);
     } catch (error) {
@@ -339,7 +349,7 @@ export class AgyDriverSession implements AgyTurnExecutor {
       generation: this.#generation,
       request,
       outcome: newTurnOutcome(),
-      toolActive: false,
+      activeTools: new Set(),
       conversationReported: false,
       resolve: () => {},
       reject: () => {},
@@ -426,6 +436,7 @@ export class AgyDriverSession implements AgyTurnExecutor {
     };
     turn.abortHandler = onAbort;
     turn.request.signal?.addEventListener("abort", onAbort, { once: true });
+    if (turn.request.signal?.aborted) onAbort();
     this.#rearmStall(turn);
   }
 
@@ -435,13 +446,13 @@ export class AgyDriverSession implements AgyTurnExecutor {
     const baseMs = turn.request.inactivityTimeoutMs ?? 120_000;
     if (baseMs <= 0) return;
     const toolMs = turn.request.toolInactivityTimeoutMs ?? Math.max(baseMs, 300_000);
-    const budgetMs = turn.toolActive ? toolMs : baseMs;
+    const budgetMs = turn.activeTools.size > 0 ? toolMs : baseMs;
     turn.stallTimer = setTimeout(() => {
       const child = this.#child;
       if (this.#active !== turn || !child) return;
       this.#detachChild(child, "dead");
       killAgyTree(child);
-      this.#settleTurn(turn, { error: new AgyStallError(budgetMs, turn.toolActive) });
+      this.#settleTurn(turn, { error: new AgyStallError(budgetMs, turn.activeTools.size > 0) });
     }, budgetMs);
   }
 
@@ -504,10 +515,7 @@ export class AgyDriverSession implements AgyTurnExecutor {
       }
     }
     for (const activity of applyEvent(turn.outcome, parsed)) {
-      if (activity.type === "tool_start") turn.toolActive = true;
-      else if (activity.type === "tool_done" || activity.type === "tool_error") {
-        turn.toolActive = false;
-      }
+      trackActiveToolStep(turn.activeTools, activity);
       turn.request.onActivity?.(activity);
     }
     if (turn.outcome.conversationId) this.#boundConversationId = turn.outcome.conversationId;

--- a/packages/pi-antigravity/lib/prompt.ts
+++ b/packages/pi-antigravity/lib/prompt.ts
@@ -20,12 +20,24 @@ export function omittedImagesPrompt(images: number): string {
   return `(${images} image(s) omitted — the agy print interface is text-only)`;
 }
 
+/** agy's CLI has no system-role input; relay Pi instructions explicitly as prompt text. */
+export function piSystemInstructionsPrompt(instructions: string): string {
+  return [
+    "## Current Pi instructions",
+    "The following is Pi's current instruction snapshot, relayed as user-prompt text because this CLI has no system-prompt channel. It replaces any earlier Pi instruction snapshot in this conversation; native system instructions still take precedence.",
+    "These instructions do not register tools. Use only the actual agy or Pi bridge tool schemas available to you, while respecting applicable project and user guidance.",
+    instructions ||
+      "Pi's instruction snapshot is now empty. Stop applying earlier relayed Pi instructions.",
+    "## End of Pi instructions",
+  ].join("\n\n");
+}
+
 /** Rehydrate a fresh agy conversation from the active branch of a pi session. */
 export function restoredPiContextPrompt(transcript: string): string {
   return [
     "## Restored pi conversation context",
     "",
-    "The agy conversation was restarted because this pi session was resumed, forked, or moved to another history branch. Treat the transcript below as prior conversation context, then answer the current user request that follows it.",
+    "This fresh agy conversation is continuing the active pi history, including any work with another provider, session resume, fork, or branch move. Treat the transcript below as prior conversation context, then answer the current user request that follows it.",
     "",
     transcript,
     "",

--- a/packages/pi-antigravity/lib/tool-steps.ts
+++ b/packages/pi-antigravity/lib/tool-steps.ts
@@ -1,0 +1,14 @@
+import type { AgyActivity } from "./reducer.ts";
+
+/** Missing step IDs use the same best-effort name key as replay correlation. */
+export function agyToolStepKey(activity: { stepId?: number; name: string }): string {
+  return activity.stepId === undefined ? `name:${activity.name}` : `step:${activity.stepId}`;
+}
+
+/** Repeated ACTIVE updates are idempotent; one completion cannot clear siblings. */
+export function trackActiveToolStep(active: Set<string>, activity: AgyActivity): void {
+  if (activity.type === "tool_start") active.add(agyToolStepKey(activity));
+  else if (activity.type === "tool_done" || activity.type === "tool_error") {
+    active.delete(agyToolStepKey(activity));
+  }
+}

--- a/packages/pi-antigravity/lib/turn.ts
+++ b/packages/pi-antigravity/lib/turn.ts
@@ -9,6 +9,7 @@
  */
 
 import type { AgyActivity, AgyUsage } from "./reducer.ts";
+import { agyToolStepKey as toolStepKey } from "./tool-steps.ts";
 
 type Waiter = (activity: AgyActivity | null, error: Error | undefined) => void;
 
@@ -126,10 +127,6 @@ export class AgyTurnController {
       });
     });
   }
-}
-
-function toolStepKey(activity: { stepId?: number; name: string }): string {
-  return activity.stepId === undefined ? `name:${activity.name}` : `step:${activity.stepId}`;
 }
 
 const USAGE_KEYS = [

--- a/packages/pi-antigravity/src/provider.ts
+++ b/packages/pi-antigravity/src/provider.ts
@@ -33,6 +33,7 @@ import { readAgyProcessProfile, type AgyProcessProfile } from "../lib/agy-profil
 import type { AgyActivity, AgyUsage } from "../lib/reducer.ts";
 import type { AgyReplayStore } from "../lib/replay.ts";
 import { mapAgyToolToNative } from "../lib/native-tools.ts";
+import { agyToolStepKey } from "../lib/tool-steps.ts";
 import { omittedImagesPrompt, restoredPiContextPrompt, WRAPPER_TOOL_NAME } from "../lib/prompt.ts";
 import {
   AntigravityRuntime,
@@ -208,10 +209,6 @@ export function mapThinkingToEffort(level: ThinkingLevel | undefined): AgyEffort
 
 let replayCallSeq = 0;
 
-function agyToolStepKey(activity: { stepId?: number; name: string }): string {
-  return activity.stepId === undefined ? `name:${activity.name}` : `step:${activity.stepId}`;
-}
-
 /**
  * True for agy `call_mcp_tool` steps that target our own bridge server.
  * Those calls surface as synthetic bridge_call activities (emitted as the
@@ -350,6 +347,7 @@ export function streamAntigravity(
         const controller = await turnRuntime.runPromise(
           turnService.beginStreamTurn({
             prompt,
+            systemPrompt: context.systemPrompt,
             historyBootstrap: summaryRequest ? undefined : piHistoryBootstrap(context),
             bootstrapSuffix: summaryRequest ? undefined : getBootstrapSuffix?.(),
             modelId: model.id,

--- a/packages/pi-antigravity/src/runtime.ts
+++ b/packages/pi-antigravity/src/runtime.ts
@@ -18,7 +18,7 @@ import {
 } from "../lib/agy-driver.ts";
 import type { AgyExecutionMode } from "../lib/agy-profile.ts";
 import type { AgyTurnOutcome, AgyUsage } from "../lib/reducer.ts";
-import { stallContinuationPrompt } from "../lib/prompt.ts";
+import { piSystemInstructionsPrompt, stallContinuationPrompt } from "../lib/prompt.ts";
 import { AgyTurnController } from "../lib/turn.ts";
 
 function envInt(name: string, fallback: number): number {
@@ -106,6 +106,8 @@ export interface AntigravityRuntimeShape {
    */
   readonly beginStreamTurn: (request: {
     readonly prompt: string;
+    /** Current Pi instructions, relayed through agy's text-only user input. */
+    readonly systemPrompt?: string;
     /** Active pi-branch history used only when a fresh agy conversation needs restoring. */
     readonly historyBootstrap?: string;
     /**
@@ -172,9 +174,12 @@ const makeRuntime = (executor: AgyTurnExecutor) =>
     /** Aborts the in-flight agy child process when the runtime closes. */
     let activeTurnAbort: AbortController | undefined;
     let generation = 0;
-    let restoreHistoryOnNextConversation = false;
+    // The first agy turn may follow work with another provider. Only an
+    // explicit reset suppresses history on a fresh conversation.
+    let restoreHistoryOnNextConversation = true;
     let restoredConversationPending = false;
     let lastBootstrappedSkillsSuffix: string | undefined;
+    let lastSentSystemPrompt: string | undefined;
 
     const invalidateActiveTurn = () => {
       generation += 1;
@@ -244,6 +249,9 @@ const makeRuntime = (executor: AgyTurnExecutor) =>
               restoreHistoryOnNextConversation = false;
               restoredConversationPending = true;
               lastBootstrappedSkillsSuffix = undefined;
+              // Persisted native history can contain a different instruction
+              // snapshot, including one from before the current Pi process.
+              lastSentSystemPrompt = undefined;
             }),
           ),
         ),
@@ -303,7 +311,31 @@ const makeRuntime = (executor: AgyTurnExecutor) =>
                 !conversationId && restoreHistoryOnNextConversation
                   ? request.historyBootstrap
                   : undefined;
-              restoreHistoryOnNextConversation = false;
+              const systemPrompt = request.systemPrompt ?? "";
+              const systemPromptRelay = (
+                !conversationId
+                  ? Boolean(systemPrompt)
+                  : systemPrompt !== lastSentSystemPrompt
+              )
+                ? piSystemInstructionsPrompt(systemPrompt)
+                : undefined;
+              const timeoutMs = envInt("AGY_TURN_TIMEOUT_MS", 600_000);
+              const deadline = Date.now() + timeoutMs;
+              const timeoutError = new AgySpawnError(
+                `agy logical turn timed out after ${Math.round(timeoutMs / 1000)}s`,
+                "",
+              );
+              const abortFailure = () =>
+                turnAbort.signal.reason === timeoutError
+                  ? timeoutError
+                  : new Error("agy turn was aborted.");
+              const deadlineTimer = setTimeout(() => turnAbort.abort(timeoutError), timeoutMs);
+              let onTurnAbort!: () => void;
+              const cancelled = new Promise<never>((_resolve, reject) => {
+                onTurnAbort = () => reject(abortFailure());
+                turnAbort.signal.addEventListener("abort", onTurnAbort, { once: true });
+                if (turnAbort.signal.aborted) onTurnAbort();
+              });
               // Direct-mode skill paths ride the prompt when the bridge is
               // disabled or registration failed. If the bridge was active
               // initially and later fails mid-conversation, or if the skill
@@ -314,13 +346,23 @@ const makeRuntime = (executor: AgyTurnExecutor) =>
                 request.bootstrapSuffix && request.bootstrapSuffix !== lastBootstrappedSkillsSuffix
                   ? request.bootstrapSuffix
                   : undefined;
+              let pendingSystemPromptRelay = systemPromptRelay;
+              let pendingBootstrapSuffix = bootstrapSuffix;
+              const freshSystemPromptRelay = systemPrompt
+                ? piSystemInstructionsPrompt(systemPrompt)
+                : undefined;
               let restoredAttemptActive = resumingPersistedConversation;
               let restoredResultMissing = false;
-              const freshRestorePrompt = [request.historyBootstrap, request.prompt, bootstrapSuffix]
+              const freshRestorePrompt = [
+                freshSystemPromptRelay,
+                request.historyBootstrap,
+                request.prompt,
+                request.bootstrapSuffix,
+              ]
                 .filter((part): part is string => Boolean(part))
                 .join("\n\n");
               const spawnRequest: AgyTurnRequest = {
-                prompt: [historyBootstrap, request.prompt, bootstrapSuffix]
+                prompt: [systemPromptRelay, historyBootstrap, request.prompt, bootstrapSuffix]
                   .filter((part): part is string => Boolean(part))
                   .join("\n\n"),
                 conversationId,
@@ -330,23 +372,20 @@ const makeRuntime = (executor: AgyTurnExecutor) =>
                 mode: request.mode,
                 bridgeRevision: request.bridgeRevision,
                 cwd,
-                timeoutMs: envInt("AGY_TURN_TIMEOUT_MS", 600_000),
+                timeoutMs,
                 inactivityTimeoutMs: envInt("AGY_STALL_TIMEOUT_MS", 120_000),
                 toolInactivityTimeoutMs: envInt("AGY_TOOL_STALL_TIMEOUT_MS", 300_000),
                 signal: turnAbort.signal,
                 onConversation: (id) => {
-                  if (turnGeneration !== generation) return;
+                  if (turnGeneration !== generation || turnAbort.signal.aborted) return;
+                  restoreHistoryOnNextConversation = false;
                   // Track eagerly — a turn hung on a background task may never
                   // resolve, and /agy-tasks needs the id meanwhile.
                   conversationId = id;
                   conversationCwd = cwd;
-                  // Prompt reached the conversation: commit the bootstrap suffix.
-                  if (bootstrapSuffix) {
-                    lastBootstrappedSkillsSuffix = bootstrapSuffix;
-                  }
                 },
                 onActivity: (activity) => {
-                  if (turnGeneration !== generation) return;
+                  if (turnGeneration !== generation || turnAbort.signal.aborted) return;
                   if (
                     restoredAttemptActive &&
                     activity.type === "result" &&
@@ -374,54 +413,89 @@ const makeRuntime = (executor: AgyTurnExecutor) =>
               const runTurnWithStallRetries = async (): Promise<AgyTurnOutcome> => {
                 let retry = 0;
                 let freshFallback = false;
+                const startFreshFallback = () => {
+                  restoredAttemptActive = false;
+                  controller.push({ type: "conversation_fallback" });
+                  conversationId = undefined;
+                  conversationUsage = {};
+                  conversationCwd = undefined;
+                  restoredConversationPending = false;
+                  restoreHistoryOnNextConversation = true;
+                  lastSentSystemPrompt = undefined;
+                  lastBootstrappedSkillsSuffix = undefined;
+                  pendingSystemPromptRelay = freshSystemPromptRelay;
+                  pendingBootstrapSuffix = request.bootstrapSuffix;
+                  freshFallback = true;
+                  retry = 0;
+                };
                 for (;;) {
-                  if (turnAbort.signal.aborted) throw new Error("agy turn was aborted.");
-                  const resumableConversationId = conversationId ?? spawnRequest.conversationId;
-                  const attempt: AgyTurnRequest =
-                    freshFallback && retry === 0
-                      ? {
-                          ...spawnRequest,
-                          prompt: freshRestorePrompt,
-                          conversationId: undefined,
-                        }
-                      : retry === 0
-                        ? spawnRequest
-                        : {
-                            ...spawnRequest,
-                            prompt: resumableConversationId
-                              ? stallContinuationPrompt()
-                              : spawnRequest.prompt,
-                            conversationId: resumableConversationId,
-                          };
+                  if (turnAbort.signal.aborted) throw abortFailure();
+                  const remainingMs = deadline - Date.now();
+                  if (remainingMs <= 0) throw timeoutError;
+                  // After a stale-resume fallback, never resurrect the missing
+                  // original ID if the fresh attempt stalls before init.
+                  const resumableConversationId = freshFallback
+                    ? conversationId
+                    : (conversationId ?? spawnRequest.conversationId);
+                  const resumingRetry = retry > 0 && resumableConversationId !== undefined;
+                  const carriedRelay = resumingRetry
+                    ? pendingSystemPromptRelay
+                    : freshFallback
+                      ? freshSystemPromptRelay
+                      : systemPromptRelay;
+                  const carriedSuffix = resumingRetry
+                    ? pendingBootstrapSuffix
+                    : freshFallback
+                      ? request.bootstrapSuffix
+                      : bootstrapSuffix;
+                  const commitAttemptSync = () => {
+                    if (turnGeneration !== generation || turnAbort.signal.aborted) return;
+                    // Only this attempt's payload can acknowledge a snapshot.
+                    // A new conversation with no instructions is empty by definition.
+                    if (carriedRelay !== undefined || resumableConversationId === undefined) {
+                      lastSentSystemPrompt = systemPrompt;
+                      pendingSystemPromptRelay = undefined;
+                    }
+                    if (carriedSuffix !== undefined) {
+                      lastBootstrappedSkillsSuffix = carriedSuffix;
+                      pendingBootstrapSuffix = undefined;
+                    }
+                  };
+                  const attempt: AgyTurnRequest = {
+                    ...spawnRequest,
+                    prompt: resumingRetry
+                      ? [carriedRelay, stallContinuationPrompt(), carriedSuffix]
+                          .filter((part): part is string => Boolean(part))
+                          .join("\n\n")
+                      : freshFallback
+                        ? freshRestorePrompt
+                        : spawnRequest.prompt,
+                    conversationId: resumableConversationId,
+                    timeoutMs: remainingMs,
+                    onConversation: (id) => {
+                      spawnRequest.onConversation?.(id);
+                      commitAttemptSync();
+                    },
+                  };
                   try {
                     const outcome = await executor.run(attempt);
+                    // A cancelled race loser must not clear a newer turn's
+                    // conversation while processing a delayed fallback result.
+                    if (turnAbort.signal.aborted) throw abortFailure();
                     if (resumingPersistedConversation && !freshFallback && restoredResultMissing) {
-                      restoredAttemptActive = false;
-                      controller.push({ type: "conversation_fallback" });
-                      conversationId = undefined;
-                      conversationUsage = {};
-                      conversationCwd = undefined;
-                      restoredConversationPending = false;
-                      freshFallback = true;
-                      retry = 0;
+                      startFreshFallback();
                       continue;
                     }
+                    if (outcome.status === "OK") commitAttemptSync();
                     return outcome;
                   } catch (error) {
-                    if (turnAbort.signal.aborted) throw new Error("agy turn was aborted.");
+                    if (turnAbort.signal.aborted) throw abortFailure();
                     if (
                       resumingPersistedConversation &&
                       !freshFallback &&
                       isMissingConversationFailure(error)
                     ) {
-                      restoredAttemptActive = false;
-                      controller.push({ type: "conversation_fallback" });
-                      conversationId = undefined;
-                      conversationUsage = {};
-                      conversationCwd = undefined;
-                      restoredConversationPending = false;
-                      freshFallback = true;
-                      retry = 0;
+                      startFreshFallback();
                       continue;
                     }
                     if (!(error instanceof AgyStallError) || retry >= STALL_MAX_RETRIES) {
@@ -437,24 +511,28 @@ const makeRuntime = (executor: AgyTurnExecutor) =>
                     });
                     const backoffMs = envInt("AGY_STALL_RETRY_BACKOFF_MS", 3_000);
                     if (!(await waitForRetryBackoff(backoffMs, turnAbort.signal))) {
-                      throw new Error("agy turn was aborted.");
+                      throw abortFailure();
                     }
                   }
                 }
               };
-              void runTurnWithStallRetries()
+              // A non-cooperative executor/preflight cannot hold the provider
+              // open past cancellation. Its late callbacks are fenced above.
+              // race attaches rejection handlers to both inputs, including the
+              // loser; a late rejection does not require a separate swallow catch.
+              void Promise.race([runTurnWithStallRetries(), cancelled])
                 .then((outcome: AgyTurnOutcome) => {
                   if (turnGeneration !== generation) {
                     controller.close();
                     return;
                   }
                   turns += 1;
-                  if (outcome.conversationId) conversationId = outcome.conversationId;
+                  if (outcome.conversationId) {
+                    conversationId = outcome.conversationId;
+                    restoreHistoryOnNextConversation = false;
+                  }
                   if (outcome.usage) conversationUsage = { ...outcome.usage };
                   restoredConversationPending = false;
-                  if (bootstrapSuffix) {
-                    lastBootstrappedSkillsSuffix = bootstrapSuffix;
-                  }
                   controller.close();
                 })
                 .catch((cause: unknown) => {
@@ -465,6 +543,8 @@ const makeRuntime = (executor: AgyTurnExecutor) =>
                   controller.fail(cause instanceof Error ? cause : new Error(String(cause)));
                 })
                 .finally(() => {
+                  clearTimeout(deadlineTimer);
+                  turnAbort.signal.removeEventListener("abort", onTurnAbort);
                   if (requestAbortHandler) {
                     request.signal?.removeEventListener("abort", requestAbortHandler);
                   }
@@ -496,6 +576,7 @@ const makeRuntime = (executor: AgyTurnExecutor) =>
             restoreHistoryOnNextConversation = false;
             restoredConversationPending = false;
             lastBootstrappedSkillsSuffix = undefined;
+            lastSentSystemPrompt = undefined;
           }),
         ),
       ),

--- a/packages/pi-antigravity/test/agy-client.test.ts
+++ b/packages/pi-antigravity/test/agy-client.test.ts
@@ -370,6 +370,86 @@ test("terminal result disarms stall watchdog and resolves even when stdio stays 
   assert.equal(outcome.finished, true);
 });
 
+function agyToolStepLine(
+  conversation: string,
+  stepIndex: number,
+  state: string,
+  name: string,
+): string {
+  return JSON.stringify({
+    event: "step_update",
+    step_update: {
+      conversation_id: conversation,
+      step_index: stepIndex,
+      state,
+      step_type: "tool",
+      tool_name: name,
+      tool_info: { name, parameters: { CommandLine: "sleep 60" } },
+    },
+  });
+}
+
+test("stall watchdog keeps the longer tool budget while another step is still ACTIVE", async () => {
+  // Regression: ACTIVE A, ACTIVE B, DONE B — finishing B must not shorten
+  // the watchdog back to the base budget while A is still ACTIVE.
+  const child = manualChild();
+  const promise = runAgyTurn({
+    prompt: "hi",
+    timeoutMs: 10_000,
+    inactivityTimeoutMs: 60,
+    toolInactivityTimeoutMs: 300,
+    spawnOverride: (() => child) as never,
+  });
+  child.emitStdout(
+    `${[
+      JSON.stringify({ event: "init", conversation_id: "c-overlap", init: {} }),
+      agyToolStepLine("c-overlap", 0, "ACTIVE", "tool_a"),
+      agyToolStepLine("c-overlap", 1, "ACTIVE", "tool_b"),
+      agyToolStepLine("c-overlap", 1, "DONE", "tool_b"),
+    ].join("\n")}\n`,
+  );
+  await assert.rejects(
+    () => promise,
+    (error: unknown) => {
+      assert.ok(error instanceof AgyStallError, `expected AgyStallError, got ${error}`);
+      assert.equal(error.toolActive, true, "step A is still ACTIVE after B finished");
+      assert.equal(error.stalledMs, 300, "fired on the tool budget, not the base budget");
+      return true;
+    },
+  );
+});
+
+test("stall watchdog treats a duplicate ACTIVE id as one step", async () => {
+  // Regression: a repeated ACTIVE for the same step id must not wedge the
+  // watchdog in the tool budget — one DONE closes the step and the base
+  // budget applies again once no other step is ACTIVE.
+  const child = manualChild();
+  const promise = runAgyTurn({
+    prompt: "hi",
+    timeoutMs: 10_000,
+    inactivityTimeoutMs: 60,
+    toolInactivityTimeoutMs: 300,
+    spawnOverride: (() => child) as never,
+  });
+  child.emitStdout(
+    `${[
+      JSON.stringify({ event: "init", conversation_id: "c-duplicate", init: {} }),
+      agyToolStepLine("c-duplicate", 0, "ACTIVE", "tool_a"),
+      agyToolStepLine("c-duplicate", 0, "ACTIVE", "tool_a"),
+      agyToolStepLine("c-duplicate", 0, "DONE", "tool_a"),
+    ].join("\n")}\n`,
+  );
+  await assert.rejects(
+    () => promise,
+    (error: unknown) => {
+      assert.ok(error instanceof AgyStallError, `expected AgyStallError, got ${error}`);
+      assert.equal(error.toolActive, false, "the step is closed by its DONE event");
+      assert.equal(error.stalledMs, 60, "fired on the base budget");
+      return true;
+    },
+  );
+});
+
 function processGone(pid: number): boolean {
   try {
     process.kill(pid, 0);

--- a/packages/pi-antigravity/test/agy-driver.test.ts
+++ b/packages/pi-antigravity/test/agy-driver.test.ts
@@ -545,6 +545,175 @@ test("persistent driver wraps synchronous spawn failures and marks itself dead",
   await executor.close("shutdown");
 });
 
+/**
+ * Driver fixture that streams multi-tool step sequences and then goes
+ * silent, so the Pi-side stall watchdog is the only thing that can end the
+ * turn. Used to pin the ACTIVE-step tracking semantics.
+ */
+async function stepSequenceFixture(): Promise<{ dir: string; script: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "agy-driver-steps-"));
+  const script = path.join(dir, "driver-steps.mjs");
+  await writeFile(
+    script,
+    `#!/usr/bin/env node
+import readline from "node:readline";
+const conversation = "driver-steps-conversation";
+const send = (obj) => console.log(JSON.stringify(obj));
+const toolStep = (index, state, name) => send({
+  event: "step_update",
+  step_update: {
+    conversation_id: conversation,
+    step_index: index,
+    state,
+    step_type: "tool",
+    tool_name: name,
+    tool_info: { name, parameters: { CommandLine: "sleep 60" } }
+  }
+});
+let initSent = false;
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+rl.on("line", (line) => {
+  const event = JSON.parse(line);
+  if (!initSent) {
+    initSent = true;
+    send({ event: "init", conversation_id: conversation, init: {} });
+  }
+  const content = event.message.content;
+  if (content === "overlap") {
+    toolStep(0, "ACTIVE", "tool_a");
+    toolStep(1, "ACTIVE", "tool_b");
+    toolStep(1, "DONE", "tool_b");
+  }
+  if (content === "duplicate") {
+    toolStep(0, "ACTIVE", "tool_a");
+    toolStep(0, "ACTIVE", "tool_a");
+    toolStep(0, "DONE", "tool_a");
+  }
+  // Every sequence ends silent: the watchdog must decide the budget.
+});
+`,
+  );
+  await chmod(script, 0o755);
+  return { dir, script };
+}
+
+test("persistent driver keeps the longer tool budget while another step is still ACTIVE", async () => {
+  // Regression: ACTIVE A, ACTIVE B, DONE B — B completing must not clear the
+  // active-tool state while A is still running, so the stall watchdog must
+  // fire on the tool budget, not the short base budget.
+  const fixture = await stepSequenceFixture();
+  const executor = new AgyDriverSession();
+  try {
+    await assert.rejects(
+      () =>
+        executor.run({
+          prompt: "overlap",
+          binary: fixture.script,
+          cwd: fixture.dir,
+          inactivityTimeoutMs: 120,
+          toolInactivityTimeoutMs: 600,
+          timeoutMs: 5_000,
+          spawnOverride: fixtureSpawn(fixture.script),
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof AgyStallError, `expected AgyStallError, got ${error}`);
+        assert.equal(error.toolActive, true, "step A is still ACTIVE after B finished");
+        assert.equal(error.stalledMs, 600, "fired on the tool budget, not the base budget");
+        return true;
+      },
+    );
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver treats a duplicate ACTIVE id as one step for the watchdog", async () => {
+  // Regression: a repeated ACTIVE for the same step id must not wedge the
+  // watchdog in the tool budget — one DONE closes the step and the base
+  // budget applies again once no other step is ACTIVE.
+  const fixture = await stepSequenceFixture();
+  const executor = new AgyDriverSession();
+  try {
+    await assert.rejects(
+      () =>
+        executor.run({
+          prompt: "duplicate",
+          binary: fixture.script,
+          cwd: fixture.dir,
+          inactivityTimeoutMs: 120,
+          toolInactivityTimeoutMs: 600,
+          timeoutMs: 5_000,
+          spawnOverride: fixtureSpawn(fixture.script),
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof AgyStallError, `expected AgyStallError, got ${error}`);
+        assert.equal(error.toolActive, false, "the step is closed by its DONE event");
+        assert.equal(error.stalledMs, 120, "fired on the base budget");
+        return true;
+      },
+    );
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver abort during startup never submits the prompt to stdin", async () => {
+  // Regression: the signal can fire while the executor is still inside the
+  // spawn/start path (binary check, recycle, child start). The turn must be
+  // settled with the abort outcome BEFORE the user event is written, and no
+  // abort listener may be registered after the signal already fired.
+  const signal = new AbortController();
+  let written = "";
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter & {
+      write: (line: string, callback: (error?: Error | null) => void) => boolean;
+      end: () => void;
+    };
+    stdout: PassThrough;
+    stderr: PassThrough;
+    pid?: number;
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = Object.assign(new EventEmitter(), {
+    write: (line: string, callback: (error?: Error | null) => void) => {
+      written += line;
+      queueMicrotask(() => callback());
+      return true;
+    },
+    end: () => {},
+  });
+  const spawnOverride = ((_binary: string, _args: readonly string[], _options: unknown) => {
+    // Abort mid-startup: after run()'s entry check, while the driver is
+    // starting the child process.
+    signal.abort();
+    return child;
+  }) as never;
+  const executor = new AgyDriverSession();
+  try {
+    const message = await executor
+      .run({
+        prompt: "must never be submitted",
+        binary: "/fake/agy",
+        spawnOverride,
+        signal: signal.signal,
+        timeoutMs: 2_000,
+        inactivityTimeoutMs: 0,
+      })
+      .then(
+        (outcome) => outcome.error ?? "",
+        (error: unknown) => (error instanceof Error ? error.message : String(error)),
+      );
+    assert.match(message, /aborted/i);
+    assert.equal(written, "", "no user event may reach the agy stdin after abort");
+    assert.equal(getEventListeners(signal.signal, "abort").length, 0);
+  } finally {
+    await executor.close("shutdown");
+  }
+});
+
 test("one-shot executor exposes rollback mode and abortable close", async () => {
   const executor = new AgyOneShotExecutor();
   assert.equal(executor.snapshot().mode, "one-shot");

--- a/packages/pi-antigravity/test/agy-driver.test.ts
+++ b/packages/pi-antigravity/test/agy-driver.test.ts
@@ -601,8 +601,12 @@ test("persistent driver keeps the longer tool budget while another step is still
   // Regression: ACTIVE A, ACTIVE B, DONE B — B completing must not clear the
   // active-tool state while A is still running, so the stall watchdog must
   // fire on the tool budget, not the short base budget.
+  // Use a long base / short tool budget so fixture startup cannot race the
+  // initial stall arm under full-suite load (same pattern as the single-tool
+  // active-budget test above).
   const fixture = await stepSequenceFixture();
   const executor = new AgyDriverSession();
+  const seen: string[] = [];
   try {
     await assert.rejects(
       () =>
@@ -610,15 +614,20 @@ test("persistent driver keeps the longer tool budget while another step is still
           prompt: "overlap",
           binary: fixture.script,
           cwd: fixture.dir,
-          inactivityTimeoutMs: 120,
-          toolInactivityTimeoutMs: 600,
+          inactivityTimeoutMs: 500,
+          toolInactivityTimeoutMs: 80,
           timeoutMs: 5_000,
           spawnOverride: fixtureSpawn(fixture.script),
+          onActivity: (activity) => seen.push(activity.type),
         }),
       (error: unknown) => {
         assert.ok(error instanceof AgyStallError, `expected AgyStallError, got ${error}`);
+        assert.ok(
+          seen.filter((type) => type === "tool_start").length >= 2 && seen.includes("tool_done"),
+          "fixture steps must arrive before the stall fires",
+        );
         assert.equal(error.toolActive, true, "step A is still ACTIVE after B finished");
-        assert.equal(error.stalledMs, 600, "fired on the tool budget, not the base budget");
+        assert.equal(error.stalledMs, 80, "fired on the tool budget, not the base budget");
         return true;
       },
     );
@@ -634,6 +643,7 @@ test("persistent driver treats a duplicate ACTIVE id as one step for the watchdo
   // budget applies again once no other step is ACTIVE.
   const fixture = await stepSequenceFixture();
   const executor = new AgyDriverSession();
+  const seen: string[] = [];
   try {
     await assert.rejects(
       () =>
@@ -641,15 +651,22 @@ test("persistent driver treats a duplicate ACTIVE id as one step for the watchdo
           prompt: "duplicate",
           binary: fixture.script,
           cwd: fixture.dir,
-          inactivityTimeoutMs: 120,
-          toolInactivityTimeoutMs: 600,
+          // Match the startup headroom of other driver stall fixtures; keep
+          // the tool budget much longer so a wedged ACTIVE would miss this.
+          inactivityTimeoutMs: 500,
+          toolInactivityTimeoutMs: 2_000,
           timeoutMs: 5_000,
           spawnOverride: fixtureSpawn(fixture.script),
+          onActivity: (activity) => seen.push(activity.type),
         }),
       (error: unknown) => {
         assert.ok(error instanceof AgyStallError, `expected AgyStallError, got ${error}`);
+        assert.ok(
+          seen.includes("tool_start") && seen.includes("tool_done"),
+          "fixture steps must arrive before the stall fires",
+        );
         assert.equal(error.toolActive, false, "the step is closed by its DONE event");
-        assert.equal(error.stalledMs, 120, "fired on the base budget");
+        assert.equal(error.stalledMs, 500, "fired on the base budget");
         return true;
       },
     );

--- a/packages/pi-antigravity/test/provider.test.ts
+++ b/packages/pi-antigravity/test/provider.test.ts
@@ -353,7 +353,10 @@ test("streamAntigravity refreshes bridge state and passes effort, profile, and r
     const events = [];
     for await (const event of streamFn(
       model,
-      contextWith([{ role: "user", content: [{ type: "text", text: prompt }] }]),
+      {
+        ...contextWith([{ role: "user", content: [{ type: "text", text: prompt }] }]),
+        systemPrompt: "Project instructions from Pi",
+      },
       { reasoning: "medium" },
     )) {
       events.push(event);
@@ -369,6 +372,7 @@ test("streamAntigravity refreshes bridge state and passes effort, profile, and r
   });
   await eventsPromise;
   assert.equal(captured?.effort, "high", "unsupported medium falls back to discovered default");
+  assert.equal(captured?.systemPrompt, "Project instructions from Pi");
   assert.equal(captured?.agent, "reviewer");
   assert.equal(captured?.mode, "plan");
   assert.equal(captured?.bridgeRevision, "2:1");
@@ -379,11 +383,13 @@ test("streamAntigravity isolates pi summarization from the resumed agy conversat
     "<conversation>\nuser: real request\nassistant: result\n</conversation>\n\nSummarize the conversation above.";
   const isolatedController = new AgyTurnController(summaryPrompt);
   const isolatedPrompts: string[] = [];
+  let isolatedSystemPrompt: string | undefined;
   let isolatedBeginCount = 0;
   let disposed = false;
   const isolatedService = {
-    beginStreamTurn: (request: { prompt: string }) =>
+    beginStreamTurn: (request: { prompt: string; systemPrompt?: string }) =>
       Effect.sync(() => {
+        isolatedSystemPrompt = request.systemPrompt;
         isolatedBeginCount += 1;
         isolatedPrompts.push(request.prompt);
         return isolatedController;
@@ -403,6 +409,10 @@ test("streamAntigravity isolates pi summarization from the resumed agy conversat
   };
   const harness = makeStreamHarness({
     prompt: summaryPrompt,
+    context: {
+      ...contextWith([{ role: "user", content: summaryPrompt }]),
+      systemPrompt: "Pi summary instructions",
+    },
     createIsolatedRuntime: () => isolatedRuntime as any,
   });
   const eventsPromise = harness.collect();
@@ -419,6 +429,7 @@ test("streamAntigravity isolates pi summarization from the resumed agy conversat
   assert.equal(harness.getSharedBeginCount(), 0);
   assert.equal(isolatedBeginCount, 1);
   assert.deepEqual(isolatedPrompts, [summaryPrompt]);
+  assert.equal(isolatedSystemPrompt, "Pi summary instructions");
   const done = events.find((event) => event.type === "done");
   assert.equal(done?.message.content[0]?.text, "Compact summary");
   assert.equal(done?.message.usage.totalTokens, 0);

--- a/packages/pi-antigravity/test/runtime-instructions.test.ts
+++ b/packages/pi-antigravity/test/runtime-instructions.test.ts
@@ -1,0 +1,380 @@
+import assert from "node:assert/strict";
+import { getEventListeners } from "node:events";
+import { setImmediate } from "node:timers/promises";
+import { test, type TestContext } from "node:test";
+import { AgySpawnError, AgyStallError, type AgyTurnRequest } from "../lib/agy-client.ts";
+import { piSystemInstructionsPrompt, stallContinuationPrompt } from "../lib/prompt.ts";
+import { newTurnOutcome } from "../lib/reducer.ts";
+import {
+  AntigravityRuntime,
+  createAntigravityRuntime,
+  type AgyTurnRunner,
+  type AntigravityRuntimeShape,
+} from "../src/runtime.ts";
+
+type TurnRequest = Parameters<AntigravityRuntimeShape["beginStreamTurn"]>[0];
+const outcome = (conversationId = "native") => ({
+  ...newTurnOutcome(),
+  conversationId,
+  status: "OK" as const,
+  finished: true,
+});
+
+function setup(t: TestContext, runner?: AgyTurnRunner) {
+  const requests: AgyTurnRequest[] = [];
+  const runtime = createAntigravityRuntime(async (request) => {
+    requests.push(request);
+    if (runner) return runner(request);
+    request.onConversation?.("native");
+    return outcome();
+  });
+  const service = runtime.runSync(AntigravityRuntime);
+  t.after(async () => {
+    await runtime.runPromise(service.close);
+    await runtime.dispose();
+  });
+  const begin = (request: Omit<TurnRequest, "modelId">) =>
+    runtime.runPromise(service.beginStreamTurn({ ...request, modelId: "fixture" }));
+  const complete = async (request: Omit<TurnRequest, "modelId">) => {
+    const controller = await begin(request);
+    while (await controller.next()) {
+      /* Drain synthetic activities. */
+    }
+    await runtime.runPromise(service.finishTurn);
+  };
+  return { runtime, service, requests, begin, complete };
+}
+
+function env(t: TestContext, name: string, value: string) {
+  const previous = process.env[name];
+  process.env[name] = value;
+  t.after(() => {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  });
+}
+
+test("first agy turn restores other-provider history after /new; explicit reset does not", async (t) => {
+  const f = setup(t);
+  await f.runtime.runPromise(f.service.setSession("/repo", undefined, false));
+  await f.complete({ prompt: "implement it", historyBootstrap: "agreed plan" });
+  assert.equal(f.requests[0].prompt, "agreed plan\n\nimplement it");
+  await f.runtime.runPromise(f.service.reset);
+  await f.complete({
+    prompt: "new task",
+    historyBootstrap: "agreed plan",
+    systemPrompt: "project rules",
+  });
+  assert.doesNotMatch(f.requests[1].prompt, /agreed plan/);
+  assert.match(f.requests[1].prompt, /project rules/);
+});
+
+test("failed pre-init send does not consume pending history or instructions", async (t) => {
+  let attempts = 0;
+  const f = setup(t, async (request) => {
+    if (++attempts === 1) throw new AgySpawnError("preflight failed", "");
+    request.onConversation?.("native");
+    return outcome();
+  });
+  const first = await f.begin({
+    prompt: "first",
+    historyBootstrap: "history",
+    systemPrompt: "rules",
+  });
+  await assert.rejects(first.next(), /preflight failed/);
+  await f.complete({ prompt: "retry", historyBootstrap: "history", systemPrompt: "rules" });
+  assert.match(f.requests[1].prompt, /history\n\nretry/);
+  assert.match(f.requests[1].prompt, /rules/);
+});
+
+test("instructions synchronize once, update, clear, and resend after reset", async (t) => {
+  const f = setup(t);
+  await f.complete({ prompt: "one", systemPrompt: "rules A" });
+  assert.equal(f.requests[0].prompt, `${piSystemInstructionsPrompt("rules A")}\n\none`);
+  await f.complete({ prompt: "two", systemPrompt: "rules A" });
+  assert.equal(f.requests[1].prompt, "two");
+  await f.complete({ prompt: "three", systemPrompt: "rules B" });
+  assert.equal(f.requests[2].prompt, `${piSystemInstructionsPrompt("rules B")}\n\nthree`);
+  await f.complete({ prompt: "four" });
+  assert.equal(f.requests[3].prompt, `${piSystemInstructionsPrompt("")}\n\nfour`);
+  await f.complete({ prompt: "five" });
+  assert.equal(f.requests[4].prompt, "five");
+  await f.runtime.runPromise(f.service.reset);
+  await f.complete({ prompt: "six", systemPrompt: "rules B" });
+  assert.equal(f.requests[5].prompt, `${piSystemInstructionsPrompt("rules B")}\n\nsix`);
+});
+
+test("tool re-entry defers changed instructions until the next user turn", async (t) => {
+  let finish!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  const f = setup(t, async (request) => {
+    request.onConversation?.("native");
+    await gate;
+    return outcome();
+  });
+  const first = await f.begin({ prompt: "same", systemPrompt: "rules A" });
+  const reentry = await f.begin({ prompt: "same", systemPrompt: "rules B" });
+  assert.equal(first, reentry);
+  assert.equal(f.requests.length, 1);
+  finish();
+  assert.equal(await first.next(), null);
+  await f.complete({ prompt: "next", systemPrompt: "rules B" });
+  assert.match(f.requests[1].prompt, /rules B/);
+});
+
+test("restored native conversations resync instructions and fresh fallback receives them too", async (t) => {
+  let attempts = 0;
+  const f = setup(t, async (request) => {
+    if (++attempts === 2) throw new AgySpawnError("conversation missing", "");
+    request.onConversation?.("native");
+    return outcome();
+  });
+  await f.complete({ prompt: "initial", systemPrompt: "same rules" });
+  await f.runtime.runPromise(
+    f.service.restoreConversation({
+      conversationId: "stale",
+      modelId: "fixture",
+      cwd: "/repo",
+      turns: 1,
+      usage: {},
+    }),
+  );
+  await f.complete({
+    prompt: "continue",
+    systemPrompt: "same rules",
+    historyBootstrap: "branch history",
+  });
+  assert.match(f.requests[1].prompt, /same rules/);
+  assert.equal(f.requests[1].conversationId, "stale");
+  assert.equal(f.requests[2].conversationId, undefined);
+  assert.equal(
+    f.requests[2].prompt,
+    `${piSystemInstructionsPrompt("same rules")}\n\nbranch history\n\ncontinue`,
+  );
+});
+
+for (const systemPrompt of ["updated instructions", ""]) {
+  test(`resume retry retains unacknowledged ${systemPrompt ? "updated" : "cleared"} instructions and skills`, async (t) => {
+    env(t, "AGY_STALL_RETRY_BACKOFF_MS", "0");
+    let attempts = 0;
+    const f = setup(t, async (request) => {
+      if (++attempts === 2) throw new AgyStallError(1, false);
+      // A terminal result without onConversation must also commit what it sent.
+      if (attempts === 1) request.onConversation?.("native");
+      return outcome();
+    });
+    await f.complete({
+      prompt: "initial",
+      systemPrompt: "old instructions",
+      bootstrapSuffix: "old skills",
+    });
+    await f.complete({ prompt: "update", systemPrompt, bootstrapSuffix: "new skills" });
+    assert.equal(f.requests[2].conversationId, "native");
+    assert.equal(
+      f.requests[2].prompt,
+      [piSystemInstructionsPrompt(systemPrompt), stallContinuationPrompt(), "new skills"].join(
+        "\n\n",
+      ),
+    );
+    await f.complete({ prompt: "next", systemPrompt, bootstrapSuffix: "new skills" });
+    assert.equal(f.requests[3].prompt, "next");
+  });
+}
+
+test("acknowledged instructions and skills are not duplicated on a stall retry", async (t) => {
+  env(t, "AGY_STALL_RETRY_BACKOFF_MS", "0");
+  let attempts = 0;
+  const f = setup(t, async (request) => {
+    request.onConversation?.("native");
+    if (++attempts === 2) throw new AgyStallError(1, false);
+    return outcome();
+  });
+  await f.complete({ prompt: "initial", systemPrompt: "old" });
+  await f.complete({ prompt: "update", systemPrompt: "new", bootstrapSuffix: "skills" });
+  assert.equal(f.requests[2].prompt, stallContinuationPrompt());
+  await f.complete({ prompt: "next", systemPrompt: "new", bootstrapSuffix: "skills" });
+  assert.equal(f.requests[3].prompt, "next");
+});
+
+test("an unacknowledged error result does not commit an instruction or skills update", async (t) => {
+  let attempts = 0;
+  const f = setup(t, async (request) => {
+    if (++attempts === 2) return { ...outcome(), status: "ERROR", error: "request rejected" };
+    request.onConversation?.("native");
+    return outcome();
+  });
+  await f.complete({ prompt: "initial", systemPrompt: "old", bootstrapSuffix: "old skills" });
+  await f.complete({ prompt: "rejected", systemPrompt: "new", bootstrapSuffix: "new skills" });
+  await f.complete({ prompt: "next", systemPrompt: "new", bootstrapSuffix: "new skills" });
+  assert.equal(
+    f.requests[2].prompt,
+    [piSystemInstructionsPrompt("new"), "next", "new skills"].join("\n\n"),
+  );
+});
+
+test("fresh fallback retries keep all context and never resurrect a missing conversation ID", async (t) => {
+  env(t, "AGY_STALL_RETRY_BACKOFF_MS", "0");
+  let attempts = 0;
+  const f = setup(t, async (request) => {
+    if (++attempts === 1) {
+      // An init from the missing conversation must not commit sync for its replacement.
+      request.onConversation?.("missing");
+      throw new AgySpawnError("conversation missing", "");
+    }
+    if (attempts === 2) throw new AgyStallError(1, false);
+    request.onConversation?.("fresh");
+    return outcome("fresh");
+  });
+  await f.runtime.runPromise(
+    f.service.restoreConversation({
+      conversationId: "missing",
+      modelId: "fixture",
+      cwd: "/repo",
+      turns: 0,
+      usage: {},
+    }),
+  );
+  await f.complete({
+    prompt: "continue",
+    systemPrompt: "rules",
+    bootstrapSuffix: "skills",
+    historyBootstrap: "history",
+  });
+  assert.equal(f.requests.length, 3);
+  assert.equal(f.requests[0].conversationId, "missing");
+  for (const request of f.requests.slice(1)) {
+    assert.equal(request.conversationId, undefined);
+    assert.equal(
+      request.prompt,
+      [piSystemInstructionsPrompt("rules"), "history", "continue", "skills"].join("\n\n"),
+    );
+  }
+  await f.complete({ prompt: "next", systemPrompt: "rules", bootstrapSuffix: "skills" });
+  assert.equal(f.requests[3].prompt, "next");
+});
+
+test("logical deadline interrupts retry backoff without submitting another attempt", async (t) => {
+  env(t, "AGY_TURN_TIMEOUT_MS", "100");
+  env(t, "AGY_STALL_RETRY_BACKOFF_MS", "1000");
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"] });
+  const f = setup(t, async () => {
+    throw new AgyStallError(10, false);
+  });
+  const turn = await f.begin({ prompt: "slow" });
+  assert.equal((await turn.next())?.type, "stall");
+  const failed = assert.rejects(turn.next(), /logical turn timed out/);
+  t.mock.timers.tick(100);
+  await failed;
+  assert.equal(f.requests.length, 1);
+  assert.equal(f.requests[0].signal?.aborted, true);
+});
+
+test("retries receive only the remaining logical-turn budget", async (t) => {
+  env(t, "AGY_TURN_TIMEOUT_MS", "100");
+  env(t, "AGY_STALL_RETRY_BACKOFF_MS", "10");
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"] });
+  let attempts = 0;
+  const f = setup(t, async () => {
+    if (++attempts === 1) {
+      t.mock.timers.tick(40);
+      throw new AgyStallError(40, false);
+    }
+    return outcome();
+  });
+  const turn = await f.begin({ prompt: "retry" });
+  assert.equal((await turn.next())?.type, "stall");
+  t.mock.timers.tick(10);
+  assert.equal(await turn.next(), null);
+  assert.equal(f.requests[0].timeoutMs, 100);
+  assert.equal(f.requests[1].timeoutMs, 50);
+});
+
+test("a delayed stale-resume result cannot reset a newer conversation after cancellation", async (t) => {
+  env(t, "AGY_TURN_TIMEOUT_MS", "100");
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"] });
+  let finish!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  let attempts = 0;
+  const f = setup(t, async (request) => {
+    if (++attempts === 1) {
+      request.onActivity?.({
+        type: "result",
+        status: "ERROR",
+        response: "",
+        error: "conversation missing",
+        usage: undefined,
+      });
+      await gate;
+      return outcome("stale");
+    }
+    request.onConversation?.("current");
+    return outcome("current");
+  });
+  await f.runtime.runPromise(
+    f.service.restoreConversation({
+      conversationId: "stale",
+      modelId: "fixture",
+      cwd: "/repo",
+      turns: 0,
+      usage: {},
+    }),
+  );
+  const old = await f.begin({ prompt: "old" });
+  const failed = assert.rejects(old.next(), /logical turn timed out/);
+  t.mock.timers.tick(100);
+  await failed;
+  await f.complete({ prompt: "new" });
+  finish();
+  await setImmediate();
+  assert.equal((await f.runtime.runPromise(f.service.snapshot)).conversationId, "current");
+  assert.equal(f.requests.length, 2);
+});
+
+test("a cancelled race handles a non-cooperative executor's later rejection", async (t) => {
+  env(t, "AGY_TURN_TIMEOUT_MS", "100");
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"] });
+  let rejectLate!: (error: Error) => void;
+  const gate = new Promise<never>((_resolve, reject) => {
+    rejectLate = reject;
+  });
+  const f = setup(t, () => gate);
+  const turn = await f.begin({ prompt: "late rejection" });
+  const failed = assert.rejects(turn.next(), /logical turn timed out/);
+  t.mock.timers.tick(100);
+  await failed;
+  rejectLate(new Error("late executor failure"));
+  // node --test treats any unhandled rejection as a failure, even after a test ends.
+  await setImmediate();
+  await setImmediate();
+  assert.equal(turn.isClosed(), true);
+});
+
+test("deadline bounds non-cooperative startup and fences late native callbacks", async (t) => {
+  env(t, "AGY_TURN_TIMEOUT_MS", "100");
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"] });
+  let finish!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  const f = setup(t, async (request) => {
+    await gate;
+    request.onConversation?.("late");
+    request.onActivity?.({ type: "text", delta: "late response" });
+    return outcome("late");
+  });
+  const turn = await f.begin({ prompt: "blocked preflight" });
+  const failed = assert.rejects(turn.next(), /logical turn timed out/);
+  t.mock.timers.tick(100);
+  await failed;
+  finish();
+  await setImmediate();
+  assert.equal(turn.hasPending(), false);
+  const snapshot = await f.runtime.runPromise(f.service.snapshot);
+  assert.equal(snapshot.conversationId, undefined);
+  assert.equal(snapshot.turns, 0);
+  assert.equal(getEventListeners(f.requests[0].signal!, "abort").length, 0);
+});

--- a/packages/pi-antigravity/test/runtime.test.ts
+++ b/packages/pi-antigravity/test/runtime.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { AgySpawnError, AgyStallError, type AgyTurnRequest } from "../lib/agy-client.ts";
-import { stallContinuationPrompt } from "../lib/prompt.ts";
+import { piSystemInstructionsPrompt, stallContinuationPrompt } from "../lib/prompt.ts";
 import { newTurnOutcome, type AgyTurnOutcome } from "../lib/reducer.ts";
 import type { AgyTurnExecutor } from "../lib/agy-driver.ts";
 import { AntigravityRuntime, createAntigravityRuntime, runAntigravity } from "../src/runtime.ts";
@@ -243,7 +243,8 @@ test("runtime restores a persisted native conversation and cumulative usage", as
     );
     assert.equal(await controller.next(), null);
     assert.equal(requests[0].conversationId, "persisted-conversation");
-    assert.equal(requests[0].prompt, "continue");
+    // A restored native conversation may still contain an old Pi snapshot.
+    assert.equal(requests[0].prompt, `${piSystemInstructionsPrompt("")}\n\ncontinue`);
     assert.deepEqual(await runAntigravity(runtime, service.snapshot), {
       conversationId: "persisted-conversation",
       model: "gemini-3.7-flash",

--- a/packages/pi-antigravity/test/tool-steps.test.ts
+++ b/packages/pi-antigravity/test/tool-steps.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { agyToolStepKey, trackActiveToolStep } from "../lib/tool-steps.ts";
+
+test("active-step tracking shares replay keys and treats step zero as an ID", () => {
+  assert.equal(agyToolStepKey({ stepId: 0, name: "run_command" }), "step:0");
+  assert.equal(agyToolStepKey({ name: "run_command" }), "name:run_command");
+});
+
+test("duplicate starts and errors affect only their own step", () => {
+  const active = new Set<string>();
+  for (const stepId of [0, 0, 1]) {
+    trackActiveToolStep(active, { type: "tool_start", stepId, name: "same", args: {} });
+  }
+  assert.equal(active.size, 2);
+  trackActiveToolStep(active, {
+    type: "tool_error",
+    stepId: 1,
+    name: "same",
+    args: {},
+    message: "failed",
+  });
+  assert.deepEqual([...active], ["step:0"]);
+  trackActiveToolStep(active, { type: "tool_done", stepId: 0, name: "same", args: {} });
+  assert.equal(active.size, 0);
+});
+
+test("missing IDs fall back to tool names without clearing unrelated tools", () => {
+  const active = new Set<string>();
+  for (const name of ["one", "one", "two"]) {
+    trackActiveToolStep(active, { type: "tool_start", name, args: {} });
+  }
+  trackActiveToolStep(active, { type: "tool_done", name: "two", args: {} });
+  assert.deepEqual([...active], ["name:one"]);
+  trackActiveToolStep(active, { type: "tool_done", name: "one", args: {} });
+  assert.equal(active.size, 0);
+});


### PR DESCRIPTION
## Summary
- Restore Pi conversation history on the first Antigravity handoff while keeping `/agy reset` as an explicit fresh start
- Relay and sync Pi system instructions through agy's text interface, retaining pending instruction/skill updates across stall retries
- Enforce a single logical-turn deadline across startup, retries, and backoff; prevent cancelled startup from submitting prompts; track overlapping native tool steps correctly
- Document that native agy operations bypass Pi permission hooks

## Test plan
- [ ] Run `pnpm --filter @tian.zuo/pi-antigravity test`
- [ ] Switch to an Antigravity model after prior Pi history and confirm context is restored on the first turn
- [ ] Run `/agy reset`, then confirm history is not replayed until a later provider switch restores it
- [ ] Change project/system instructions mid-session and confirm they are relayed once, not on every tool loop
- [ ] Stall a turn (or force retries) and confirm pending instruction/skill updates survive retries within the shared deadline
- [ ] Cancel during startup and confirm no prompt is submitted
- [ ] Exercise overlapping native tool steps and confirm stall budgets stay correct until all active tools finish