### PR TITLE
fix(pi-find): search correctness hardening

### DIFF
--- a/.changeset/tidy-search-correctness.md
+++ b/.changeset/tidy-search-correctness.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-find": patch
+---
+
+Fix root-relative glob matching without bypassing ignore rules, isolate grep from user ripgrep configuration, and report unexpected process termination as an error. Preserve unusual filenames with NUL-delimited find output and JSON-quoted display paths, and never surface partial records after a timeout kill. Normalize @ and home paths, reject explicit .git searches, retain empty-search timeout warnings, and document search limits. Add regression coverage for these behaviors and active cancellation.

--- a/packages/pi-find/README.md
+++ b/packages/pi-find/README.md
@@ -33,7 +33,7 @@ grep(pattern, path?, glob?)
 find(pattern, path?)
 ```
 
-- `pattern` is a file glob, for example `*.ts` or `**/*.test.ts`.
+- `pattern` is a case-sensitive file glob, for example `*.ts` or `**/*.test.ts`.
 - `path` is one directory and defaults to the current directory.
 
 ```jsonc
@@ -42,15 +42,31 @@ find(pattern, path?)
 
 ## Search behavior
 
-- Both tools respect `.gitignore` and always skip `.git`.
+- Both tools respect `.gitignore` and always skip `.git`. Explicit `.git`
+  roots, files inside them, and symlink aliases to them are rejected.
+- Globs without `/` match basenames at any depth. Globs containing `/` match
+  paths relative to the search directory (or the parent of an explicit grep
+  file). For example, `src/*.ts` matches direct children of `src`, while
+  `src/**/*.ts` includes descendants. Use `/` in globs on every platform.
+  Glob filtering never re-includes ignored files.
+- A leading `@` is stripped from input paths; `~` and `~/...` expand to the
+  home directory. Ripgrep user configuration is ignored so it cannot change
+  the tool's case sensitivity or ignore behavior.
 - Hidden files and directories are not searched by default. An explicitly
   named hidden path still works, for example `path: ".github"`.
 - Grep stops after 100 matches; find stops after 200 files. A result says when
   the fixed limit was reached so the caller can narrow the search.
+- Grep skips files larger than 4 MiB during directory traversal. Explicitly
+  named files follow ripgrep's explicit-file behavior and can exceed that limit.
 - Grep lines longer than 400 characters are clipped.
 - Search output also has a hard byte limit, and running searches are
   cancellable.
 - Relative result paths can be passed directly to pi's `read` and `edit` tools.
+  Paths containing control characters, backslashes, or quotes are JSON-quoted;
+  decode the JSON string before using them. Newlines in filenames do not create
+  extra find results.
+- Timeouts are marked as partial, including when no results were gathered.
+  Unexpected process termination is an error, not a completed empty search.
 
 For uncommon searches involving several roots, exclusions, multiline matching,
 counts, sorting, or pipelines, use `rg` or `fd` through the shell rather than

--- a/packages/pi-find/lib/prompt.ts
+++ b/packages/pi-find/lib/prompt.ts
@@ -7,26 +7,28 @@ export const FIND_RESULT_LIMIT = 200;
 export const SEARCH_TIMEOUT_MS = 30_000;
 
 export const GREP_TOOL_DESCRIPTION =
-  "Search file contents with a case-sensitive regex; respects .gitignore; 30s timeout.";
+  "Search file contents with a case-sensitive regex; respects .gitignore. Skips hidden paths by default and files over 4 MiB during traversal. Up to 100 matching lines, clipped at 400 characters; bounded output; 30s timeout. Ripgrep config is ignored. Special paths are JSON-quoted; decode before read/edit.";
 export const GREP_PROMPT_SNIPPET = "Search file contents with a regex";
 
 export const GREP_PARAMETER_DESCRIPTIONS = {
   pattern: "Case-sensitive ripgrep regex.",
   path: "File or directory to search; default is the current directory.",
-  glob: "Optional file glob, for example '*.ts' or '**/*.test.ts'.",
+  glob: "Case-sensitive glob: basename ('*.ts') or search-root-relative path ('src/*.ts').",
 };
 
-export const FIND_TOOL_DESCRIPTION = "Find files with a glob; respects .gitignore; 30s timeout.";
+export const FIND_TOOL_DESCRIPTION =
+  "Find files with a case-sensitive glob; respects .gitignore. Skips hidden paths by default. Up to 200 files; bounded output; 30s timeout. Paths containing special characters are JSON-quoted; decode them before passing to read/edit.";
 export const FIND_PROMPT_SNIPPET = "Find files with a glob";
 
 export const FIND_PARAMETER_DESCRIPTIONS = {
-  pattern: "File glob, for example '*.ts' or '**/*.test.ts'.",
+  pattern: "Case-sensitive glob: basename ('*.ts') or search-root-relative path ('src/*.ts').",
   path: "Directory to search; default is the current directory.",
 };
 
 export const NO_GREP_MATCHES = "No matches found.";
 export const NO_FILES_FOUND = "No files found.";
 export const EMPTY_PATTERN_ERROR = "Search pattern cannot be empty.";
+export const GIT_PATH_ERROR = "Searches inside .git are excluded; choose a working-tree path.";
 
 export function missingSearchPathError(searchPath: string): string {
   return `Search path does not exist: ${searchPath}.`;

--- a/packages/pi-find/lib/rg-json.ts
+++ b/packages/pi-find/lib/rg-json.ts
@@ -19,7 +19,7 @@ interface RgData {
 }
 
 function decodeText(value: RgData | string | undefined): string {
-  if (value === undefined) return "";
+  if (value == null) return "";
   if (typeof value === "string") return value;
   if (typeof value.text === "string") return value.text;
   if (typeof value.bytes === "string") {
@@ -55,7 +55,7 @@ export function decodeRgEvent(line: string): RgLine | undefined {
     return undefined;
   }
 
-  if (event.type !== "match") return undefined;
+  if (event == null || event.type !== "match") return undefined;
   const data = event.data;
   if (!data || typeof data.line_number !== "number") return undefined;
 

--- a/packages/pi-find/lib/tools.ts
+++ b/packages/pi-find/lib/tools.ts
@@ -63,8 +63,14 @@ export interface SearchDetails {
   readonly timedOut: boolean;
 }
 
+export function displayPath(path: string): string {
+  return /[\x00-\x1f\x7f\\"]/.test(path) ? JSON.stringify(path) : path;
+}
+
 export function renderGrepLines(outcome: GrepOutcome): string[] {
-  return outcome.matches.map((match) => `${match.path}:${match.lineNumber}: ${match.text}`);
+  return outcome.matches.map(
+    (match) => `${displayPath(match.path)}:${match.lineNumber}: ${match.text}`,
+  );
 }
 
 function countFiles(outcome: GrepOutcome): number {
@@ -215,7 +221,7 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
         };
       }
 
-      const body = boundedBody(outcome.files, "find");
+      const body = boundedBody(outcome.files.map(displayPath), "find");
       const count = outcome.files.length;
       const notices = [
         ...(outcome.truncated ? [resultLimitNotice("files", FIND_RESULT_LIMIT)] : []),
@@ -298,7 +304,12 @@ function renderSearchResult(
     );
   }
   if (details.resultCount === 0) {
-    return expandedResult(theme.fg("muted", "no results"), output, options.expanded, theme);
+    const summary = details.timedOut
+      ? theme.fg("warning", "search timed out (no results gathered)")
+      : details.truncated
+        ? theme.fg("warning", "no results shown (truncated)")
+        : theme.fg("muted", "no results");
+    return expandedResult(summary, output, options.expanded, theme);
   }
 
   const unit =

--- a/packages/pi-find/package.json
+++ b/packages/pi-find/package.json
@@ -42,7 +42,8 @@
     "test": "node --test --experimental-strip-types test/*.test.ts"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.101"
+    "effect": "4.0.0-beta.101",
+    "minimatch": "^10.2.6"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/packages/pi-find/src/runtime.ts
+++ b/packages/pi-find/src/runtime.ts
@@ -1,13 +1,16 @@
 /** Effect service backing the deliberately small grep and find tools. */
 
-import { existsSync, statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import * as nodePath from "node:path";
 import { Cause, Context, Effect, Exit, Layer, ManagedRuntime, Result } from "effect";
+import { Minimatch } from "minimatch";
 import {
   EMPTY_PATTERN_ERROR,
   FIND_RESULT_LIMIT,
   findPathNotDirectoryError,
   GREP_RESULT_LIMIT,
+  GIT_PATH_ERROR,
   missingSearchPathError,
 } from "../lib/prompt.ts";
 import { decodeRgEvent } from "../lib/rg-json.ts";
@@ -59,7 +62,8 @@ export class SearchRuntime extends Context.Service<SearchRuntime, SearchRuntimeS
 ) {}
 
 function normalizeResultPath(filePath: string): string {
-  const normalized = nodePath.normalize(filePath).replaceAll("\\", "/");
+  const native = nodePath.normalize(filePath);
+  const normalized = process.platform === "win32" ? native.replaceAll("\\", "/") : native;
   return normalized.replace(/^\.\//, "");
 }
 
@@ -73,13 +77,31 @@ function searchTarget(
   requestedPath: string | undefined,
   requireDirectory: boolean,
 ): { readonly argument: string; readonly root: string } | SearchInputError {
-  const argument = requestedPath ?? ".";
+  let argument = (requestedPath ?? ".").replace(/^@/, "");
+  if (argument === "~") argument = homedir();
+  else if (
+    argument.startsWith("~/") ||
+    (process.platform === "win32" && argument.startsWith("~\\"))
+  ) {
+    argument = nodePath.join(homedir(), argument.slice(2));
+  }
   const absolute = nodePath.resolve(cwd, argument);
   let isDirectory: boolean;
   try {
     isDirectory = statSync(absolute).isDirectory();
   } catch {
     return new SearchInputError({ message: missingSearchPathError(argument) });
+  }
+  // realpath catches symlink aliases to .git, but a component we lack
+  // permission to resolve must not read as "path does not exist".
+  let resolved = absolute;
+  try {
+    resolved = realpathSync(absolute);
+  } catch {
+    // keep the stat-verified path
+  }
+  if ([absolute, resolved].some((path) => normalizeResultPath(path).split("/").includes(".git"))) {
+    return new SearchInputError({ message: GIT_PATH_ERROR });
   }
   if (requireDirectory && !isDirectory) {
     return new SearchInputError({ message: findPathNotDirectoryError(argument) });
@@ -110,22 +132,62 @@ function isExplicitHiddenPath(searchPath: string | undefined): boolean {
 /** Files larger than this are skipped: giant blobs (caches, bundles, sourcemaps) are what turns a broad search into an overnight scan. Matches OMP's native grep ceiling. */
 const GREP_MAX_FILESIZE = "4M";
 
+/** Safe basename prefilter only; complex globs are left to Minimatch. */
+function basenamePrefilter(pattern: string | undefined): string {
+  const basename = pattern?.split("/").at(-1);
+  // Restrict the entire pattern: a brace/extglob alternative can contain slashes.
+  return pattern !== undefined && /^[a-zA-Z0-9_./*?-]+$/.test(pattern) && basename ? basename : "*";
+}
+
 export function buildRgArgs(request: GrepRequest, searchRoot: string): string[] {
-  const args = ["--json", "--line-number", "--color=never", "--max-filesize", GREP_MAX_FILESIZE];
+  const args = [
+    "--no-config",
+    "--case-sensitive",
+    "--json",
+    "--line-number",
+    "--color=never",
+    "--max-filesize",
+    GREP_MAX_FILESIZE,
+  ];
   if (!isInsideGitRepository(searchRoot)) args.push("--no-require-git");
-  if (request.glob !== undefined) {
-    args.push("--type-add", `pifind:${request.glob}`, "--type", "pifind");
-  }
+  const prefilter = basenamePrefilter(request.glob);
+  if (prefilter !== "*") args.push("--type-add", `pifind:${prefilter}`, "--type", "pifind");
   if (!isExplicitHiddenPath(request.path)) args.push("--glob", "!.*");
   args.push("--glob", "!.git/", "--regexp", request.pattern, "--", request.path ?? ".");
   return args;
 }
 
 export function buildFdArgs(request: FindRequest, searchRoot: string): string[] {
-  const args = ["--type", "f", "--glob", request.pattern, "--exclude", ".git"];
+  const args = [
+    "--type",
+    "f",
+    "--print0",
+    "--color=never",
+    "--case-sensitive",
+    "--glob",
+    "--exclude",
+    ".git",
+  ];
   if (!isInsideGitRepository(searchRoot)) args.push("--no-require-git");
-  args.push("--", request.path ?? ".");
+  args.push("--", basenamePrefilter(request.pattern), request.path ?? ".");
   return args;
+}
+
+/** Match slash globs relative to the search root, otherwise match basenames. */
+function pathMatcher(pattern: string | undefined, root: string, cwd: string) {
+  const matcher =
+    pattern === undefined
+      ? undefined
+      : new Minimatch(pattern, {
+          dot: true,
+          matchBase: !pattern.includes("/"),
+          nonegate: true,
+          nocomment: true,
+          nocase: false,
+        });
+  return (file: string): boolean =>
+    matcher === undefined ||
+    matcher.match(normalizeResultPath(nodePath.relative(root, nodePath.resolve(cwd, file))));
 }
 
 const makeSearchRuntime = Effect.gen(function* () {
@@ -140,16 +202,17 @@ const makeSearchRuntime = Effect.gen(function* () {
       const target = searchTarget(request.cwd, request.path, false);
       if (target instanceof SearchInputError) return Effect.fail(target);
 
+      const accepts = pathMatcher(request.glob, target.root, request.cwd);
       const matches: GrepMatch[] = [];
       let sawOverflow = false;
       return streamLines({
         binary: "rg",
-        args: buildRgArgs(request, target.root),
+        args: buildRgArgs({ ...request, path: target.argument }, target.root),
         cwd: request.cwd,
         signal: request.signal,
         onLine(line) {
           const event = decodeRgEvent(line);
-          if (event === undefined) return true;
+          if (event === undefined || !accepts(event.path)) return true;
           if (matches.length >= GREP_RESULT_LIMIT) {
             sawOverflow = true;
             return false;
@@ -181,16 +244,18 @@ const makeSearchRuntime = Effect.gen(function* () {
       const target = searchTarget(request.cwd, request.path, true);
       if (target instanceof SearchInputError) return Effect.fail(target);
 
+      const accepts = pathMatcher(request.pattern, target.root, request.cwd);
       const files: string[] = [];
       let sawOverflow = false;
       return streamLines({
         binary: "fd",
-        args: buildFdArgs(request, target.root),
+        args: buildFdArgs({ ...request, path: target.argument }, target.root),
+        delimiter: "\0",
         cwd: request.cwd,
         signal: request.signal,
         onLine(line) {
-          const file = line.endsWith("\r") ? line.slice(0, -1) : line;
-          if (file.length === 0) return true;
+          const file = line;
+          if (file.length === 0 || !accepts(file)) return true;
           if (files.length >= FIND_RESULT_LIMIT) {
             sawOverflow = true;
             return false;

--- a/packages/pi-find/src/stream.ts
+++ b/packages/pi-find/src/stream.ts
@@ -9,7 +9,6 @@
 
 import { spawn } from "node:child_process";
 import { statSync } from "node:fs";
-import { createInterface } from "node:readline";
 import { Effect } from "effect";
 import { SEARCH_TIMEOUT_MS } from "../lib/prompt.ts";
 import { missingBinaryMessage, resolveBinary, type SearchBinary } from "./binaries.ts";
@@ -24,6 +23,8 @@ export interface StreamRequest {
    * killed and the run settles successfully with what was gathered so far.
    */
   readonly onLine: (line: string) => boolean;
+  /** fd uses NUL records so newlines in filenames remain intact. */
+  readonly delimiter?: "\n" | "\0";
   readonly signal?: AbortSignal;
   /** Wall-clock budget; defaults to SEARCH_TIMEOUT_MS. Overridable for tests. */
   readonly timeoutMs?: number;
@@ -48,7 +49,7 @@ function isBenignExit(
   stoppedEarly: boolean,
   timedOut: boolean,
 ): boolean {
-  if (code === 0 || code === null) return true;
+  if (code === 0) return true;
   if (stoppedEarly || timedOut) return true;
   return binary === "rg" && code === 1;
 }
@@ -103,7 +104,8 @@ export function streamLines(
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    const reader = createInterface({ input: child.stdout });
+    const delimiter = request.delimiter ?? "\n";
+    let pending = "";
     let stderr = "";
     let stoppedEarly = false;
     let timedOut = false;
@@ -111,7 +113,7 @@ export function streamLines(
     let aborted = false;
 
     const cleanup = () => {
-      reader.close();
+      child.stdout.removeListener("data", onData);
       clearTimeout(timeoutId);
       outerSignal?.removeEventListener("abort", onAbort);
       effectSignal.removeEventListener("abort", onAbort);
@@ -137,7 +139,7 @@ export function streamLines(
 
     function onAbort() {
       aborted = true;
-      stopChild();
+      stopChild("SIGKILL");
     }
 
     // A search should finish in well under the budget; the timer only bounds a
@@ -154,17 +156,17 @@ export function streamLines(
     child.stderr?.on("data", (chunk: Buffer) => {
       // Bounded: a pathological glob can make rg complain per file, and the
       // message we surface only ever needs the first few lines.
-      if (stderr.length < 4096) stderr += chunk.toString("utf8");
+      if (stderr.length < 4096) stderr = (stderr + chunk.toString("utf8")).slice(0, 4096);
     });
 
-    reader.on("line", (line: string) => {
-      if (stoppedEarly || aborted) return;
+    function onLine(line: string) {
+      if (settled || stoppedEarly || aborted) return;
       let wantsMore: boolean;
       try {
         wantsMore = request.onLine(line);
       } catch (error) {
         stoppedEarly = true;
-        stopChild();
+        stopChild("SIGKILL");
         settle(
           new SearchProcessError({
             message: `Failed to read ${request.binary} output: ${
@@ -177,9 +179,25 @@ export function streamLines(
       }
       if (!wantsMore) {
         stoppedEarly = true;
-        stopChild();
+        stopChild("SIGKILL");
       }
-    });
+    }
+
+    function onData(chunk: string) {
+      if (settled || stoppedEarly || aborted) return;
+      pending += chunk;
+      let start = 0;
+      let end = pending.indexOf(delimiter, start);
+      while (end !== -1) {
+        onLine(pending.slice(start, end));
+        start = end + 1;
+        if (settled || stoppedEarly || aborted) break;
+        end = pending.indexOf(delimiter, start);
+      }
+      pending = settled || stoppedEarly || aborted ? "" : pending.slice(start);
+    }
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", onData);
 
     child.on("error", (error: Error) => {
       settle(
@@ -190,7 +208,12 @@ export function streamLines(
       );
     });
 
-    child.on("close", (code: number | null) => {
+    child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      // A killed producer's trailing fragment is garbage, not a record: rg's
+      // partial JSON is dropped by the decoder, but a truncated fd path would
+      // silently become a bogus result. Only flush on a natural exit.
+      if (!timedOut && pending.length > 0) onLine(pending);
+      pending = "";
       if (aborted) {
         settle(
           new SearchAbortedError({
@@ -206,7 +229,9 @@ export function streamLines(
             message:
               detail.length > 0
                 ? `${request.binary} failed: ${detail}`
-                : `${request.binary} exited with code ${code}`,
+                : signal !== null
+                  ? `${request.binary} terminated by ${signal}`
+                  : `${request.binary} exited with code ${code}`,
             tool: request.binary,
             exitCode: code ?? undefined,
           }),
@@ -218,7 +243,7 @@ export function streamLines(
 
     // Interruption path: kill the child so a cancelled turn leaves nothing behind.
     return Effect.sync(() => {
-      stopChild();
+      stopChild("SIGKILL");
       cleanup();
     });
   });

--- a/packages/pi-find/test/regressions.test.ts
+++ b/packages/pi-find/test/regressions.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { resolveBinary } from "../src/binaries.ts";
+import { createSearchRuntime, runSearch, SearchRuntime } from "../src/runtime.ts";
+import { streamLines } from "../src/stream.ts";
+import { displayPath } from "../lib/tools.ts";
+
+const hasBoth = resolveBinary("rg") !== null && resolveBinary("fd") !== null;
+
+async function fixture(
+  run: (root: string, runtime: ReturnType<typeof createSearchRuntime>) => Promise<void>,
+) {
+  const root = mkdtempSync(join(tmpdir(), "pi-find-regression-"));
+  const runtime = createSearchRuntime();
+  try {
+    mkdirSync(join(root, "src", "deep"), { recursive: true });
+    writeFileSync(join(root, "src", "a.ts"), "needle\n");
+    writeFileSync(join(root, "src", "deep", "b.ts"), "needle\n");
+    writeFileSync(join(root, "src", "ignored.ts"), "needle\n");
+    writeFileSync(join(root, ".gitignore"), "ignored.ts\n");
+    await run(root, runtime);
+  } finally {
+    await runtime.dispose();
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("slash globs are root-relative and do not override ignores", { skip: !hasBoth }, async () => {
+  await fixture(async (cwd, runtime) => {
+    const service = runtime.runSync(SearchRuntime);
+    for (const [path, pattern, expected] of [
+      [undefined, "src/*.ts", ["src/a.ts"]],
+      [undefined, "src/**/*.ts", ["src/a.ts", "src/deep/b.ts"]],
+      ["src", "deep/*.ts", ["src/deep/b.ts"]],
+      [undefined, "*.ts", ["src/a.ts", "src/deep/b.ts"]],
+      [undefined, "*.TS", []],
+      [undefined, "{src/a.ts,src/deep/b.ts}", ["src/a.ts", "src/deep/b.ts"]],
+    ] as const) {
+      const found = await runSearch(runtime, service.find({ cwd, path, pattern }));
+      const grepped = await runSearch(
+        runtime,
+        service.grep({ cwd, path, pattern: "needle", glob: pattern }),
+      );
+      assert.deepEqual([...found.files].sort(), expected);
+      assert.deepEqual(grepped.matches.map((match) => match.path).sort(), expected);
+    }
+  });
+});
+
+test("option-like patterns are data, not fd flags", { skip: !hasBoth }, async () => {
+  await fixture(async (cwd, runtime) => {
+    writeFileSync(join(cwd, "--version"), "needle\n");
+    const service = runtime.runSync(SearchRuntime);
+    const found = await runSearch(runtime, service.find({ cwd, pattern: "--version" }));
+    assert.deepEqual(found.files, ["--version"]);
+  });
+});
+
+test("ripgrep ignores user configuration", { skip: !hasBoth }, async () => {
+  await fixture(async (cwd, runtime) => {
+    const config = join(cwd, "rg.conf");
+    writeFileSync(config, "--ignore-case\n--no-ignore\n");
+    const previous = process.env.RIPGREP_CONFIG_PATH;
+    process.env.RIPGREP_CONFIG_PATH = config;
+    try {
+      const service = runtime.runSync(SearchRuntime);
+      assert.deepEqual(
+        (await runSearch(runtime, service.grep({ cwd, pattern: "NEEDLE" }))).matches,
+        [],
+      );
+      const matches = (
+        await runSearch(runtime, service.grep({ cwd, pattern: "needle", glob: "src/*.ts" }))
+      ).matches;
+      assert.deepEqual(
+        matches.map((match) => match.path),
+        ["src/a.ts"],
+      );
+    } finally {
+      if (previous === undefined) delete process.env.RIPGREP_CONFIG_PATH;
+      else process.env.RIPGREP_CONFIG_PATH = previous;
+    }
+  });
+});
+
+test("special filenames survive search and display round trips", {
+  skip: !hasBoth || process.platform === "win32",
+}, async () => {
+  await fixture(async (cwd, runtime) => {
+    const names = ["line\nbreak.ts", "literal\\name.ts", "return\r.ts", "引數.ts"];
+    mkdirSync(join(cwd, "special"));
+    for (const name of names) writeFileSync(join(cwd, "special", name), "needle\n");
+    const service = runtime.runSync(SearchRuntime);
+    const found = await runSearch(runtime, service.find({ cwd, path: "special", pattern: "*.ts" }));
+    const grepped = await runSearch(
+      runtime,
+      service.grep({ cwd, path: "special", pattern: "needle" }),
+    );
+    const expected = names.map((name) => `special/${name}`).sort();
+    assert.deepEqual([...found.files].sort(), expected);
+    assert.deepEqual(grepped.matches.map((match) => match.path).sort(), expected);
+    for (const file of found.files) {
+      const displayed = displayPath(file);
+      assert.equal(displayed.includes("\n"), false);
+      assert.equal(displayed.startsWith('"') ? JSON.parse(displayed) : displayed, file);
+    }
+  });
+});
+
+test("normalizes @ and home paths; rejects explicit .git roots and aliases", {
+  skip: !hasBoth,
+}, async () => {
+  await fixture(async (cwd, runtime) => {
+    const service = runtime.runSync(SearchRuntime);
+    for (const path of ["@src", `~/${relative(homedir(), join(cwd, "src"))}`]) {
+      assert.equal(
+        (await runSearch(runtime, service.find({ cwd, path, pattern: "a.ts" }))).files.length,
+        1,
+      );
+      assert.equal(
+        (await runSearch(runtime, service.grep({ cwd, path, pattern: "needle", glob: "a.ts" })))
+          .matches.length,
+        1,
+      );
+    }
+    mkdirSync(join(cwd, ".git"));
+    writeFileSync(join(cwd, ".git", "config"), "needle\n");
+    const paths = [".git"];
+    if (process.platform !== "win32") {
+      symlinkSync(join(cwd, ".git"), join(cwd, "git-alias"));
+      paths.push("git-alias");
+    }
+    for (const path of paths) {
+      await assert.rejects(
+        runSearch(runtime, service.find({ cwd, path, pattern: "*" })),
+        /inside .git are excluded/,
+      );
+      await assert.rejects(
+        runSearch(runtime, service.grep({ cwd, path, pattern: "needle" })),
+        /inside .git are excluded/,
+      );
+    }
+    await assert.rejects(
+      runSearch(runtime, service.grep({ cwd, path: ".git/config", pattern: "needle" })),
+      /inside .git are excluded/,
+    );
+    if (process.platform !== "win32") {
+      rmSync(join(cwd, ".git"), { recursive: true });
+      symlinkSync(join(cwd, "src"), join(cwd, ".git"));
+      await assert.rejects(
+        runSearch(runtime, service.find({ cwd, path: ".git", pattern: "*" })),
+        /inside .git are excluded/,
+      );
+    }
+  });
+});
+
+test("unexpected signal termination is an error", {
+  skip: !hasBoth || process.platform === "win32",
+}, async () => {
+  await fixture(async (cwd, runtime) => {
+    const pre = join(cwd, "pre");
+    writeFileSync(pre, '#!/bin/sh\nkill -KILL "$PPID"\n');
+    chmodSync(pre, 0o755);
+    await assert.rejects(
+      runSearch(
+        runtime,
+        streamLines({
+          binary: "rg",
+          cwd,
+          args: ["--no-config", "--pre", pre, "needle", "src/a.ts"],
+          onLine: () => true,
+        }),
+      ),
+      /terminated by SIGKILL/,
+    );
+  });
+});
+
+test("active search cancellation returns promptly", {
+  skip: !hasBoth || process.platform === "win32",
+  timeout: 3000,
+}, async () => {
+  await fixture(async (cwd, runtime) => {
+    const fifo = join(cwd, "pipe");
+    assert.equal(spawnSync("mkfifo", [fifo]).status, 0);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 100);
+    try {
+      await assert.rejects(
+        runSearch(
+          runtime,
+          streamLines({
+            binary: "rg",
+            cwd,
+            args: ["--no-config", "needle", fifo],
+            onLine: () => true,
+            signal: controller.signal,
+          }),
+          { signal: controller.signal },
+        ),
+        (error: Error) => error.name === "AbortError",
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+});

--- a/packages/pi-find/test/rg-json.test.ts
+++ b/packages/pi-find/test/rg-json.test.ts
@@ -48,6 +48,8 @@ test("ignores blank and malformed lines", () => {
   assert.equal(decodeRgEvent("   "), undefined);
   assert.equal(decodeRgEvent("not json"), undefined);
   assert.equal(decodeRgEvent("{"), undefined);
+  assert.equal(decodeRgEvent("null"), undefined);
+  assert.equal(decodeRgEvent(matchEvent({ path: null })), undefined);
 });
 
 test("ignores events missing a line number or path", () => {

--- a/packages/pi-find/test/search.test.ts
+++ b/packages/pi-find/test/search.test.ts
@@ -245,6 +245,7 @@ test("searches are abortable", { skip: !hasRg }, async () => {
 test("engine arguments contain only the fixed simple behavior", () => {
   const rg = buildRgArgs({ pattern: "needle", path: "src", glob: "*.ts", cwd: root }, root);
   assert.ok(rg.includes("--regexp"));
+  // Simple basename prefilters avoid scanning unrelated file contents.
   assert.ok(rg.includes("--type-add"));
   assert.ok(rg.includes("pifind:*.ts"));
   assert.ok(rg.includes("--max-filesize"));
@@ -258,5 +259,8 @@ test("engine arguments contain only the fixed simple behavior", () => {
   const fd = buildFdArgs({ pattern: "*.ts", path: "src", cwd: root }, root);
   assert.ok(fd.includes("--glob"));
   assert.ok(fd.includes("*.ts"));
+  assert.ok(fd.includes("--print0"));
+  assert.ok(rg.includes("--no-config"));
+  assert.ok(rg.includes("--case-sensitive"));
   assert.ok(!fd.includes("--hidden"));
 });

--- a/packages/pi-find/test/tool-integration.test.ts
+++ b/packages/pi-find/test/tool-integration.test.ts
@@ -111,6 +111,39 @@ test("empty searches return short model-visible answers", {
   }
 });
 
+test("empty timeout results retain a warning even when collapsed", async () => {
+  const { runtime, tools } = captureTools();
+  try {
+    for (const kind of ["grep", "find"] as const) {
+      const result = {
+        content: [{ type: "text" as const, text: "Search timed out; results are partial." }],
+        details: {
+          kind,
+          query: "*",
+          resultCount: 0,
+          fileCount: 0,
+          truncated: false,
+          timedOut: true,
+        },
+      };
+      for (const expanded of [false, true]) {
+        const component = tools.get(kind)!.renderResult!(
+          result,
+          { expanded, isPartial: false },
+          theme,
+          { isError: false },
+        );
+        assert.match(component.render(80).join("\n"), /timed out/);
+        for (const width of [1, 12, 42]) {
+          for (const line of component.render(width)) assert.ok(visibleWidth(line) <= width);
+        }
+      }
+    }
+  } finally {
+    await runtime.dispose();
+  }
+});
+
 test("custom renderers remain width-safe", () => {
   const { runtime, tools } = captureTools();
   try {

--- a/packages/pi-find/test/tools.test.ts
+++ b/packages/pi-find/test/tools.test.ts
@@ -60,10 +60,13 @@ test("model-facing metadata stays concise and describes the fixed semantics", ()
     ...Object.values(GREP_PARAMETER_DESCRIPTIONS),
     ...Object.values(FIND_PARAMETER_DESCRIPTIONS),
   ]) {
-    assert.ok(value.length <= 90, `metadata is too long: ${value}`);
+    assert.ok(value.length <= 400, `metadata is too long: ${value}`);
   }
   assert.match(GREP_TOOL_DESCRIPTION, /case-sensitive regex/);
   assert.match(FIND_TOOL_DESCRIPTION, /glob/);
+  assert.match(GREP_TOOL_DESCRIPTION, /4 MiB/);
+  assert.match(GREP_TOOL_DESCRIPTION, /100 matching lines/);
+  assert.match(FIND_TOOL_DESCRIPTION, /200 files/);
 });
 
 test("fixed limit notices tell the caller to narrow the search", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.101
         version: 4.0.0-beta.101
+      minimatch:
+        specifier: ^10.2.6
+        version: 10.2.6
       typebox:
         specifier: '*'
         version: 1.3.14


### PR DESCRIPTION
## Summary

Correctness hardening for `pi-find`'s grep/find tools, driven by end-to-end regression tests against real `rg`/`fd`.

### Glob semantics
- **Root-relative slash globs**: `src/*.ts` now matches direct children of `src`; `src/**/*.ts` matches descendants; basename globs (`*.ts`) still match at any depth. Implemented as a `minimatch` post-filter on results, so glob filtering can never re-include gitignored files (previously the raw glob went straight to the engines, where it could also smuggle negations past the built-in excludes).
- Simple basename patterns are still pushed down to `rg`/`fd` as prefilters (restricted charset; braces/extglob fall back to `*` + full post-filter) to avoid scanning unrelated file contents.

### Engine isolation
- `rg --no-config --case-sensitive`: user `RIPGREP_CONFIG_PATH` can no longer flip case sensitivity or ignore rules; `fd --case-sensitive` for the same reason.

### Filenames and paths
- `fd --print0` + NUL-delimited streaming: newlines in filenames no longer split find results.
- Result paths containing control characters, backslashes, or quotes are JSON-quoted in model-facing output (`decode before read/edit` documented in the tool description).
- `normalizeResultPath` no longer rewrites literal backslashes on POSIX (was corrupting filenames like `literal\name.ts`).
- Leading `@` is stripped; `~`/`~/...` expand to the home directory.
- Explicit `.git` roots, files inside them, and symlink aliases (checked via realpath, with a fallback when realpath fails on permissions) are rejected with a clear input error.

### Process robustness
- Unexpected signal termination (e.g. SIGKILL) is now a `SearchProcessError`, not a silently-completed empty search (`code === null` is no longer blindly benign; rg exit 1 for "no matches" still is).
- Timeout/stop-early/abort paths SIGKILL the child; stderr accumulation is actually bounded (`slice(0, 4096)` after append).
- Trailing output is flushed only on natural exit — a timeout-killed `fd` can no longer surface a partially-written record as a real file.
- Empty timed-out searches keep their warning in both the model text and the TUI renderer (verified width-safe at 1/12/42/80 columns).

### Review fixes included
Two issues found during self-review are fixed here: the partial-record flush above, and the `realpathSync` failure that used to misreport an existing path as missing.

## Test plan

- [x] `pnpm test` — full monorepo green; pi-find 42/42 including 7 new end-to-end regression tests (`test/regressions.test.ts`) covering slash globs, option-like patterns, rg config isolation, special-filename round trips, `@`/`~`/`.git` handling, signal termination, and active cancellation
- [x] `pnpm run typecheck`
- [x] `pnpm run check`
- [x] `biome check packages/pi-find/` clean
- [x] Manually verified: `**` basename prefilter works with both engines; rg `--max-filesize` skips a 5 MB file in traversal but searches it when explicitly named (matches the README claim)
- [x] Changeset added (`patch`)

🤖 Generated with [pi](https://pi.dev)
