### PR TITLE
fix(pi-antigravity): recycle driver after backgrounded turns, replay deferred results

### DIFF
--- a/.changeset/agy-driver-background-task-recycle.md
+++ b/.changeset/agy-driver-background-task-recycle.md
@@ -1,0 +1,9 @@
+---
+"@tian.zuo/pi-antigravity": patch
+---
+
+Preserve terminal results across incomplete-tool replay so Pi does not automatically resubmit the original command after a background-task timeout. Track emitted text across replay messages to avoid repeating the terminal response, emitting only a missing suffix and preserving streamed text on divergence.
+
+Defensively recycle persistent agy processes when terminal results leave tools ACTIVE, including failed results, while retaining the conversation ID for subsequent user turns. Quarantine the driver immediately, allow its process group 500 ms to handle SIGTERM, then force cleanup of surviving processes before releasing queued turns. Keep cleanup tracked during shutdown. Unfinished commands may be cancelled; bridge handoff and incomplete-tool messages now explain this and recommend refreshing /agy-tasks before retrying, without promising that one-shot tasks stopped.
+
+Improve empty-stderr diagnostics with model/conversation context and recovery options without assuming a cause.

--- a/packages/pi-antigravity/README.md
+++ b/packages/pi-antigravity/README.md
@@ -81,6 +81,14 @@ Pi's current system instructions (including project guidance and extension addit
 | `AGY_TOOL_STALL_TIMEOUT_MS=300000`       | Stall budget while a tool step is ACTIVE — a quiet foreground tool is legitimate, so silence inside a tool gets a longer leash.              |
 | `AGY_STALL_RETRY_BACKOFF_MS=3000`        | Pause before each stall retry. Stalls retry at most twice, rendered as a collapsed "agy stream stalled … restarting the turn" thinking line. |
 
+## Terms of Service & account safety
+
+This extension never talks to Google's servers itself. Authentication, tokens, and all API access stay inside the official first-party `agy` CLI; this extension only drives its supported stream-json/`--print` interface and renders the output inside pi. OAuth credentials never leave the official client.
+
+This matters because Google's [Antigravity Terms of Service](https://antigravity.google/terms) explicitly prohibit accessing the service through third-party software, and the [official FAQ](https://antigravity.google/docs/faq) names third-party coding agents as grounds for suspension — Google's recommended path for third-party agents is a Vertex AI or AI Studio API key. In February 2026 Google ran automated 403 suspension sweeps against accounts (including paid subscribers) whose credentials were used by reverse-engineered clients hitting the private `cloudcode-pa.googleapis.com` API.
+
+In practice: extensions that reimplement Antigravity's private API with extracted OAuth client IDs put your Google account at real risk of permanent suspension. This extension avoids that class of violation by design, though driving the official CLI programmatically is automation Google has not explicitly licensed.
+
 ## Development
 
 Reference: [Pi-cursor-sdk](https://github.com/fitchmultz/pi-cursor-sdk)

--- a/packages/pi-antigravity/lib/agy-driver.ts
+++ b/packages/pi-antigravity/lib/agy-driver.ts
@@ -27,6 +27,7 @@ export type AgyRecycleCause =
   | "session-tree"
   | "restore"
   | "reset"
+  | "background-task"
   | "unspecified";
 
 export interface AgyProcessConfigSnapshot {
@@ -164,6 +165,7 @@ export class AgyDriverSession implements AgyTurnExecutor {
   #recycleReasons = new Map<AgyRecycleCause, number>();
   #lastRecycleReason: AgyRecycleCause | undefined;
   #shutdown = false;
+  #recycling: Promise<void> = Promise.resolve();
 
   snapshot(): AgyExecutorSnapshot {
     return {
@@ -205,6 +207,7 @@ export class AgyDriverSession implements AgyTurnExecutor {
 
   async close(reason: AgyExecutorCloseReason, cause?: AgyRecycleCause): Promise<void> {
     if (reason === "shutdown") this.#shutdown = true;
+    await this.#recycling;
     const child = this.#child;
     if (!child) {
       this.#state = reason === "shutdown" ? "dead" : "idle";
@@ -550,9 +553,16 @@ export class AgyDriverSession implements AgyTurnExecutor {
     const turn = this.#active;
     if (turn) {
       const tail = this.#stderrTail.trim().split("\n").slice(-3).join("\n");
+      // Only append canned recovery hints when agy left no diagnostics of
+      // its own — a real stderr tail beats boilerplate.
+      const hint = tail
+        ? `: ${tail}`
+        : ` (no stderr${this.#config?.model ? ` model=${this.#config.model}` : ""}${
+            this.#boundConversationId ? ` conv=${this.#boundConversationId.slice(0, 8)}` : ""
+          }). The cause is unknown. Try /agy reset before retrying, or set PI_ANTIGRAVITY_DRIVER=0 for one-shot mode. Check for commands still running before retrying; use pi's own bash for long-lived commands.`;
       this.#settleTurn(turn, {
         error: new AgySpawnError(
-          `agy exited with code ${code ?? signal ?? "signal"} before producing a result${tail ? `: ${tail}` : ""}`,
+          `agy exited with code ${code ?? signal ?? "signal"} before producing a result${hint}`,
           this.#stderrTail,
         ),
       });
@@ -565,9 +575,46 @@ export class AgyDriverSession implements AgyTurnExecutor {
     if (turn.stallTimer) clearTimeout(turn.stallTimer);
     if (turn.abortHandler) turn.request.signal?.removeEventListener("abort", turn.abortHandler);
     this.#active = undefined;
-    if (this.#child) this.#state = "ready";
+    const child = this.#child;
+    // Both successful and failed terminal results can leave ACTIVE tools.
+    // Quarantine this process immediately, but let outstanding commands handle
+    // SIGTERM before forcing group cleanup. Resolving only afterwards keeps
+    // queued turns from spawning a replacement while cleanup is in progress.
+    if (child && !("error" in result) && turn.activeTools.size > 0) {
+      this.#log(`recycle:background-task:${turn.activeTools.size}`);
+      this.#recordRecycle("background-task");
+      this.#recycling = this.#recycleIncompleteChild(child);
+      void this.#recycling.then(() => turn.resolve(result.outcome), turn.reject);
+      return;
+    }
+    if (child) this.#state = "ready";
     if ("error" in result) turn.reject(result.error);
     else turn.resolve(result.outcome);
+  }
+
+  async #recycleIncompleteChild(child: DriverChild): Promise<void> {
+    this.#detachChild(child, "stopping");
+    // Detached from reuse/event handling, but still owned by the death hooks.
+    trackAgyChild(child);
+    this.#log("background-task:SIGTERM");
+    signalAgyTree(child, "SIGTERM");
+    // A closed driver/stdio does not prove its descendants exited. Give the
+    // whole group a bounded grace period, then reap any survivors even if the
+    // leader has already gone. Windows escalates via taskkill /T here.
+    await new Promise<void>((resolve) => setTimeout(resolve, TERM_CLOSE_MS));
+    await new Promise<void>((resolve) => {
+      const finish = () => {
+        clearTimeout(timer);
+        child.off("close", finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, TERM_CLOSE_MS);
+      child.once("close", finish);
+      killAgyTree(child);
+      if (child.exitCode !== null || child.signalCode !== null) finish();
+    });
+    this.#log("background-task:cleanup-complete");
+    this.#state = this.#shutdown ? "dead" : "idle";
   }
 
   #detachChild(child: DriverChild, nextState: AgyDriverState): void {

--- a/packages/pi-antigravity/lib/prompt.ts
+++ b/packages/pi-antigravity/lib/prompt.ts
@@ -15,6 +15,27 @@
  */
 export const WRAPPER_TOOL_NAME = "antigravity";
 export const WRAPPER_TOOL_DESCRIPTION = "";
+export const BRIDGE_PENDING_TOOL_MESSAGE =
+  "Started and still running at tool handoff. Unfinished commands may be cancelled when " +
+  "the agy turn ends. Refresh /agy-tasks to check current process status and partial output.";
+
+/** Replay diagnostics must not promise that an unobserved task survived or stopped. */
+export function agyIncompleteToolError(tool: string, resultError?: string): string {
+  if (
+    tool === "run_command" &&
+    (!resultError || /timeout waiting for response/i.test(resultError))
+  ) {
+    return (
+      "agy did not report this command completing. It may have become a background task " +
+      '(headless agy can report "timeout waiting for response"). Its current process state ' +
+      "is unknown: persistent-driver cleanup cancels unfinished work with SIGTERM, then " +
+      "force-kills surviving processes after a short grace period, while " +
+      "one-shot mode may leave it running. Check /agy-tasks and verify whether the command " +
+      "is still running before retrying; use pi's own bash for long-lived commands."
+    );
+  }
+  return "agy tool call did not complete.";
+}
 
 export function omittedImagesPrompt(images: number): string {
   return `(${images} image(s) omitted — the agy print interface is text-only)`;

--- a/packages/pi-antigravity/lib/turn.ts
+++ b/packages/pi-antigravity/lib/turn.ts
@@ -22,6 +22,7 @@ export class AgyTurnController {
   #incompleteTools = new Map<string, Extract<AgyActivity, { type: "tool_start" }>>();
   #reportedUsage: AgyUsage;
   #thoughtReported = false;
+  #emittedText = "";
 
   constructor(prompt: string, conversationUsage: AgyUsage = {}) {
     this.prompt = prompt;
@@ -61,6 +62,25 @@ export class AgyTurnController {
     const tools = [...this.#incompleteTools.values()];
     this.#incompleteTools.clear();
     return tools;
+  }
+
+  /** Keep the terminal result pending while Pi executes incomplete-tool replay.
+   * Unlike push(), this also works after the executor has closed the turn.
+   */
+  deferResult(result: Extract<AgyActivity, { type: "result" }>): void {
+    this.#queue.unshift(result);
+  }
+
+  /** Track rendered deltas across Pi messages, including closed text blocks. */
+  recordEmittedText(delta: string): void {
+    this.#emittedText += delta;
+  }
+
+  /** The terminal response normally concatenates the turn's streamed deltas.
+   * On divergence, preserve already-rendered text rather than repeat/replace it.
+   */
+  remainingResponseText(response: string): string {
+    return response.startsWith(this.#emittedText) ? response.slice(this.#emittedText.length) : "";
   }
 
   /** Show at most one synthetic thought summary per logical agy turn. */

--- a/packages/pi-antigravity/src/provider.ts
+++ b/packages/pi-antigravity/src/provider.ts
@@ -34,7 +34,13 @@ import type { AgyActivity, AgyUsage } from "../lib/reducer.ts";
 import type { AgyReplayStore } from "../lib/replay.ts";
 import { mapAgyToolToNative } from "../lib/native-tools.ts";
 import { agyToolStepKey } from "../lib/tool-steps.ts";
-import { omittedImagesPrompt, restoredPiContextPrompt, WRAPPER_TOOL_NAME } from "../lib/prompt.ts";
+import {
+  agyIncompleteToolError,
+  BRIDGE_PENDING_TOOL_MESSAGE,
+  omittedImagesPrompt,
+  restoredPiContextPrompt,
+  WRAPPER_TOOL_NAME,
+} from "../lib/prompt.ts";
 import {
   AntigravityRuntime,
   createAntigravityRuntime,
@@ -177,27 +183,6 @@ const OVERFLOW_PATTERN = /context (length|window|size).*(exceed|limit)|exceeds.*
  * failure so truncated or empty answers never pass silently.
  */
 const RECOVERED_INTERRUPTION_PATTERN = /stream was interrupted/i;
-
-/**
- * Error recorded for an agy tool call that never reached DONE. agy runs
- * long-lived commands as background tasks (its own manage_task system); in
- * headless print mode the step never completes and the turn ends with
- * "timeout waiting for response" while the spawned process keeps running.
- */
-export function agyIncompleteToolError(tool: string, resultError?: string): string {
-  if (
-    tool === "run_command" &&
-    (!resultError || /timeout waiting for response/i.test(resultError))
-  ) {
-    return (
-      "agy started this command as a background task, which headless agy cannot await " +
-      "(\u201ctimeout waiting for response\u201d). The process keeps running after the turn \u2014 " +
-      "follow up in a later message to have agy check the task\u2019s output, or run " +
-      "long-lived processes with pi\u2019s own bash instead."
-    );
-  }
-  return "agy tool call did not complete.";
-}
 
 /** Map an explicit pi thinking level to agy's `--effort` (low|medium|high). */
 export function mapThinkingToEffort(level: ThinkingLevel | undefined): AgyEffort | undefined {
@@ -564,7 +549,7 @@ export function streamAntigravity(
             const tool = pending.toolCall.arguments.tool;
             replay.record(pending.id, {
               agyTool: tool,
-              output: "Started and still running. Track live status and output with /agy-tasks.",
+              output: BRIDGE_PENDING_TOOL_MESSAGE,
             });
             stream.push({
               type: "toolcall_end",
@@ -666,6 +651,13 @@ export function streamAntigravity(
           const activity = await controller.next();
           if (activity === null) {
             if (emitIncompleteTools() > 0) {
+              controller.deferResult({
+                type: "result",
+                status: "ERROR",
+                response: "",
+                error: "agy turn ended without a result event.",
+                usage: undefined,
+              });
               endWithToolUse();
               return;
             }
@@ -752,6 +744,7 @@ export function streamAntigravity(
                 textBuffer = "";
                 stream.push({ type: "text_start", contentIndex: textIndex, partial: output });
               }
+              controller.recordEmittedText(activity.delta);
               textBuffer += activity.delta;
               const block = output.content[textIndex];
               if (block.type === "text") block.text = textBuffer;
@@ -765,6 +758,7 @@ export function streamAntigravity(
             }
             case "result": {
               if (emitIncompleteTools(activity.error) > 0) {
+                controller.deferResult(activity);
                 endWithToolUse();
                 return;
               }
@@ -778,54 +772,41 @@ export function streamAntigravity(
               if (usage) attachUsage(usage, false);
               else attachUsage(activity.usage, true);
 
-              if (activity.response) {
+              // Account for text rendered in earlier Pi messages and blocks,
+              // not just this closure's textBuffer (which tool boundaries clear).
+              const suffix = controller.remainingResponseText(activity.response);
+              if (suffix) {
+                controller.recordEmittedText(suffix);
                 if (textIndex !== null) {
-                  // Deltas already streamed this block. agy's authoritative
-                  // response is normally the concatenation of those deltas, so
-                  // drift means a dropped tail: emit the missing suffix as a
-                  // real delta, keeping delta-only consumers in sync with
-                  // `partial` rather than silently rewriting the block.
-                  if (textBuffer !== activity.response) {
-                    const block = output.content[textIndex];
-                    if (activity.response.startsWith(textBuffer)) {
-                      const suffix = activity.response.slice(textBuffer.length);
-                      if (block.type === "text") block.text = activity.response;
-                      textBuffer = activity.response;
-                      stream.push({
-                        type: "text_delta",
-                        contentIndex: textIndex,
-                        delta: suffix,
-                        partial: output,
-                      });
-                    } else {
-                      // True divergence (never observed): streamed text cannot
-                      // be retracted through deltas, so keep what consumers
-                      // already saw and let text_end confirm it.
-                      if (block.type === "text") block.text = textBuffer;
-                    }
-                  }
-                  closeText();
+                  textBuffer += suffix;
+                  const block = output.content[textIndex];
+                  if (block.type === "text") block.text = textBuffer;
+                  stream.push({
+                    type: "text_delta",
+                    contentIndex: textIndex,
+                    delta: suffix,
+                    partial: output,
+                  });
                 } else {
                   closeUnfilledThought();
-                  output.content.push({ type: "text", text: activity.response });
+                  output.content.push({ type: "text", text: suffix });
                   const idx = output.content.length - 1;
                   stream.push({ type: "text_start", contentIndex: idx, partial: output });
                   stream.push({
                     type: "text_delta",
                     contentIndex: idx,
-                    delta: activity.response,
+                    delta: suffix,
                     partial: output,
                   });
                   stream.push({
                     type: "text_end",
                     contentIndex: idx,
-                    content: activity.response,
+                    content: suffix,
                     partial: output,
                   });
                 }
-              } else {
-                closeText();
               }
+              closeText();
 
               const hasResponse =
                 Boolean(activity.response?.trim()) ||

--- a/packages/pi-antigravity/test/agy-client.test.ts
+++ b/packages/pi-antigravity/test/agy-client.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { test } from "node:test";
 import { AgyStallError, buildAgyArgs, runAgyTurn } from "../lib/agy-client.ts";
 import { getAgyChildrenRegistry, killAllAgyTrees } from "../lib/agy-children.ts";
-import { agyIncompleteToolError } from "../src/provider.ts";
+import { agyIncompleteToolError } from "../lib/prompt.ts";
 import { CONVERSATION_ID, OK_CAPTURE, REAL_CAPTURE } from "./fixtures.ts";
 
 type FakeChild = {

--- a/packages/pi-antigravity/test/agy-driver.test.ts
+++ b/packages/pi-antigravity/test/agy-driver.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { EventEmitter, getEventListeners } from "node:events";
 import { PassThrough } from "node:stream";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -13,6 +13,7 @@ import {
   type AgyTurnRequest,
 } from "../lib/agy-client.ts";
 import { AgyDriverSession, AgyOneShotExecutor } from "../lib/agy-driver.ts";
+import { getAgyChildrenRegistry } from "../lib/agy-children.ts";
 
 async function driverFixture(): Promise<{ dir: string; script: string }> {
   const dir = await mkdtemp(path.join(tmpdir(), "agy-driver-"));
@@ -21,11 +22,13 @@ async function driverFixture(): Promise<{ dir: string; script: string }> {
     script,
     `#!/usr/bin/env node
 import readline from "node:readline";
+import { writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 const args = process.argv.slice(2);
 let turns = 0;
 const conversation = "driver-conversation";
 const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
-rl.on("line", (line) => {
+rl.on("line", async (line) => {
   const event = JSON.parse(line);
   turns += 1;
   console.log(JSON.stringify({ event: "init", conversation_id: conversation, init: {} }));
@@ -45,6 +48,62 @@ rl.on("line", (line) => {
   }
   if (event.message.content === "silent") return;
   if (event.message.content === "exit-before-result") process.exit(7);
+  // Backgrounded long command: the tool step goes ACTIVE and the result still
+  // arrives, so the step never reaches DONE/ERROR (issue #43 state).
+  const activeToolStep = JSON.stringify({
+    event: "step_update",
+    step_update: {
+      conversation_id: conversation,
+      step_index: turns,
+      state: "ACTIVE",
+      step_type: "tool",
+      tool_name: "run_command",
+      tool_info: { name: "run_command", parameters: { CommandLine: "sleep 60" } }
+    }
+  });
+  if (event.message.content === "background") console.log(activeToolStep);
+  if (["background-graceful", "background-stubborn"].includes(event.message.content)) {
+    const worker = spawn(process.execPath, ["--input-type=module", "-e", [
+      'import { writeFileSync } from "node:fs";',
+      'process.on("SIGTERM", () => { writeFileSync("worker-term", "yes");',
+      event.message.content === "background-graceful"
+        ? 'setTimeout(() => { writeFileSync("worker-cleanup", "yes"); process.exit(0); }, 25);'
+        : '',
+      '}); process.send("ready"); setInterval(() => {}, 1000);'
+    ].join("\\n")], { stdio: ["ignore", "ignore", "ignore", "ipc"] });
+    await new Promise(resolve => worker.once("message", resolve));
+    process.on("SIGTERM", () => {
+      writeFileSync("term-received", "yes");
+      if (event.message.content === "background-graceful") {
+        setTimeout(() => {
+          writeFileSync("cleanup-finished", "yes");
+          process.exit(0);
+        }, 75);
+      }
+    });
+    console.log(activeToolStep);
+  }
+  if (event.message.content === "completed-tool") {
+    console.log(activeToolStep);
+    const done = JSON.parse(activeToolStep);
+    done.step_update.state = "DONE";
+    console.log(JSON.stringify(done));
+  }
+  if (event.message.content === "background-error") {
+    console.log(activeToolStep);
+    console.log(JSON.stringify({
+      event: "result",
+      conversation_id: conversation,
+      result: {
+        status: "FAILURE",
+        response: "",
+        error: "timeout waiting for response",
+        conversation_id: conversation,
+        num_turns: turns
+      }
+    }));
+    return;
+  }
   console.log(JSON.stringify({
     event: "result",
     conversation_id: conversation,
@@ -376,6 +435,208 @@ test("persistent driver identifies every process reuse mismatch", async () => {
   }
 });
 
+for (const mode of ["graceful", "stubborn"] as const) {
+  test(`background recycle gives ${mode} processes a grace period before the next spawn`, {
+    skip: process.platform === "win32" ? "POSIX signals" : false,
+  }, async () => {
+    const fixture = await driverFixture();
+    const executor = new AgyDriverSession();
+    const children: ReturnType<typeof spawn>[] = [];
+    const spawnOverride = ((
+      _binary: string,
+      args: readonly string[],
+      options: Parameters<typeof spawn>[2],
+    ) => {
+      if (children.length) {
+        assert.ok(
+          children[0].exitCode !== null || children[0].signalCode !== null,
+          "the previous leader must exit before its replacement spawns",
+        );
+      }
+      const child = spawn(process.execPath, [fixture.script, ...args], options);
+      children.push(child);
+      return child;
+    }) as typeof spawn;
+    const request = {
+      binary: fixture.script,
+      cwd: fixture.dir,
+      spawnOverride,
+      inactivityTimeoutMs: 5_000,
+    };
+    try {
+      const first = executor.run({ ...request, prompt: `background-${mode}` });
+      const second = executor.run({
+        ...request,
+        prompt: "second",
+        conversationId: "driver-conversation",
+      });
+      const [outcome] = await Promise.all([first, second]);
+      assert.equal(outcome.status, "OK");
+      assert.equal(await readFile(path.join(fixture.dir, "term-received"), "utf8"), "yes");
+      assert.equal(await readFile(path.join(fixture.dir, "worker-term"), "utf8"), "yes");
+      if (mode === "graceful") {
+        assert.equal(await readFile(path.join(fixture.dir, "worker-cleanup"), "utf8"), "yes");
+        assert.equal(await readFile(path.join(fixture.dir, "cleanup-finished"), "utf8"), "yes");
+        assert.equal(children[0].exitCode, 0);
+      } else {
+        assert.equal(children[0].signalCode, "SIGKILL");
+      }
+      assert.equal(executor.snapshot().stats?.spawnCount, 2);
+      assert.equal(executor.snapshot().stats?.recycleCount, 1);
+    } finally {
+      await executor.close("shutdown");
+      await rm(fixture.dir, { recursive: true, force: true });
+    }
+  });
+}
+
+test("shutdown waits for quarantined background cleanup and retains death-hook ownership", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  let pid: number | undefined;
+  let receivedResult!: () => void;
+  const resultSeen = new Promise<void>((resolve) => {
+    receivedResult = resolve;
+  });
+  try {
+    const pending = executor.run({
+      binary: fixture.script,
+      cwd: fixture.dir,
+      prompt: "background",
+      inactivityTimeoutMs: 5_000,
+      spawnOverride: fixtureSpawn(fixture.script),
+      onActivity: (activity) => {
+        if (activity.type === "result") {
+          pid = executor.snapshot().pid;
+          receivedResult();
+        }
+      },
+    });
+    await resultSeen;
+    assert.equal(executor.snapshot().state, "stopping");
+    assert.equal(executor.snapshot().pid, undefined, "quarantined child cannot be reused");
+    assert.ok(pid);
+    assert.ok(getAgyChildrenRegistry().live.has(pid));
+    await executor.close("shutdown");
+    assert.equal((await pending).status, "OK");
+    assert.equal(executor.snapshot().state, "dead");
+    assert.equal(getAgyChildrenRegistry().live.has(pid), false);
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver reuses a process after all tool steps complete", async () => {
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  const request = {
+    binary: fixture.script,
+    cwd: fixture.dir,
+    inactivityTimeoutMs: 5_000,
+    spawnOverride: fixtureSpawn(fixture.script),
+  };
+  try {
+    const first = await executor.run({ ...request, prompt: "completed-tool" });
+    assert.equal(executor.snapshot().state, "ready");
+    const second = await executor.run({
+      ...request,
+      prompt: "second",
+      conversationId: first.conversationId,
+    });
+    assert.equal(JSON.parse(first.response).pid, JSON.parse(second.response).pid);
+    assert.equal(executor.snapshot().stats?.recycleCount, 0);
+    assert.equal(executor.snapshot().stats?.reusedTurns, 1);
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver recycles after a turn that backgrounds a tool step", async () => {
+  // Issue #43: a turn that ends while a run_command step is still ACTIVE
+  // backgrounded a long command; reusing that agy process makes the very
+  // next turn exit code 1 with empty stderr. The driver must spawn fresh
+  // instead, resuming the same conversation by id.
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  const spawnOverride = fixtureSpawn(fixture.script);
+  try {
+    const first = await executor.run({
+      prompt: "background",
+      binary: fixture.script,
+      cwd: fixture.dir,
+      inactivityTimeoutMs: 5_000,
+      spawnOverride,
+    });
+    assert.equal(first.status, "OK");
+    const firstResponse = JSON.parse(first.response) as { pid: number };
+    assert.equal(executor.snapshot().state, "idle", "no live child between turns");
+
+    const second = await executor.run({
+      prompt: "second",
+      conversationId: first.conversationId,
+      binary: fixture.script,
+      cwd: fixture.dir,
+      inactivityTimeoutMs: 5_000,
+      spawnOverride,
+    });
+    const secondResponse = JSON.parse(second.response) as { pid: number; args: string[] };
+    assert.notEqual(secondResponse.pid, firstResponse.pid);
+    assert.equal(
+      secondResponse.args[secondResponse.args.indexOf("--conversation") + 1],
+      first.conversationId,
+    );
+    const snapshot = executor.snapshot();
+    assert.equal(snapshot.stats?.spawnCount, 2);
+    assert.equal(snapshot.stats?.recycleCount, 1);
+    assert.equal(snapshot.stats?.lastRecycleReason, "background-task");
+    assert.deepEqual(snapshot.stats?.recycleReasons, { "background-task": 1 });
+    assert.ok(snapshot.lifecycle.some((entry) => entry.includes("recycle:background-task:")));
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("persistent driver recycles after an ERROR result with a still-ACTIVE tool", async () => {
+  // Regression for issue #43: the observed poisoning arrives as a FAILURE
+  // result ("timeout waiting for response") while run_command stays ACTIVE,
+  // so the recycle must key on the ACTIVE residue, not on result status.
+  const fixture = await driverFixture();
+  const executor = new AgyDriverSession();
+  const spawnOverride = fixtureSpawn(fixture.script);
+  try {
+    const first = await executor.run({
+      prompt: "background-error",
+      binary: fixture.script,
+      cwd: fixture.dir,
+      inactivityTimeoutMs: 5_000,
+      spawnOverride,
+    });
+    assert.equal(first.status, "ERROR");
+    assert.match(first.error ?? "", /timeout waiting for response/);
+    assert.equal(executor.snapshot().state, "idle", "no live child between turns");
+
+    const second = await executor.run({
+      prompt: "second",
+      conversationId: first.conversationId,
+      binary: fixture.script,
+      cwd: fixture.dir,
+      inactivityTimeoutMs: 5_000,
+      spawnOverride,
+    });
+    assert.equal(second.status, "OK");
+    const stats = executor.snapshot().stats;
+    assert.equal(stats?.spawnCount, 2);
+    assert.equal(stats?.recycleCount, 1);
+    assert.equal(stats?.lastRecycleReason, "background-task");
+  } finally {
+    await executor.close("shutdown");
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
 test("persistent driver kills a silent active process with AgyStallError", async () => {
   const fixture = await driverFixture();
   const executor = new AgyDriverSession();
@@ -520,7 +781,9 @@ test("persistent driver reports a child close before its terminal result", async
         }),
       (error: unknown) =>
         error instanceof AgySpawnError &&
-        /exited with code 7 before producing a result/.test(error.message),
+        /exited with code 7 before producing a result/.test(error.message) &&
+        /no stderr/.test(error.message) &&
+        /PI_ANTIGRAVITY_DRIVER=0/.test(error.message),
     );
   } finally {
     await executor.close("shutdown");

--- a/packages/pi-antigravity/test/provider.test.ts
+++ b/packages/pi-antigravity/test/provider.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
-  agyIncompleteToolError,
   isSummarizationRequest,
   latestUserPrompt,
   mapThinkingToEffort,
@@ -10,6 +9,9 @@ import {
   streamAntigravity,
 } from "../src/provider.ts";
 import { AgyTurnController } from "../lib/turn.ts";
+import { agyIncompleteToolError } from "../lib/prompt.ts";
+import { newTurnOutcome } from "../lib/reducer.ts";
+import { AntigravityRuntime, createAntigravityRuntime } from "../src/runtime.ts";
 import { AgyReplayStore } from "../lib/replay.ts";
 import { AgyPiBridge } from "../lib/bridge.ts";
 import { assertDeltasMatchPartial } from "./delta-replay.ts";
@@ -218,7 +220,9 @@ test("mapThinkingToEffort maps pi thinking levels to agy effort", () => {
 test("agyIncompleteToolError explains agy background tasks for run_command", () => {
   const bg = agyIncompleteToolError("run_command", "timeout waiting for response");
   assert.match(bg, /background task/);
-  assert.match(bg, /keeps running/);
+  assert.match(bg, /process state is unknown/);
+  assert.match(bg, /one-shot mode may leave it running/);
+  assert.doesNotMatch(bg, /task is stopped|keeps running/);
 
   // Unknown stream end for run_command still gets the background hint.
   assert.match(agyIncompleteToolError("run_command"), /background task/);
@@ -233,6 +237,86 @@ test("agyIncompleteToolError explains agy background tasks for run_command", () 
     "agy tool call did not complete.",
   );
 });
+
+for (const status of ["OK", "ERROR", "missing-result"] as const) {
+  test(`incomplete tool replay preserves ${status} completion without resubmitting the prompt`, async () => {
+    const requests: string[] = [];
+    const runtime = createAntigravityRuntime({
+      async run(request) {
+        requests.push(request.prompt);
+        request.onConversation?.("background-conversation");
+        request.onActivity?.({
+          type: "tool_start",
+          stepId: 1,
+          name: "run_command",
+          args: { CommandLine: "sleep 60" },
+        });
+        if (status !== "missing-result") {
+          request.onActivity?.({
+            type: "result",
+            status,
+            response: status === "OK" ? "Command started." : "",
+            error: status === "ERROR" ? "timeout waiting for response" : undefined,
+            usage: undefined,
+          });
+        }
+        return {
+          ...newTurnOutcome(),
+          conversationId: "background-conversation",
+          status: status === "OK" ? "OK" : "ERROR",
+          finished: status !== "missing-result",
+        };
+      },
+      snapshot: () => ({ mode: "persistent", state: "idle", lifecycle: [] }),
+      async close() {},
+    });
+    const service = runtime.runSync(AntigravityRuntime);
+    const replay = new AgyReplayStore();
+    const streamFn = streamAntigravity(runtime, service, replay, new AgyPiBridge("test-reentry"));
+    const model = {
+      id: "test-model",
+      name: "Test",
+      provider: "antigravity",
+      api: "antigravity-stream-json",
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    } as Model<string>;
+    const context = contextWith([{ role: "user", content: "Run the long command" }]);
+    try {
+      const first = await streamFn(model, context).result();
+      assert.equal(first.stopReason, "toolUse");
+      const tool = first.content.find((block) => block.type === "toolCall");
+      assert.ok(tool);
+      context.messages.push(first, {
+        role: "toolResult",
+        toolCallId: tool.id,
+        toolName: tool.name,
+        content: [{ type: "text", text: "Command completion unknown." }],
+        isError: true,
+        timestamp: Date.now(),
+      });
+      // Exercise re-entry after the executor has closed, not just while running.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const second = await streamFn(model, context).result();
+      assert.equal(requests.length, 1, "tool replay must not start another agy turn");
+      assert.equal(second.stopReason, status === "OK" ? "stop" : "error");
+      if (status !== "OK") {
+        assert.match(
+          second.errorMessage ?? "",
+          status === "ERROR" ? /timeout waiting for response/ : /without a result event/,
+        );
+      } else {
+        assert.ok(
+          second.content.some(
+            (block) => block.type === "text" && block.text === "Command started.",
+          ),
+        );
+      }
+    } finally {
+      await runtime.runPromise(service.close);
+      await runtime.dispose();
+    }
+  });
+}
 
 /** Harness for stream-level tests: a turn controller behind a fake runtime. */
 function makeStreamHarness(
@@ -302,6 +386,42 @@ function makeStreamHarness(
     getSharedBeginCount: () => sharedBeginCount,
     getRequest: () => request,
   };
+}
+
+for (const { before, after, response, expected } of [
+  { before: "Started.", after: "", response: "Started.", expected: "" },
+  { before: "Started", after: "", response: "Started at :3000.", expected: " at :3000." },
+  { before: "", after: "", response: "Started.", expected: "Started." },
+  { before: "Started.", after: "", response: "Different final text.", expected: "" },
+  { before: "Started", after: " at :3000", response: "Started at :3000.", expected: "." },
+]) {
+  test(`deferred response emits only unseen text: ${JSON.stringify({ before, after, response })}`, async () => {
+    const h = makeStreamHarness();
+    if (before) h.controller.push({ type: "text", delta: before });
+    h.controller.push({ type: "tool_start", stepId: 1, name: "run_command", args: {} });
+    if (after) h.controller.push({ type: "text", delta: after });
+    h.controller.push({
+      type: "result",
+      status: "OK",
+      response,
+      error: undefined,
+      usage: undefined,
+    });
+    h.controller.close();
+    const first = await h.collect();
+    assert.equal(first.at(-1).reason, "toolUse");
+    assertDeltasMatchPartial(first);
+    const second = await h.collect();
+    assert.equal(second.at(-1).reason, "stop");
+    assertDeltasMatchPartial(second);
+    const text = (events: any[]) =>
+      events
+        .filter((event) => event.type === "text_delta")
+        .map((event) => event.delta)
+        .join("");
+    assert.equal(text(first), before + after);
+    assert.equal(text(second), expected);
+  });
 }
 
 test("streamAntigravity refreshes bridge state and passes effort, profile, and revision before begin", async () => {


### PR DESCRIPTION
# Summary

Fixes #43 — the persistent stream-json driver (`AgyDriverSession`) exits code 1 with empty stderr on the turn immediately after a turn that backgrounded a long-lived `run_command` (agy's `timeout waiting for response` path), with pi's auto-retry resubmitting the same prompt into the wedged process.

## Root cause

- A turn settles while a `run_command` step is still ACTIVE; `#settleTurn` marked the child `ready` for reuse.
- The next turn on that reused process dies instantly (`agy exited with code 1 before producing a result`, no stderr tail).
- The incomplete-tool wrapper made pi re-invoke the provider, which resubmitted the same prompt into the poisoned process.

## Changes

**Recycle background-poisoned processes** (`lib/agy-driver.ts`)
- When any terminal result (OK or ERROR) leaves tool steps ACTIVE, quarantine the process immediately (new `background-task` recycle cause) instead of marking it ready.
- Cleanup gives outstanding commands a graceful exit: SIGTERM to the process group, a bounded grace period, then a force-reap of survivors — while remaining owned by the death hooks so a pi crash mid-grace still cleans up. The next spawn waits for cleanup to finish; the conversation id is retained for resume.

**Replay deferred results instead of resubmitting** (`src/provider.ts`, `lib/turn.ts`)
- When incomplete tools end a message with `toolUse`, the terminal result is deferred on the turn controller; re-entry after the wrapper replays the recorded outcome (OK / ERROR / missing-result) without starting another agy turn — no duplicate command execution.
- Emitted text deltas are tracked across messages, so the replayed/terminal response emits only unseen text (also fixes latent response duplication on multi-message turns).

**Diagnostics & prompts** (`lib/prompt.ts`)
- Empty-stderr spawn errors now include model/conversation context and recovery options instead of a bare message.
- `agyIncompleteToolError` moved to `lib/prompt.ts` (prompt separation) and reworded: incomplete commands have unknown process state; describes the actual SIGTERM → grace → force-kill cleanup and one-shot behavior.

## Testing

- Driver: reuse after fully-completed tool steps (no over-recycling); recycle after ACTIVE residue on both OK and FAILURE results; graceful vs stubborn process groups during the grace window; shutdown waits for quarantined cleanup and retains death-hook ownership.
- Provider: incomplete-tool replay preserves OK/ERROR/missing-result outcomes without resubmitting; deferred responses emit only unseen text across five before/after/response combinations.
- `pnpm run typecheck`, `pnpm run check`, and the package test suite (254 tests) pass.
