### PR TITLE
refactor(pi-find): move search caveats from prompts into results

### DIFF
--- a/.changeset/short-find-prompts.md
+++ b/.changeset/short-find-prompts.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-find": patch
+---
+
+Simplify grep/find descriptions to search semantics and hidden-path defaults. Keep limits and timeout guidance in results, show JSON path decoding guidance only for quoted paths, and mention the traversal file-size cap only on empty grep results without timeout or truncation notices.

--- a/packages/pi-find/lib/prompt.ts
+++ b/packages/pi-find/lib/prompt.ts
@@ -7,24 +7,26 @@ export const FIND_RESULT_LIMIT = 200;
 export const SEARCH_TIMEOUT_MS = 30_000;
 
 export const GREP_TOOL_DESCRIPTION =
-  "Search file contents with a case-sensitive regex; respects .gitignore. Skips hidden paths by default and files over 4 MiB during traversal. Up to 100 matching lines, clipped at 400 characters; bounded output; 30s timeout. Ripgrep config is ignored. Special paths are JSON-quoted; decode before read/edit.";
+  "Search file contents with a case-sensitive regex; respects .gitignore; skips hidden paths by default.";
 export const GREP_PROMPT_SNIPPET = "Search file contents with a regex";
 
 export const GREP_PARAMETER_DESCRIPTIONS = {
   pattern: "Case-sensitive ripgrep regex.",
-  path: "File or directory to search; default is the current directory.",
-  glob: "Case-sensitive glob: basename ('*.ts') or search-root-relative path ('src/*.ts').",
+  path: "Search file or directory; defaults to cwd.",
+  glob: "Case-sensitive glob: basename ('*.ts') or search-root-relative ('src/*.ts').",
 };
 
 export const FIND_TOOL_DESCRIPTION =
-  "Find files with a case-sensitive glob; respects .gitignore. Skips hidden paths by default. Up to 200 files; bounded output; 30s timeout. Paths containing special characters are JSON-quoted; decode them before passing to read/edit.";
+  "Find files with a case-sensitive glob; respects .gitignore; skips hidden paths by default.";
 export const FIND_PROMPT_SNIPPET = "Find files with a glob";
 
 export const FIND_PARAMETER_DESCRIPTIONS = {
-  pattern: "Case-sensitive glob: basename ('*.ts') or search-root-relative path ('src/*.ts').",
-  path: "Directory to search; default is the current directory.",
+  pattern: "Case-sensitive glob: basename ('*.ts') or search-root-relative ('src/*.ts').",
+  path: "Search directory; defaults to cwd.",
 };
 
+export const QUOTED_PATH_NOTICE = "[JSON-decode quoted paths before read/edit.]";
+export const FILE_SIZE_LIMIT_NOTICE = "[Files >4 MiB are skipped during traversal.]";
 export const NO_GREP_MATCHES = "No matches found.";
 export const NO_FILES_FOUND = "No files found.";
 export const EMPTY_PATTERN_ERROR = "Search pattern cannot be empty.";

--- a/packages/pi-find/lib/tools.ts
+++ b/packages/pi-find/lib/tools.ts
@@ -9,6 +9,7 @@ import {
 import { Text } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
 import {
+  FILE_SIZE_LIMIT_NOTICE,
   FIND_PARAMETER_DESCRIPTIONS,
   FIND_PROMPT_SNIPPET,
   FIND_RESULT_LIMIT,
@@ -22,6 +23,7 @@ import {
   NO_FILES_FOUND,
   NO_GREP_MATCHES,
   outputLimitNotice,
+  QUOTED_PATH_NOTICE,
   resultLimitNotice,
   SEARCH_TIMEOUT_MS,
   searchTimeoutNotice,
@@ -107,6 +109,15 @@ function boundedBody(lines: readonly string[], kind: "grep" | "find"): BoundedBo
   };
 }
 
+/** Join a header, an optional body, and notices with exactly one blank line between sections. */
+export function resultText(header: string, body: string, notices: readonly string[]): string {
+  return [
+    header,
+    ...(body.length === 0 ? [] : ["", body]),
+    ...notices.flatMap((notice) => ["", notice]),
+  ].join("\n");
+}
+
 export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance): void {
   pi.registerTool({
     name: "grep",
@@ -131,6 +142,9 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
 
       const matchCount = outcome.matches.length;
       const notices = [
+        ...(outcome.matches.some((match) => displayPath(match.path) !== match.path)
+          ? [QUOTED_PATH_NOTICE]
+          : []),
         ...(outcome.truncated ? [resultLimitNotice("matches", GREP_RESULT_LIMIT)] : []),
         ...(outcome.timedOut ? [searchTimeoutNotice(SEARCH_TIMEOUT_MS)] : []),
       ];
@@ -138,7 +152,12 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
       // notice travels even when nothing was gathered.
       if (matchCount === 0 && notices.length === 0) {
         return {
-          content: [{ type: "text" as const, text: NO_GREP_MATCHES }],
+          content: [
+            {
+              type: "text" as const,
+              text: resultText(NO_GREP_MATCHES, "", [FILE_SIZE_LIMIT_NOTICE]),
+            },
+          ],
           details: {
             kind: "grep",
             query: params.pattern,
@@ -152,12 +171,11 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
 
       const body = boundedBody(renderGrepLines(outcome), "grep");
       const fileCount = countFiles(outcome);
-      const text = [
+      const text = resultText(
         matchCount === 0 ? NO_GREP_MATCHES : grepResultHeader(matchCount, fileCount),
-        "",
         body.text,
-        ...notices.flatMap((notice) => ["", notice]),
-      ].join("\n");
+        notices,
+      );
 
       return {
         content: [{ type: "text" as const, text }],
@@ -224,15 +242,15 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
       const body = boundedBody(outcome.files.map(displayPath), "find");
       const count = outcome.files.length;
       const notices = [
+        ...(outcome.files.some((path) => displayPath(path) !== path) ? [QUOTED_PATH_NOTICE] : []),
         ...(outcome.truncated ? [resultLimitNotice("files", FIND_RESULT_LIMIT)] : []),
         ...(outcome.timedOut ? [searchTimeoutNotice(SEARCH_TIMEOUT_MS)] : []),
       ];
-      const text = [
+      const text = resultText(
         count === 0 && !outcome.timedOut ? NO_FILES_FOUND : findResultHeader(count),
-        "",
         body.text,
-        ...notices.flatMap((notice) => ["", notice]),
-      ].join("\n");
+        notices,
+      );
 
       return {
         content: [{ type: "text" as const, text }],

--- a/packages/pi-find/test/tool-integration.test.ts
+++ b/packages/pi-find/test/tool-integration.test.ts
@@ -99,12 +99,39 @@ test("empty searches return short model-visible answers", {
     const grep = await tools
       .get("grep")!
       .execute("grep", { pattern: "missing" }, undefined, undefined, { cwd: root });
-    assert.equal(text(grep), "No matches found.");
+    assert.equal(text(grep), "No matches found.\n\n[Files >4 MiB are skipped during traversal.]");
 
     const find = await tools
       .get("find")!
       .execute("find", { pattern: "*.ts" }, undefined, undefined, { cwd: root });
     assert.equal(text(find), "No files found.");
+  } finally {
+    await runtime.dispose();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("path decoding guidance appears only for quoted paths", {
+  skip: !hasRg || !hasFd || process.platform === "win32",
+}, async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "pi-find-quoted-"));
+  const { runtime, tools } = captureTools();
+  try {
+    for (const filename of ["plain.txt", 'quoted".txt']) {
+      writeFileSync(path.join(root, filename), "needle\n");
+      for (const kind of ["grep", "find"]) {
+        const result = await tools
+          .get(kind)!
+          .execute(kind, { pattern: kind === "grep" ? "needle" : "*.txt" }, undefined, undefined, {
+            cwd: root,
+          });
+        assert.equal(
+          text(result).includes("JSON-decode quoted paths before read/edit"),
+          filename !== "plain.txt",
+        );
+      }
+      rmSync(path.join(root, filename));
+    }
   } finally {
     await runtime.dispose();
     rmSync(root, { recursive: true, force: true });

--- a/packages/pi-find/test/tools.test.ts
+++ b/packages/pi-find/test/tools.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { FindParams, GrepParams, renderGrepLines } from "../lib/tools.ts";
+import { FindParams, GrepParams, renderGrepLines, resultText } from "../lib/tools.ts";
 import {
   FIND_PARAMETER_DESCRIPTIONS,
   FIND_PROMPT_SNIPPET,
@@ -60,13 +60,27 @@ test("model-facing metadata stays concise and describes the fixed semantics", ()
     ...Object.values(GREP_PARAMETER_DESCRIPTIONS),
     ...Object.values(FIND_PARAMETER_DESCRIPTIONS),
   ]) {
-    assert.ok(value.length <= 400, `metadata is too long: ${value}`);
+    assert.ok(value.length <= 120, `metadata is too long: ${value}`);
   }
   assert.match(GREP_TOOL_DESCRIPTION, /case-sensitive regex/);
   assert.match(FIND_TOOL_DESCRIPTION, /glob/);
-  assert.match(GREP_TOOL_DESCRIPTION, /4 MiB/);
-  assert.match(GREP_TOOL_DESCRIPTION, /100 matching lines/);
-  assert.match(FIND_TOOL_DESCRIPTION, /200 files/);
+  for (const description of [GREP_TOOL_DESCRIPTION, FIND_TOOL_DESCRIPTION]) {
+    assert.match(description, /respects \.gitignore/);
+    assert.match(description, /skips hidden paths by default/);
+    assert.doesNotMatch(description, /MiB|matching lines|timeout|JSON|config|\d/);
+  }
+});
+
+test("result text keeps one blank line between sections", () => {
+  assert.equal(
+    resultText("No matches found.", "", [searchTimeoutNotice(30_000)]),
+    "No matches found.\n\n[Search timed out after 30s; results are partial. Narrow the path, pattern, or glob.]",
+  );
+  assert.equal(
+    resultText("1 match in 1 file", "a.ts:1: needle", []),
+    "1 match in 1 file\n\na.ts:1: needle",
+  );
+  assert.equal(resultText("0 files", "", []), "0 files");
 });
 
 test("fixed limit notices tell the caller to narrow the search", () => {


### PR DESCRIPTION
## Summary

Moves `pi-find`'s situational caveats out of the always-on tool descriptions and into the tool results, where they only appear when they actually apply. The descriptions keep only the stable search semantics.

### Prompt changes
- `grep` / `find` descriptions shrink to case sensitivity, `.gitignore`, and hidden-path defaults (304/230 → 101/90 chars, ~86 tokens saved per request before caching).
- Limits, timeout, and byte-cap guidance stay in the result notices that were already emitted when those conditions occur.
- `[JSON-decode quoted paths before read/edit.]` is appended only when a returned path is actually JSON-quoted, so the guidance sits next to the data it applies to.
- `[Files >4 MiB are skipped during traversal.]` is appended only to a clean empty grep result — not to timed-out or truncated ones, where it is not the explanation.
- `resultText()` joins header, body, and notices with exactly one blank line, so empty-body results no longer leave a gap.

### Test changes
- Metadata guard tightened from 400 → 120 chars; it now asserts the retained semantics (`respects .gitignore`, `skips hidden paths by default`) instead of the removed limits.
- New integration test: quoted-path guidance appears for `quoted".txt` and not for `plain.txt`, for both `grep` and `find` (skipped on Windows, where `"` is not a valid filename character).
- New unit test for `resultText` covering header-only, header + body, and header + notices shapes.

## Test plan

- [x] `pnpm test` — full monorepo green (pi-find 44/44)
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run check`
- [x] Changeset added (`patch`)

🤖 Generated with [pi](https://pi.dev)
