### PR TITLE
feat(pi-antigravity): add /agy-subagents, flatten /agy subcommands to /agy-*

### DIFF
--- a/.changeset/tidy-owls-march.md
+++ b/.changeset/tidy-owls-march.md
@@ -1,0 +1,7 @@
+---
+"@tian.zuo/pi-antigravity": minor
+---
+
+Add `/agy-subagents`: a zero-token roster of agy subagent activity folded from the stream (invoke_subagent/run_subagent/define_subagent/browser_subagent spawns, send_message counts, manage_subagents kills), reset together with the conversation. agy has no read-only subcommand for live subagent state — `/subagents` in print mode burns a model turn — so the extension tracks the tool steps itself.
+
+Flatten the `/agy` subcommands into top-level commands: `/agy reset|models|agents|doctor` are now `/agy-reset`, `/agy-models`, `/agy-agents`, `/agy-doctor` (consistent with `/agy-tasks`, `/agy-artifacts`, `/agy-usage`). Bare `/agy` still shows status and points at the new names when given arguments.

--- a/packages/pi-antigravity/README.md
+++ b/packages/pi-antigravity/README.md
@@ -5,7 +5,7 @@ Use **Google Antigravity** (`agy`) models inside the [pi coding agent](https://p
 ## Highlights
 
 - **Persistent stream driver** — ordinary user turns reuse one healthy `agy` process; conversation, model, workspace, agent, mode, and bridge changes recycle it safely.
-- **Actionable diagnostics** — `/agy doctor` explains executable selection, checks every candidate and the minimum version, and reports models, driver spawn/recycle counters, bridge revision, conversation database, and display metadata without spending model tokens.
+- **Actionable diagnostics** — `/agy-doctor` explains executable selection, checks every candidate and the minimum version, and reports models, driver spawn/recycle counters, bridge revision, conversation database, and display metadata without spending model tokens.
 - **Native rendering, not mimicry** — agy's read-only tools (`view_file`, `grep_search`, `find_by_name`, `list_dir`) are re-executed as real pi builtins (`read` / `grep` / `find` / `ls`), so their cards use pi's own renderers and show live, accurate output. Everything else renders through one display-only `antigravity` wrapper.
 - **Skills & MCP bridge** — your global pi Agent Skills are one `pi__p<pid>__activate_skill` tool (pass `{ name }` from the tool's enum), and pi's MCP servers (via the `pi-mcp-adapter` tools) are reachable from agy with pi's permissions, hooks, and rendering. Per-session tool names keep concurrent pi sessions fully isolated.
 - **Background-task manager** — long-running agy commands are tracked in a dashboard and stoppable with one keystroke (`/agy-tasks`).
@@ -46,7 +46,7 @@ Claude and GPT models
 
 ## Context and permissions
 
-The first agy turn receives the active Pi conversation history, including earlier work with another provider. `/agy reset` deliberately starts fresh without replaying that history; it does not delete the Pi transcript. A later provider switch or branch move can restore the active history again.
+The first agy turn receives the active Pi conversation history, including earlier work with another provider. `/agy-reset` deliberately starts fresh without replaying that history; it does not delete the Pi transcript. A later provider switch or branch move can restore the active history again.
 
 Pi's current system instructions (including project guidance and extension additions) are relayed on the first native turn, after a native conversation restore, and when they change. Unchanged instructions are not repeated on each turn or tool-loop re-entry; removing them sends an explicit clearing notice. Unacknowledged instruction and skill-catalog updates are retained across stall retries. Disposable summaries receive their own instructions without changing the live conversation.
 
@@ -59,10 +59,11 @@ Pi's current system instructions (including project guidance and extension addit
 | Command          | What it does                                                                                                    |
 | ---------------- | --------------------------------------------------------------------------------------------------------------- |
 | `/agy`           | Conversation title/status (id, model, turns, process, native context)                                           |
-| `/agy reset`     | Drop the agy conversation and driver; next turn starts fresh                                                    |
-| `/agy models`    | Re-discover models and re-register the provider                                                                 |
-| `/agy agents`    | List configured custom agy agents without inference                                                             |
-| `/agy doctor`    | Diagnose all binary candidates/selection, models, driver spawn/recycle counters, bridge, and conversation state |
+| `/agy-reset`     | Drop the agy conversation and driver; next turn starts fresh                                                    |
+| `/agy-models`    | Re-discover models and re-register the provider                                                                 |
+| `/agy-agents`    | List configured custom agy agents without inference                                                             |
+| `/agy-doctor`    | Diagnose all binary candidates/selection, models, driver spawn/recycle counters, bridge, and conversation state |
+| `/agy-subagents` | List live subagent activity observed on the agy stream (spawns, messages, kills) — no model tokens             |
 | `/agy-tasks`     | Background-task dashboard (`stop <task-id> \| all` for scripts)                                                 |
 | `/agy-artifacts` | Artifact browser (`open <name>` for scripts)                                                                    |
 | `/agy-usage`     | Model quotas (weekly and 5-hour remaining per group)                                                            |

--- a/packages/pi-antigravity/index.ts
+++ b/packages/pi-antigravity/index.ts
@@ -6,10 +6,11 @@
 //
 // Commands:
 //   /agy            show agy conversation and persistent-driver status
-//   /agy reset      drop the current agy conversation (next turn starts fresh)
-//   /agy models     re-discover models from `agy models` and re-register
-//   /agy agents     list configured custom agents
-//   /agy doctor     diagnose binary, models, driver, bridge, and local state
+//   /agy-reset      drop the current agy conversation (next turn starts fresh)
+//   /agy-models     re-discover models from `agy models` and re-register
+//   /agy-agents     list configured custom agents
+//   /agy-doctor     diagnose binary, models, driver, bridge, and local state
+//   /agy-subagents  list subagent activity observed on the agy stream
 //   /agy-usage      show Antigravity model quotas (weekly and 5-hour limits)
 
 import type {
@@ -71,6 +72,7 @@ import {
 import { readAgyConversationMetadata } from "./lib/conversation-metadata.ts";
 import { AgyReplayStore, type RecordedAgyTool } from "./lib/replay.ts";
 import { findAgyTask, listAgyTasks, stopAgyTask } from "./lib/tasks.ts";
+import { formatAgySubagents, trackAgySubagent, type AgySubagentEntry } from "./lib/subagents.ts";
 import { findAgyArtifact, listAgyArtifacts } from "./lib/artifacts.ts";
 import { fetchAgyUsage } from "./lib/usage.ts";
 import { WRAPPER_TOOL_DESCRIPTION, WRAPPER_TOOL_NAME } from "./lib/prompt.ts";
@@ -245,6 +247,10 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
   let currentCache = getInitialModelCache();
   let observedContextTokens: number | undefined;
   let persistedConversationKey: string | undefined;
+  // Live subagent roster, folded from stream activities since the last
+  // conversation reset/restore. In-memory only: agy's own conversation
+  // database remains the durable record.
+  const subagentRoster = new Map<string, AgySubagentEntry>();
   let selectedModelKey: string | undefined;
 
   pi.registerEntryRenderer(AGY_COMPACTION_ENTRY, (entry, _options, theme) => {
@@ -548,8 +554,10 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
     if (activity.type === "conversation_fallback") {
       observedContextTokens = undefined;
       persistedConversationKey = undefined;
+      subagentRoster.clear();
       return;
     }
+    trackAgySubagent(subagentRoster, activity);
     if (activity.type === "usage") {
       const nextContextTokens = agyContextTokens(activity.usage);
       const compaction = detectAgyCompaction(observedContextTokens, nextContextTokens);
@@ -850,153 +858,11 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
   });
 
   pi.registerCommand("agy", {
-    description: "Manage the agy backend: status | reset | models | agents | doctor",
+    description: "Show agy conversation and persistent-driver status",
     handler: async (args, ctx) => {
-      const sub = args.trim().toLowerCase();
-      if (sub === "reset") {
-        await runAntigravity(runtime, service.reset);
-        appendConversationReset(ctx);
-        ctx.ui.notify("antigravity: conversation reset; next turn starts fresh.", "info");
-        return;
-      }
-      if (sub === "models") {
-        const refreshed = await discoverModels(true);
-        currentCache = refreshed;
-        registerAntigravityProvider(refreshed.models);
+      if (args.trim()) {
         ctx.ui.notify(
-          `antigravity: ${refreshed.models.length} models registered (${refreshed.source}).`,
-          "info",
-        );
-        return;
-      }
-      if (sub === "agents") {
-        try {
-          const agents = parseAgyAgents(await execAgy(["agents"]));
-          ctx.ui.notify(
-            agents.length > 0
-              ? `antigravity custom agents:\n${agents.map((agent) => `• ${agent}`).join("\n")}`
-              : "antigravity: no custom agents configured.",
-            "info",
-          );
-        } catch (error) {
-          ctx.ui.notify(
-            `antigravity: failed to list agents (${error instanceof Error ? error.message : String(error)}).`,
-            "error",
-          );
-        }
-        return;
-      }
-      if (sub === "doctor") {
-        const lines = ["antigravity doctor"];
-        const binary = await checkAgyBinary({ refresh: true });
-        if (binary.ok) {
-          lines.push(
-            `binary: ${binary.binary} (${binary.version}, ${binary.source})`,
-            `binary selection: ${binary.selectionReason ?? "compatible candidate"}`,
-            `minimum: ${MIN_AGY_VERSION}`,
-          );
-        } else {
-          lines.push(
-            `binary: ERROR [${binary.category}] ${binary.message}`,
-            `minimum: ${MIN_AGY_VERSION}`,
-          );
-        }
-        for (const candidate of binary.candidates ?? []) {
-          const selected =
-            binary.ok && candidate.binary === binary.binary ? "selected" : "candidate";
-          lines.push(
-            `binary ${selected}: ${candidate.source} ${candidate.binary} · ${
-              candidate.ok
-                ? candidate.development
-                  ? (candidate.version ?? "development")
-                  : (candidate.version ?? "unknown")
-                : `ERROR [${candidate.category ?? "unknown"}]`
-            }`,
-          );
-        }
-
-        try {
-          const discovered = parseAgyModels((await runAgyCommand(["models"])).stdout);
-          if (discovered.length === 0) throw new Error("no valid model rows returned");
-          currentCache = { fetchedAt: Date.now(), source: "live", models: discovered };
-          registerAntigravityProvider(discovered);
-          lines.push(`models: ${discovered.length} (live)`);
-        } catch (error) {
-          lines.push(
-            `models: ERROR ${error instanceof Error ? error.message : String(error)}; ${currentCache.models.length} cached (${currentCache.source})`,
-          );
-        }
-
-        let snapshot: AntigravityStateSnapshot | undefined;
-        try {
-          snapshot = await runAntigravity(runtime, service.snapshot);
-          const executor = snapshot.executor;
-          const config = executor.config;
-          lines.push(
-            `driver: ${executor.mode} · ${executor.state}${executor.pid ? ` · pid ${executor.pid}` : ""}`,
-            `driver binary: ${config?.binary ?? "none"}${config?.binaryVersion ? ` · ${config.binaryVersion}` : ""}`,
-            `driver config: model=${config?.model ?? "none"} effort=${config?.effort ?? "none"} agent=${config?.agent ?? "none"} mode=${config?.mode ?? "default"}`,
-          );
-          if (executor.stats) {
-            const stats = executor.stats;
-            const reasons = Object.entries(stats.recycleReasons)
-              .map(([reason, count]) => `${reason}=${count}`)
-              .join(", ");
-            lines.push(
-              executor.mode === "persistent"
-                ? `driver stats: spawns=${stats.spawnCount} respawns=${Math.max(0, stats.spawnCount - 1)} turns=${stats.submittedTurns} reused=${stats.reusedTurns} recycles=${stats.recycleCount} current=${stats.currentProcessTurns}`
-                : `driver stats: one-shot launches=${stats.spawnCount} turns=${stats.submittedTurns}`,
-              `driver recycle reasons: ${reasons || "none"}`,
-            );
-          }
-        } catch (error) {
-          lines.push(`driver: ERROR ${error instanceof Error ? error.message : String(error)}`);
-        }
-
-        const selected = currentCache.models.find((model) => model.id === ctx.model?.id);
-        let profile = "agent=none mode=default";
-        try {
-          const configured = readAgyProcessProfile();
-          profile = `agent=${configured.agent ?? "none"} mode=${configured.mode ?? "default"}`;
-          lines.push(
-            `selection: ${ctx.model?.id ?? "none"} · effort ${
-              resolveAgyModelEffort(
-                selected,
-                ctx.thinkingLevel === "off"
-                  ? undefined
-                  : mapThinkingToEffort(
-                      ctx.thinkingLevel as Exclude<typeof ctx.thinkingLevel, "off">,
-                    ),
-              ) ?? "none"
-            }`,
-          );
-        } catch (error) {
-          lines.push(`profile: ERROR ${error instanceof Error ? error.message : String(error)}`);
-        }
-        lines.push(`profile: ${profile}`);
-        lines.push(
-          `bridge: enabled=${BRIDGE_ENABLED} running=${bridgeManager.isRunning()} registered=${bridgeManager.isRegistered()} revision=${bridgeManager.processRevision()}`,
-        );
-
-        const conversationId = snapshot?.conversationId;
-        if (conversationId) {
-          const [exists, metadata] = await Promise.all([
-            agyConversationExists(conversationId),
-            readAgyConversationMetadata(conversationId),
-          ]);
-          lines.push(
-            `conversation: ${conversationId} · db ${exists ? "readable" : "missing/unreadable"}`,
-            `metadata: ${metadata.status}`,
-          );
-        } else {
-          lines.push("conversation: none", "metadata: not applicable");
-        }
-        ctx.ui.notify(lines.join("\n"), binary.ok ? "info" : "error");
-        return;
-      }
-      if (sub) {
-        ctx.ui.notify(
-          `antigravity: unknown argument "${sub}". Use reset | models | agents | doctor.`,
+          'antigravity: use "/agy-reset", "/agy-models", "/agy-agents", "/agy-subagents", or "/agy-doctor".',
           "error",
         );
         return;
@@ -1034,6 +900,175 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
         `antigravity: ${title}\nconversation: ${id ?? "none"}\n${details.join(" · ")}\n${profile}`,
         "info",
       );
+    },
+  });
+
+  pi.registerCommand("agy-reset", {
+    description: "Drop the agy conversation and driver; next turn starts fresh",
+    handler: async (args, ctx) => {
+      if (args.trim()) {
+        ctx.ui.notify('agy-reset: usage "/agy-reset".', "error");
+        return;
+      }
+      await runAntigravity(runtime, service.reset);
+      subagentRoster.clear();
+      appendConversationReset(ctx);
+      ctx.ui.notify("antigravity: conversation reset; next turn starts fresh.", "info");
+    },
+  });
+
+  pi.registerCommand("agy-models", {
+    description: "Re-discover models from `agy models` and re-register the provider",
+    handler: async (args, ctx) => {
+      if (args.trim()) {
+        ctx.ui.notify('agy-models: usage "/agy-models".', "error");
+        return;
+      }
+      const refreshed = await discoverModels(true);
+      currentCache = refreshed;
+      registerAntigravityProvider(refreshed.models);
+      ctx.ui.notify(
+        `antigravity: ${refreshed.models.length} models registered (${refreshed.source}).`,
+        "info",
+      );
+    },
+  });
+
+  pi.registerCommand("agy-agents", {
+    description: "List configured custom agy agents",
+    handler: async (args, ctx) => {
+      if (args.trim()) {
+        ctx.ui.notify('agy-agents: usage "/agy-agents".', "error");
+        return;
+      }
+      try {
+        const agents = parseAgyAgents(await execAgy(["agents"]));
+        ctx.ui.notify(
+          agents.length > 0
+            ? `antigravity custom agents:\n${agents.map((agent) => `• ${agent}`).join("\n")}`
+            : "antigravity: no custom agents configured.",
+          "info",
+        );
+      } catch (error) {
+        ctx.ui.notify(
+          `antigravity: failed to list agents (${error instanceof Error ? error.message : String(error)}).`,
+          "error",
+        );
+      }
+    },
+  });
+
+  pi.registerCommand("agy-doctor", {
+    description: "Diagnose binary, models, driver, bridge, and conversation state",
+    handler: async (args, ctx) => {
+      if (args.trim()) {
+        ctx.ui.notify('agy-doctor: usage "/agy-doctor".', "error");
+        return;
+      }
+      const lines = ["antigravity doctor"];
+      const binary = await checkAgyBinary({ refresh: true });
+      if (binary.ok) {
+        lines.push(
+          `binary: ${binary.binary} (${binary.version}, ${binary.source})`,
+          `binary selection: ${binary.selectionReason ?? "compatible candidate"}`,
+          `minimum: ${MIN_AGY_VERSION}`,
+        );
+      } else {
+        lines.push(
+          `binary: ERROR [${binary.category}] ${binary.message}`,
+          `minimum: ${MIN_AGY_VERSION}`,
+        );
+      }
+      for (const candidate of binary.candidates ?? []) {
+        const selected = binary.ok && candidate.binary === binary.binary ? "selected" : "candidate";
+        lines.push(
+          `binary ${selected}: ${candidate.source} ${candidate.binary} · ${
+            candidate.ok
+              ? candidate.development
+                ? (candidate.version ?? "development")
+                : (candidate.version ?? "unknown")
+              : `ERROR [${candidate.category ?? "unknown"}]`
+          }`,
+        );
+      }
+
+      try {
+        const discovered = parseAgyModels((await runAgyCommand(["models"])).stdout);
+        if (discovered.length === 0) throw new Error("no valid model rows returned");
+        currentCache = { fetchedAt: Date.now(), source: "live", models: discovered };
+        registerAntigravityProvider(discovered);
+        lines.push(`models: ${discovered.length} (live)`);
+      } catch (error) {
+        lines.push(
+          `models: ERROR ${error instanceof Error ? error.message : String(error)}; ${currentCache.models.length} cached (${currentCache.source})`,
+        );
+      }
+
+      let snapshot: AntigravityStateSnapshot | undefined;
+      try {
+        snapshot = await runAntigravity(runtime, service.snapshot);
+        const executor = snapshot.executor;
+        const config = executor.config;
+        lines.push(
+          `driver: ${executor.mode} · ${executor.state}${executor.pid ? ` · pid ${executor.pid}` : ""}`,
+          `driver binary: ${config?.binary ?? "none"}${config?.binaryVersion ? ` · ${config.binaryVersion}` : ""}`,
+          `driver config: model=${config?.model ?? "none"} effort=${config?.effort ?? "none"} agent=${config?.agent ?? "none"} mode=${config?.mode ?? "default"}`,
+        );
+        if (executor.stats) {
+          const stats = executor.stats;
+          const reasons = Object.entries(stats.recycleReasons)
+            .map(([reason, count]) => `${reason}=${count}`)
+            .join(", ");
+          lines.push(
+            executor.mode === "persistent"
+              ? `driver stats: spawns=${stats.spawnCount} respawns=${Math.max(0, stats.spawnCount - 1)} turns=${stats.submittedTurns} reused=${stats.reusedTurns} recycles=${stats.recycleCount} current=${stats.currentProcessTurns}`
+              : `driver stats: one-shot launches=${stats.spawnCount} turns=${stats.submittedTurns}`,
+            `driver recycle reasons: ${reasons || "none"}`,
+          );
+        }
+      } catch (error) {
+        lines.push(`driver: ERROR ${error instanceof Error ? error.message : String(error)}`);
+      }
+
+      const selected = currentCache.models.find((model) => model.id === ctx.model?.id);
+      let profile = "agent=none mode=default";
+      try {
+        const configured = readAgyProcessProfile();
+        profile = `agent=${configured.agent ?? "none"} mode=${configured.mode ?? "default"}`;
+        lines.push(
+          `selection: ${ctx.model?.id ?? "none"} · effort ${
+            resolveAgyModelEffort(
+              selected,
+              ctx.thinkingLevel === "off"
+                ? undefined
+                : mapThinkingToEffort(
+                    ctx.thinkingLevel as Exclude<typeof ctx.thinkingLevel, "off">,
+                  ),
+            ) ?? "none"
+          }`,
+        );
+      } catch (error) {
+        lines.push(`profile: ERROR ${error instanceof Error ? error.message : String(error)}`);
+      }
+      lines.push(`profile: ${profile}`);
+      lines.push(
+        `bridge: enabled=${BRIDGE_ENABLED} running=${bridgeManager.isRunning()} registered=${bridgeManager.isRegistered()} revision=${bridgeManager.processRevision()}`,
+      );
+
+      const conversationId = snapshot?.conversationId;
+      if (conversationId) {
+        const [exists, metadata] = await Promise.all([
+          agyConversationExists(conversationId),
+          readAgyConversationMetadata(conversationId),
+        ]);
+        lines.push(
+          `conversation: ${conversationId} · db ${exists ? "readable" : "missing/unreadable"}`,
+          `metadata: ${metadata.status}`,
+        );
+      } else {
+        lines.push("conversation: none", "metadata: not applicable");
+      }
+      ctx.ui.notify(lines.join("\n"), binary.ok ? "info" : "error");
     },
   });
 
@@ -1124,6 +1159,22 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
       }
 
       await openAgyArtifactsPicker(ctx, rescan);
+    },
+  });
+
+  pi.registerCommand("agy-subagents", {
+    description: "List subagent activity observed on the agy stream (spawns, messages, kills)",
+    handler: async (args, ctx) => {
+      if (args.trim()) {
+        ctx.ui.notify('agy-subagents: usage "/agy-subagents".', "error");
+        return;
+      }
+      const report = formatAgySubagents(subagentRoster);
+      ctx.ui.notify(
+        report ??
+          "antigravity: no subagent activity observed this session. Subagents appear here as agy streams invoke_subagent/send_message steps.",
+        "info",
+      );
     },
   });
 

--- a/packages/pi-antigravity/lib/agy-driver.ts
+++ b/packages/pi-antigravity/lib/agy-driver.ts
@@ -559,7 +559,7 @@ export class AgyDriverSession implements AgyTurnExecutor {
         ? `: ${tail}`
         : ` (no stderr${this.#config?.model ? ` model=${this.#config.model}` : ""}${
             this.#boundConversationId ? ` conv=${this.#boundConversationId.slice(0, 8)}` : ""
-          }). The cause is unknown. Try /agy reset before retrying, or set PI_ANTIGRAVITY_DRIVER=0 for one-shot mode. Check for commands still running before retrying; use pi's own bash for long-lived commands.`;
+          }). The cause is unknown. Try /agy-reset before retrying, or set PI_ANTIGRAVITY_DRIVER=0 for one-shot mode. Check for commands still running before retrying; use pi's own bash for long-lived commands.`;
       this.#settleTurn(turn, {
         error: new AgySpawnError(
           `agy exited with code ${code ?? signal ?? "signal"} before producing a result${hint}`,

--- a/packages/pi-antigravity/lib/subagents.ts
+++ b/packages/pi-antigravity/lib/subagents.ts
@@ -1,0 +1,225 @@
+/**
+ * Subagent roster — folds agy's subagent tool calls into a live list for
+ * `/agy-subagents`. agy has no read-only subcommand or slash command for live
+ * subagent state (`/subagents` expands to a model turn), so the only zero-token
+ * source is the stream itself: `invoke_subagent`/`run_subagent`/
+ * `define_subagent`/`browser_subagent` spawns arrive as ordinary tool steps
+ * (ACTIVE → DONE/ERROR), `send_message` addresses a spawned agent, and
+ * `manage_subagents` carries lifecycle actions (kill/…). Tracking is
+ * best-effort: entries describe observed tool activity, not agy's internal
+ * hub state.
+ */
+
+import type { AgyActivity } from "./reducer.ts";
+import { agyToolStepKey } from "./tool-steps.ts";
+
+export type AgySubagentStatus = "running" | "done" | "error" | "killed";
+
+export interface AgySubagentEntry {
+  key: string;
+  /** Subagent name from the call args, or the tool name when absent. */
+  name: string;
+  /** Tool that produced the entry (`invoke_subagent`, `run_subagent`, …). */
+  tool: string;
+  status: AgySubagentStatus;
+  startedAtMs: number;
+  /** agy-reported duration once the step completes. */
+  durationSeconds?: number;
+  /** Task/prompt summary when the call carried one. */
+  detail?: string;
+  /** `send_message` calls addressed to this entry. */
+  messages: number;
+  error?: string;
+}
+
+const SPAWN_TOOLS = new Set([
+  "invoke_subagent",
+  "run_subagent",
+  "define_subagent",
+  "browser_subagent",
+]);
+const MESSAGE_TOOLS = new Set(["send_message"]);
+const MANAGE_TOOLS = new Set(["manage_subagents"]);
+
+/** True for tool names in agy's subagent orchestration family. */
+export function isAgySubagentTool(name: string): boolean {
+  return SPAWN_TOOLS.has(name) || MESSAGE_TOOLS.has(name) || MANAGE_TOOLS.has(name);
+}
+
+/** First defined non-empty string among the given keys (agy mixes key casings). */
+function pickArg(input: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  }
+  return undefined;
+}
+
+function pickName(args: Record<string, unknown>, tool: string): string {
+  return (
+    pickArg(args, [
+      "Name",
+      "name",
+      "Subagent",
+      "subagent",
+      "subagent_name",
+      "SubagentName",
+      "Agent",
+      "agent",
+      "Type",
+      "type",
+    ]) ?? tool
+  );
+}
+
+function pickDetail(args: Record<string, unknown>): string | undefined {
+  const detail = pickArg(args, [
+    "Task",
+    "task",
+    "Prompt",
+    "prompt",
+    "Instruction",
+    "instruction",
+    "Instructions",
+    "Goal",
+    "goal",
+    "Description",
+    "description",
+    "Message",
+    "message",
+  ]);
+  return detail?.replace(/\s+/g, " ").slice(0, 120);
+}
+
+/** Case-insensitive lookup by subagent name (send/manage steps carry no step id). */
+function findByName(
+  roster: Map<string, AgySubagentEntry>,
+  name: string,
+): AgySubagentEntry | undefined {
+  const needle = name.toLowerCase();
+  for (const entry of roster.values()) {
+    if (entry.name.toLowerCase() === needle) return entry;
+  }
+  return undefined;
+}
+
+/** Fold one stream activity into the roster; ignores non-tool activities. */
+export function trackAgySubagent(
+  roster: Map<string, AgySubagentEntry>,
+  activity: AgyActivity,
+  now = Date.now(),
+): void {
+  if (
+    activity.type !== "tool_start" &&
+    activity.type !== "tool_done" &&
+    activity.type !== "tool_error"
+  ) {
+    return;
+  }
+  const { name: tool, args } = activity;
+
+  if (MESSAGE_TOOLS.has(tool)) {
+    if (activity.type !== "tool_start") return;
+    const target = pickArg(args, [
+      "To",
+      "to",
+      "Target",
+      "target",
+      "Subagent",
+      "subagent",
+      "Name",
+      "name",
+    ]);
+    const entry = target ? findByName(roster, target) : undefined;
+    if (entry) entry.messages += 1;
+    return;
+  }
+
+  if (MANAGE_TOOLS.has(tool)) {
+    if (activity.type !== "tool_start") return;
+    const action = (
+      pickArg(args, ["Action", "action", "Operation", "operation"]) ?? ""
+    ).toLowerCase();
+    if (!/kill|stop|terminat|cancel|abort/.test(action)) return;
+    const target = pickArg(args, [
+      "Name",
+      "name",
+      "Subagent",
+      "subagent",
+      "subagent_id",
+      "SubagentId",
+      "Id",
+      "id",
+    ]);
+    if (target) {
+      const entry = findByName(roster, target);
+      if (entry && entry.status === "running") entry.status = "killed";
+      return;
+    }
+    for (const entry of roster.values()) {
+      if (entry.status === "running") entry.status = "killed";
+    }
+    return;
+  }
+
+  if (!SPAWN_TOOLS.has(tool)) return;
+  const key = agyToolStepKey({ stepId: activity.stepId, name: `${tool}:${pickName(args, tool)}` });
+  if (activity.type === "tool_start") {
+    if (!roster.has(key)) {
+      roster.set(key, {
+        key,
+        name: pickName(args, tool),
+        tool,
+        status: "running",
+        startedAtMs: now,
+        detail: pickDetail(args),
+        messages: 0,
+      });
+    }
+    return;
+  }
+  const entry = roster.get(key);
+  if (!entry) return;
+  if (activity.type === "tool_done") {
+    if (entry.status === "running") entry.status = "done";
+    if (entry.durationSeconds === undefined) {
+      entry.durationSeconds = activity.durationSeconds;
+    }
+  } else {
+    entry.status = "error";
+    entry.error = activity.message;
+  }
+}
+
+function formatElapsed(seconds: number): string {
+  const s = Math.max(0, Math.round(seconds));
+  if (s < 60) return `${s}s`;
+  return `${Math.floor(s / 60)}m${s % 60}s`;
+}
+
+/** One line per entry plus a header; empty roster returns undefined. */
+export function formatAgySubagents(
+  roster: Map<string, AgySubagentEntry>,
+  now = Date.now(),
+): string | undefined {
+  const entries = [...roster.values()];
+  if (entries.length === 0) return undefined;
+  const running = entries.filter((entry) => entry.status === "running").length;
+  const lines = [
+    `antigravity subagents: ${entries.length} tracked${running ? ` · ${running} running` : ""}`,
+  ];
+  for (const entry of entries) {
+    const elapsed = entry.durationSeconds ?? Math.max(0, (now - entry.startedAtMs) / 1000);
+    const parts = [
+      `• ${entry.name}`,
+      entry.status,
+      formatElapsed(elapsed),
+      entry.messages > 0 ? `${entry.messages} msg${entry.messages === 1 ? "" : "s"}` : undefined,
+      entry.detail ? `"${entry.detail}"` : undefined,
+      entry.error,
+    ].filter((part): part is string => part !== undefined);
+    lines.push(parts.join(" · "));
+  }
+  return lines.join("\n");
+}

--- a/packages/pi-antigravity/src/runtime.ts
+++ b/packages/pi-antigravity/src/runtime.ts
@@ -5,7 +5,7 @@
  *
  * Continuity policy: agy keeps its own authoritative conversation history
  * (`--conversation <id>`), so the conversation is reused across turns and
- * reset only when the selected model changes or the user asks (/agy reset).
+ * reset only when the selected model changes or the user asks (/agy-reset).
  */
 
 import { Context, Data, Effect, Layer, ManagedRuntime, Exit, Cause, Result } from "effect";

--- a/packages/pi-antigravity/test/subagents.test.ts
+++ b/packages/pi-antigravity/test/subagents.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  type AgySubagentEntry,
+  formatAgySubagents,
+  isAgySubagentTool,
+  trackAgySubagent,
+} from "../lib/subagents.ts";
+
+function roster(): Map<string, AgySubagentEntry> {
+  return new Map();
+}
+
+test("isAgySubagentTool covers the subagent tool family only", () => {
+  for (const name of [
+    "invoke_subagent",
+    "run_subagent",
+    "define_subagent",
+    "browser_subagent",
+    "send_message",
+    "manage_subagents",
+  ]) {
+    assert.ok(isAgySubagentTool(name), name);
+  }
+  for (const name of ["run_command", "view_file", "manage_task", "antigravity"]) {
+    assert.ok(!isAgySubagentTool(name), name);
+  }
+});
+
+test("spawn/done lifecycle produces a finished entry with name and detail", () => {
+  const map = roster();
+  trackAgySubagent(map, {
+    type: "tool_start",
+    stepId: 7,
+    name: "invoke_subagent",
+    args: { Name: "researcher", Task: "map the repo layout" },
+  });
+  trackAgySubagent(map, {
+    type: "tool_done",
+    stepId: 7,
+    name: "invoke_subagent",
+    args: { Name: "researcher" },
+    durationSeconds: 12.4,
+  });
+  const entries = [...map.values()];
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].name, "researcher");
+  assert.equal(entries[0].status, "done");
+  assert.equal(entries[0].durationSeconds, 12.4);
+  assert.equal(entries[0].detail, "map the repo layout");
+});
+
+test("error steps mark the entry without losing earlier state", () => {
+  const map = roster();
+  trackAgySubagent(map, {
+    type: "tool_start",
+    stepId: 1,
+    name: "run_subagent",
+    args: { name: "worker" },
+  });
+  trackAgySubagent(map, {
+    type: "tool_error",
+    stepId: 1,
+    name: "run_subagent",
+    args: {},
+    message: "quota exhausted",
+  });
+  const entry = [...map.values()][0];
+  assert.equal(entry.status, "error");
+  assert.equal(entry.error, "quota exhausted");
+});
+
+test("parallel spawns keep separate entries keyed by step id", () => {
+  const map = roster();
+  for (const stepId of [1, 2]) {
+    trackAgySubagent(map, {
+      type: "tool_start",
+      stepId,
+      name: "invoke_subagent",
+      args: { Name: "researcher" },
+    });
+  }
+  trackAgySubagent(map, {
+    type: "tool_done",
+    stepId: 2,
+    name: "invoke_subagent",
+    args: {},
+  });
+  const statuses = [...map.values()].map((entry) => entry.status).sort();
+  assert.deepEqual(statuses, ["done", "running"]);
+});
+
+test("send_message counts messages against the addressed subagent", () => {
+  const map = roster();
+  trackAgySubagent(map, {
+    type: "tool_start",
+    stepId: 3,
+    name: "invoke_subagent",
+    args: { Name: "Planner" },
+  });
+  for (let i = 0; i < 2; i++) {
+    trackAgySubagent(map, {
+      type: "tool_start",
+      stepId: 10 + i,
+      name: "send_message",
+      args: { To: "planner", Message: "status?" },
+    });
+  }
+  // Unknown targets do not create phantom entries.
+  trackAgySubagent(map, {
+    type: "tool_start",
+    stepId: 20,
+    name: "send_message",
+    args: { To: "ghost", Message: "hi" },
+  });
+  const entry = [...map.values()][0];
+  assert.equal(entry.messages, 2);
+  assert.equal(map.size, 1);
+});
+
+test("manage_subagents kill marks named target or all running", () => {
+  const map = roster();
+  for (const [stepId, name] of [
+    [1, "a"],
+    [2, "b"],
+  ] as const) {
+    trackAgySubagent(map, {
+      type: "tool_start",
+      stepId,
+      name: "invoke_subagent",
+      args: { Name: name },
+    });
+  }
+  trackAgySubagent(map, {
+    type: "tool_start",
+    stepId: 5,
+    name: "manage_subagents",
+    args: { Action: "kill", Name: "a" },
+  });
+  assert.equal(findEntry(map, "a").status, "killed");
+  assert.equal(findEntry(map, "b").status, "running");
+  trackAgySubagent(map, {
+    type: "tool_start",
+    stepId: 6,
+    name: "manage_subagents",
+    args: { Action: "kill all" },
+  });
+  assert.equal(findEntry(map, "b").status, "killed");
+});
+
+function findEntry(map: Map<string, AgySubagentEntry>, name: string): AgySubagentEntry {
+  const entry = [...map.values()].find((candidate) => candidate.name === name);
+  assert.ok(entry, `missing entry ${name}`);
+  return entry;
+}
+
+test("non-subagent tools and non-tool activities are ignored", () => {
+  const map = roster();
+  trackAgySubagent(map, { type: "tool_start", stepId: 1, name: "run_command", args: {} });
+  trackAgySubagent(map, { type: "text", delta: "hello" });
+  trackAgySubagent(map, { type: "usage", usage: {} });
+  assert.equal(map.size, 0);
+});
+
+test("formatAgySubagents renders header and bounded one-line entries", () => {
+  const map = roster();
+  trackAgySubagent(
+    map,
+    {
+      type: "tool_start",
+      stepId: 1,
+      name: "invoke_subagent",
+      args: { Name: "researcher", Task: "x".repeat(300) },
+    },
+    1_000,
+  );
+  trackAgySubagent(map, {
+    type: "tool_start",
+    stepId: 2,
+    name: "run_subagent",
+    args: { name: "worker" },
+  });
+  trackAgySubagent(map, {
+    type: "tool_done",
+    stepId: 2,
+    name: "run_subagent",
+    args: {},
+    durationSeconds: 95,
+  });
+  const report = formatAgySubagents(map, 61_000);
+  assert.ok(report);
+  const lines = report.split("\n");
+  assert.equal(lines[0], "antigravity subagents: 2 tracked · 1 running");
+  assert.ok(lines[1].includes("researcher") && lines[1].includes("running"));
+  assert.ok(lines[2].includes("worker") && lines[2].includes("done") && lines[2].includes("1m35s"));
+  for (const line of lines) {
+    assert.ok(line.length < 220, `line too long: ${line.length}`);
+  }
+});
+
+test("formatAgySubagents returns undefined for an empty roster", () => {
+  assert.equal(formatAgySubagents(roster()), undefined);
+});


### PR DESCRIPTION
## Summary

- **`/agy-subagents`** — zero-token roster of agy subagent activity, folded from the stream itself: `invoke_subagent`/`run_subagent`/`define_subagent`/`browser_subagent` spawns (ACTIVE → DONE/ERROR, duration), `send_message` message counts, `manage_subagents` kills. Verified that `agy --print /subagents` is *not* a native slash command — it burns a full model turn — so tracking the tool steps is the only read-only source. Roster is in-memory and clears on `/agy-reset` / conversation fallback.
- **Flattened `/agy` subcommands** — `/agy reset|models|agents|doctor` → `/agy-reset`, `/agy-models`, `/agy-agents`, `/agy-doctor`, consistent with the existing `/agy-tasks`, `/agy-artifacts`, `/agy-usage`. Bare `/agy` still shows status and points at the new names when given arguments.
- Includes changeset (minor) and README/comment updates.

#### Test plan

- [x] `pnpm --filter @tian.zuo/pi-antigravity test` — 263 tests, incl. 9 new roster tests (spawn/done/error lifecycle, parallel spawns, message counting, kill semantics, formatting)
- [x] `tsc --noEmit` clean
- [x] biome clean (pre-push hooks passed)
- [ ] Manual: `pi -e ./packages/pi-antigravity`, run an agy turn that spawns subagents, check `/agy-subagents`

Generated with [Devin](https://devin.ai)
