### PR TITLE
feat(pi-devin): Devin ACP provider extension

### DIFF
--- a/.changeset/pi-devin-initial.md
+++ b/.changeset/pi-devin-initial.md
@@ -1,0 +1,13 @@
+---
+"@tian.zuo/pi-devin": minor
+---
+
+Initial release: Devin ACP provider extension for pi.
+
+Registers `devin/*` models backed by `devin acp` (Agent Client Protocol over
+stdio), preserving Devin's native server-side agent loop. Includes model
+catalog discovery from `devin models list` with thinking-level resolution,
+per-branch session persistence via `session/load`, streamed text/thinking,
+display-only tool cards with result replay, permission prompts, Devin modes,
+`/devin` commands (status/reset/sessions/mode/models/login/doctor), and usage
+reporting.

--- a/extensions/pi-devin.ts
+++ b/extensions/pi-devin.ts
@@ -1,0 +1,1 @@
+export { default } from "../packages/pi-devin/index";

--- a/packages/pi-devin/PLAN.md
+++ b/packages/pi-devin/PLAN.md
@@ -1,0 +1,261 @@
+# Plan: `pi-devin` — Devin models inside pi via `devin acp` (ACP)
+
+pi stays the UI (chat, model picker, tool cards, sessions); the selected Devin
+model runs underneath through a persistent `devin acp` child speaking the
+Agent Client Protocol (JSON-RPC over stdio). Same shape as `pi-antigravity`
+(stream-json driver) and `pi-cursor-sdk` (`@cursor/sdk` runtime), but the wire
+protocol is standard ACP plus Cognition extensions.
+
+References:
+
+- `packages/pi-antigravity` — in-repo reference for provider registration,
+  streamSimple adaptation, display-only replay wrapper, conversation-state
+  persistence, diagnostics.
+- `~/Workspace/pi-cursor-sdk` (fitchmultz/pi-cursor-sdk) — reference for model
+  catalog cache/fallback, native tool replay, lazy provider loading.
+- `@agentclientprotocol/sdk@1.4.0` — official ACP TS SDK
+  (published 2026-08-20; typed schema + generic `onRequest`/`onNotification`
+  for custom methods).
+
+## What `devin acp` provides (verified by live probe, devin 3000.10.21)
+
+### Agent methods (client → `devin acp`)
+
+| Method | Verified | Notes |
+| --- | --- | --- |
+| `initialize` | yes | returns caps below |
+| `authenticate` | advertised | `authMethods: [{id:"devin-browser"}]`; also reads `WINDSURF_API_KEY` / `devin auth login` creds |
+| `session/new` | yes | `{cwd, mcpServers[]}` → `{sessionId, modes, configOptions}` |
+| `session/load` | partial | `loadSession: true`; probe on a same-process session returned `session_not_found` — resume semantics need a cross-process probe |
+| `session/list` | yes | `{sessionId, cwd, title, updatedAt, _meta: {createdAt, isLocked}}` — shared session DB; locked = open elsewhere |
+| `session/delete` | advertised | `sessionCapabilities.delete` |
+| `session/prompt` | yes | `{sessionId, prompt:[ContentBlock]}` → `{stopReason, usage, _meta.userMessageId}` |
+| `session/cancel` | standard | notification; bind to pi abort |
+| `session/set_mode` | yes | modes: `accept-edits`(Code), `ask`, `plan`, `bypass` |
+| `session/set_config_option` | yes | `{configId:"model", value:"claude-sonnet-5-low"}` switched the session model; `configId:"mode"` also present as a select option |
+| `session/resume`, `session/fork`, `session/close` | in SDK | availability TBD by probe |
+
+### Agent capabilities
+
+- `promptCapabilities`: image **true**, embeddedContext **true**, audio false —
+  pi images can be sent as content blocks; pi history could ride as an embedded
+  `resource` block instead of inlined text (decision below).
+- `mcpCapabilities`: http/sse **false** — `session/new` accepts only **stdio**
+  MCP servers.
+- Cognition `_meta` extensions: multiRootWorkspace, sessionRename,
+  sessionShare, documentLifecycle, userEdits, terminalLifecycle, userConfig,
+  userShellCommand, editableCommands, commandRevision, chains, megaplan,
+  ruleMentions.
+
+### `session/update` kinds observed
+
+`agent_message_chunk`, `agent_thought_chunk`, `tool_call`/`tool_call_update`
+(ACP-standard: kind, title, status, locations, content incl. `diff`,
+rawInput/rawOutput), `plan`, `usage_update` (`used`/`size` + `_meta`
+inputTokens/outputTokens/subagent_context), `available_commands_update`
+(devin's slash commands + skills as commands), `current_mode_update`,
+`config_option_update`, `session_info_update` (title). SDK schema also covers
+`compaction_update`, `user_message_chunk`.
+
+### Cognition notifications observed
+
+`_cognition.ai/agent_stopped` (turn stats: toolCalls, filesChanged,
+commandsRun, inputTokens, outputTokens, ttftMs, tokensPerSec, totalTimeMs,
+modelLabel) — feeds usage + token-speed; `_cognition.ai/turn_stats`,
+`_cognition.ai/thinking_complete`, `_cognition.ai/output` (log channels),
+`_cognition.ai/mcp/serversChanged`.
+
+### Client capabilities the server understands
+
+(from its initialize log) `fs.read`, `fs.write`, `terminal`, `terminal_auth`,
+`subagents`, `elicitation`, `partial_content`, `multi_root`,
+`grouped_options`, `mcp`, `plugins`, `editor_context`, `terminal_context`,
+`load_stats`, `wiki`, `revert`, `workspace_dir_commands`, `browser_preview`,
+`clipboard_write`, `local_tools`, etc. v1 advertises **fs+terminal false**:
+devin self-executes tools and reports them via `tool_call` updates (verified
+working in the probe).
+
+### Client → must implement
+
+`session/update` handler; `session/request_permission` (route to
+`ctx.ui.select`); optionally later `fs/read_text_file`,
+`fs/write_text_file`, `terminal/*`.
+
+### Out-of-band discovery
+
+- `devin models list` — full catalog: 47 families, concrete model IDs with
+  thinking suffixes (`-none/-low/-medium/-high/-xhigh/-max`), `-fast`/
+  `-priority` variants, context windows and pricing. Cheaper than an ACP
+  handshake for registration.
+- `devin version` → `devin 3000.10.21 (611c1cba)` for doctor.
+- `devin acp --model <m>` / `DEVIN_MODEL` — default model per ACP session;
+  `--agent-type summarizer|review`; `--refusal-fallback`.
+
+## Architecture
+
+```
+pi extension "devin"
+  └─ AcpDriver          persistent `devin acp` child (one per pi process;
+                        sessions are per-session/new|load, share one conn)
+       └─ ClientSideConnection (@agentclientprotocol/sdk) or thin NDJSON RPC
+            ├─ session/new · session/load · session/prompt · cancel
+            ├─ set_mode / set_config_option (mode + model sync)
+            └─ session/list · session/delete · authenticate
+  └─ streamDevin()      streamSimple: pi turn → session/prompt → pi events
+  └─ DevinReplayStore + `devin` wrapper tool  display-only tool cards
+  └─ conversation-state persistence  pi.appendEntry(ACP_SESSION_ENTRY,…)
+  └─ /devin commands    status · reset · models · sessions · mode · login · doctor
+```
+
+Key structural differences from pi-antigravity:
+
+- **No NDJSON dialect to reverse-engineer** — ACP is typed; the SDK handles
+  framing, schema, and (via generic `onRequest`/`onNotification` overloads)
+  Cognition's custom methods.
+- **No `toolUse` re-entry loop for devin's own tools** — ACP agents run their
+  tool loop server-side; `tool_call` updates are display-only. pi's
+  `stopReason: "toolUse"` round-trip is only needed if we later expose pi
+  tools to devin (bridge — non-goal v1).
+- **One process hosts many sessions** — no per-config process fingerprint;
+  model/mode are per-session config options settable mid-session, so a
+  recycle is only needed on process death.
+
+## Locked decisions
+
+1. **Transport: `@agentclientprotocol/sdk`.** Typed schema + generic
+   `onRequest`/`onNotification` overloads cover `_cognition.ai/*` custom
+   methods. Stage 0 includes a smoke script; hand-rolled NDJSON
+   (~350 LOC, `agy-client.ts` style) is the documented fallback if the SDK
+   drops unknown notifications or fights Node's type stripper.
+2. **Naming.** Provider `devin`, package `@tian.zuo/pi-devin` in
+   `packages/pi-devin`, commands `/devin …`, state under `~/.pi/devin/`.
+3. **Models: family-level registration + thinking suffix.** Parse
+   `devin models list` into families; register one pi model per family
+   (`devin/claude-opus-5`, `devin/swe-2`, …) with contextWindow/cost from
+   the family rows. Pi thinking level (`:low`/`:medium`/`:high`/`:xhigh`/
+   `:max`) resolves to the concrete devin variant (`claude-opus-5-high`)
+   at turn time, then `session/set_config_option {configId:"model"}` syncs
+   it. `-fast`/`-priority` variants become their own selectable families
+   (`devin/claude-opus-5-fast:high`). Models with no variants (plain rows)
+   accept no thinking suffix. Cache at `~/.pi/devin/model-list.json` with a
+   bundled fallback snapshot; `session/new`'s `configOptions` is the live
+   cross-check.
+4. **Pi↔ACP session mapping.** Persist `{sessionId, cwd, modelId, turns}`
+   per pi branch via `pi.appendEntry` (mirroring `conversation-state.ts`).
+   Reload/tree-nav → `session/load` (skip when `isLocked`); `/devin reset`
+   drops the mapping (never deletes the devin session); `/devin sessions`
+   lists `session/list` with load/delete actions. `~/.pi/pi-acp/` already
+   holds an earlier session-map attempt — read-only migration optional.
+5. **History bootstrap.** First turn of a fresh ACP session receives
+   serialized pi history as an embedded `resource` content block
+   (`embeddedContext: true`), labeled as transcript — not a system role
+   (same "text adapter" caveat as agy: devin's native system prompt is
+   authoritative). Pi system prompt snapshot rides the same way on turn 1
+   and on change. Stage 0 probe confirms devin reads `resource` blocks on
+   `session/prompt`; fallback is labeled text.
+6. **Permissions: route to pi UI.** `session/request_permission` →
+   `ctx.ui.select` over ACP options (allow_once/always/reject kinds);
+   abort → reject_once. Devin's mode select stays an independent coarse
+   gate (`/devin mode ask|plan|code|bypass`, shown in `/devin` status —
+   not mapped onto pi's permission concepts). v1 does not advertise
+   fs/terminal caps.
+7. **Tool display.** Display-only `devin` wrapper tool + replay store
+   (pi-antigravity pattern). ACP `tool_call` already carries title/kind/
+   status/locations/content — render `diff` content as an edit-style card,
+   `terminal` content as output lines. No native re-execution in v1 (ACP
+   results are authoritative; re-running reads buys nothing but prettier
+   cards — stage later if wanted).
+8. **Compaction.** Devin compacts internally (`compaction_update`); pi still
+   sends its own `<conversation>` summary requests through the provider —
+   run those in a **disposable ACP session** (fresh `session/new`, never
+   `load`), exactly like agy's isolated runtime.
+
+## Stages
+
+### Stage 0 — protocol harness + smoke
+**Goal**: proven transport choice and live-verified method matrix.
+- `lib/acp-connection.ts`: spawn `devin acp`, NDJSON line transport via SDK
+  (or hand-rolled if smoke fails); request/response map, notification fan-out,
+  stderr/log routing, bounded pending-request cleanup.
+- Manual probe script (not CI): initialize → session/new → prompt →
+  set_config_option → cancel → session/load across a process restart →
+  session/list/delete. Record results here.
+**Success**: probe passes on devin 3000.10.x; custom `_cognition.ai/*`
+notifications received; no leaked processes.
+
+### Stage 1 — provider skeleton + model catalog
+**Goal**: `pi --model devin/<id>` reaches a streamed answer.
+- `lib/models.ts`: `devin models list` family parser → `ProviderModelConfig`
+  (one pi model per family; contextWindow/cost from family rows,
+  reasoning=true); thinking-level → concrete variant resolution
+  (`resolveDevinModelVariant(family, level)`); cache + bundled fallback;
+  `/devin models` refresh.
+- `lib/diagnostics.ts` + `/devin doctor`: `devin` resolution (`DEVIN_BINARY`
+  override → PATH), `devin version` parse with min-version gate (start
+  3000.10.x), auth presence check, handshake probe, counters.
+- `src/provider.ts`: `streamDevin` — ensure session → `session/prompt` →
+  map `agent_message_chunk`/`agent_thought_chunk`/`usage_update`/
+  `stopReason` to pi events; abort → `session/cancel`.
+- `index.ts`: `pi.registerProvider("devin", …)`, wrapper tool, `/devin`,
+  `/devin reset`, `/devin doctor`.
+**Tests**: models parser, prompt conversion, event reducer vs recorded
+fixtures, abort→cancel, error surfaces.
+
+### Stage 2 — sessions, modes, config sync
+**Goal**: reloads resume; model/mode pickers act on the live session.
+- `lib/conversation-state.ts`: append/restore ACP session binding per pi
+  branch (sessionId + cwd + model + turns), lock-aware `session/load`,
+  fallback to fresh `session/new` on `session_not_found`/locked.
+- Mode + model sync: pi `model_select`/`/devin mode` → `set_config_option`
+  /`set_mode`; reconcile on `config_option_update`/`current_mode_update`.
+- `/devin sessions` picker over `session/list` (title, age, locked);
+  load/delete actions.
+- Disposable-session summarization for pi compaction/branch summaries.
+**Tests**: state append/restore matrix, lock/not-found fallbacks, summary
+isolation (no fake user input in the real session).
+
+### Stage 3 — tool cards + permissions
+**Goal**: devin's tools render as pi cards; gated actions ask the user.
+- `lib/replay.ts` + `lib/render.ts`: `tool_call`/`tool_call_update` →
+  display-only `devin` cards; kind-aware labels; `diff` content → edit card;
+  `terminal` content → output block; error status → error card.
+- `session/request_permission` → `ctx.ui.select` (title + tool detail),
+  remember allow-always per (tool-kind, path-pattern) within the turn.
+- Widget hint while devin runs tools (reuse the agy widget pattern).
+**Tests**: card rendering width-safety, permission option mapping, abort
+during a pending permission.
+
+### Stage 4 — polish
+- `/devin login` → `authenticate` (devin-browser); auth_required error →
+  actionable message.
+- `_cognition.ai/agent_stopped` stats → usage/token-speed feed;
+  `usage_update` → context-occupancy display.
+- `available_commands_update` → `/devin commands` list (forwarding `/x`
+  text prompts is cheap; decide after probing).
+- Env flags: `DEVIN_BINARY`, `DEVIN_ACP_MODEL`, `PI_DEVIN_DRIVER=0`
+  (rollback: fresh `devin acp` per turn), stall watchdogs like agy's.
+- Changeset + README (mermaid diagram like pi-antigravity's).
+
+## Non-goals (v1)
+
+- Pi-tool/MCP bridge into devin (`mcpCapabilities` is stdio-only and devin
+  already loads the user's own `~/.config/devin/mcp_config.json` — revisit
+  only if skills-in-devin is actually wanted).
+- `terminal/*` client capability (devin self-executes; a later stage could
+  back it with pi's exec for background-terminals integration).
+- Cognition editor extensions: documentLifecycle, userEdits, chains,
+  megaplan, sessionShare UI, browser_preview, subagent_control.
+- Auto-install/update of the devin binary.
+
+## Probes still needed in Stage 0
+
+1. `session/load` across a **process restart** (same-process load returned
+   `session_not_found`; verify persisted-session resume + `isLocked`
+   behavior).
+2. Whether `session/prompt` `resource` blocks are actually read by the model
+   (decides history bootstrap format; fallback = labeled text).
+3. `session/request_permission` shape on a gated action (run a write command
+   under mode `ask`/`accept-edits` and capture options payload).
+4. `session/resume`/`session/fork`/`session/close` availability.
+5. Whether the SDK's generic `onNotification` surfaces `_cognition.ai/*`
+   methods (fallback: raw line tap).

--- a/packages/pi-devin/README.md
+++ b/packages/pi-devin/README.md
@@ -13,7 +13,7 @@ permissions, modes, and persistent sessions.
 
 ## Requirements
 
-- `devin` CLI ≥ `3000.9.0` on `PATH` (or `DEVIN_BINARY=/path/to/devin`)
+- `devin` CLI ≥ `3000.10.0` on `PATH` (or `DEVIN_BINARY=/path/to/devin`)
 - Authenticated once via `devin auth login` (or `WINDSURF_API_KEY`)
 
 ## Models

--- a/packages/pi-devin/README.md
+++ b/packages/pi-devin/README.md
@@ -1,0 +1,93 @@
+# @tian.zuo/pi-devin
+
+Use [Devin](https://devin.ai) models inside [pi](https://pi.dev) by driving the
+Devin CLI as an ACP (Agent Client Protocol) server.
+
+```bash
+pi -e ./extensions/pi-devin.ts --model devin/swe-2
+```
+
+Devin runs its own agent loop server-side — this extension keeps that loop
+intact and surfaces it in pi: streamed text and thinking, tool cards, usage,
+permissions, modes, and persistent sessions.
+
+## Requirements
+
+- `devin` CLI ≥ `3000.9.0` on `PATH` (or `DEVIN_BINARY=/path/to/devin`)
+- Authenticated once via `devin auth login` (or `WINDSURF_API_KEY`)
+
+## Models
+
+Run `devin models list` to see the catalog. The extension registers one pi
+model per Devin model family/variant and resolves pi's thinking suffix to a
+concrete Devin row:
+
+| pi model                       | resolves to (examples)            |
+| ------------------------------ | --------------------------------- |
+| `devin/adaptive`               | Devin's auto model selection      |
+| `devin/swe-2`                  | `swe-2-medium` (default)          |
+| `devin/swe-2:max`              | `swe-2-max`                       |
+| `devin/claude-opus-5:high`     | `claude-opus-5-high`              |
+| `devin/claude-opus-5-fast:low` | `claude-opus-5-low-fast`          |
+| `devin/gpt-5.4:off`            | `gpt-5-4-none`                    |
+| `devin/gpt-5.4-fast:high`      | `gpt-5-4-high-priority`           |
+| `devin/claude-sonnet-4.6:high` | `claude-sonnet-4-6-thinking`      |
+
+Requested thinking levels resolve to the highest available Devin variant at or
+below that level (e.g. `:xhigh` on a family without xhigh picks `high`).
+
+Model discovery runs `devin models list`, caches the parsed catalog in
+`~/.pi/devin/models.json`, and falls back to a bundled snapshot when the CLI is
+unavailable.
+
+## Commands
+
+- `/devin` — current session, model, mode, and turn stats
+- `/devin reset` — drop the Devin session binding (next turn starts fresh)
+- `/devin sessions` — list Devin sessions; attach or delete one
+- `/devin mode [ask|plan|accept-edits|bypass]` — get/set Devin's permission mode
+- `/devin models` — re-discover models and re-register the picker
+- `/devin login` — trigger Devin's browser authentication
+- `/devin doctor` — binary, auth, catalog, and runtime diagnostics
+
+## How it works
+
+- One `devin acp` child process (stdio NDJSON/JSON-RPC) hosts ACP sessions.
+- Each pi session branch binds to one Devin session id; the binding persists in
+  pi's session file (`pi-devin-session-state` entries) so reloading pi resumes
+  the same Devin session via `session/load`.
+- Streamed `session/update` notifications become pi thinking/text blocks,
+  tool-card placeholders, and usage.
+- Devin tool calls appear as display-only `devin` tool calls; pi "executes"
+  them by replaying the recorded Devin result, then re-enters the provider.
+- `session/request_permission` prompts through pi's select UI. Headless runs
+  deny by default; set `PI_DEVIN_HEADLESS_PERMISSION=allow` to auto-allow.
+- Pi compaction/summarization requests run in disposable ACP sessions so they
+  never pollute the real Devin session's history.
+
+## Environment variables
+
+| Variable                        | Purpose                                       |
+| ------------------------------- | --------------------------------------------- |
+| `DEVIN_BINARY`                  | Path to the devin binary (default: PATH)      |
+| `PI_DEVIN_DEBUG=1`              | Log devin-acp stderr lines to pi's stderr     |
+| `PI_DEVIN_HEADLESS_PERMISSION`  | `allow` auto-approves prompts without a UI    |
+| `DEVIN_MODEL`                   | Devin-side default model for new sessions     |
+
+## Notes and limits
+
+- Devin ACP does not implement `session/resume`, `session/fork`, or
+  `session/close` — the extension uses `session/load`/`session/new` only.
+- Empty Devin sessions are not persisted server-side; the binding falls back to
+  `session/new` if a stored session is gone.
+- MCP servers cannot be attached through ACP (`mcpCapabilities` accepts stdio
+  only, unused here); Devin's own MCP config applies.
+- Devin's slash commands surface via `available_commands_update`; they run on
+  the Devin side.
+
+## Development
+
+```bash
+pnpm run check   # typecheck (tsc --noEmit)
+pnpm test        # unit tests + a live ACP round-trip (skipped without devin)
+```

--- a/packages/pi-devin/index.ts
+++ b/packages/pi-devin/index.ts
@@ -1,0 +1,824 @@
+/**
+ * pi-devin — use Devin models in pi via `devin acp` (Agent Client Protocol).
+ *
+ * One `devin acp` child process hosts ACP sessions; the current pi branch is
+ * bound to one devin session id, persisted across reloads. devin's own agent
+ * loop (tools, plans, compaction) runs server-side; pi renders streamed text,
+ * thinking, tool cards, and usage.
+ */
+
+import { Type } from "typebox";
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { DevinAcpClient } from "./lib/acp-client.ts";
+import { piConfigDir, readJson, writeJson } from "./lib/config.ts";
+import { checkDevinBinary, MIN_DEVIN_VERSION, runDevinCommand } from "./lib/diagnostics.ts";
+import {
+  devinGroups,
+  groupThinkingLevelMap,
+  parseDevinModels,
+  type DevinModelFamily,
+  modelCacheTtlMs,
+} from "./lib/models.ts";
+import { WRAPPER_TOOL_DESCRIPTION, WRAPPER_TOOL_NAME } from "./lib/prompt.ts";
+import { DevinReplayStore, type RecordedDevinTool } from "./lib/replay.ts";
+import { formatDevinCall, summarizeDevinResult } from "./lib/render.ts";
+import {
+  DEVIN_SESSION_STATE_ENTRY,
+  restorableDevinSession,
+  type PersistedDevinSession,
+} from "./lib/session-state.ts";
+import { streamDevin } from "./src/provider.ts";
+import { createDevinRuntime, DevinRuntime, runDevin } from "./src/runtime.ts";
+import { runDevinSessionsPicker } from "./src/sessions-ui.ts";
+
+const DEVIN_PROVIDER = "devin";
+const MODEL_CACHE_FILE = `${piConfigDir("devin")}/models.json`;
+const DEFAULT_MODE = "accept-edits";
+
+interface DevinModelCache {
+  fetchedAt: number;
+  source: "live" | "fallback";
+  families: DevinModelFamily[];
+}
+
+/** Bundled snapshot of `devin models list` (devin 3000.10.x, 2026-09). */
+const FALLBACK_FAMILIES: DevinModelFamily[] = [
+  {
+    id: "adaptive",
+    name: "Adaptive",
+    aliases: [],
+    rows: [
+      {
+        id: "adaptive",
+        name: "Adaptive",
+        contextWindow: 262144,
+        cost: { input: 0.5, output: 2, cacheRead: 0.1, cacheWrite: 0 },
+      },
+    ],
+  },
+  {
+    id: "swe-2",
+    name: "SWE-2",
+    aliases: ["swe"],
+    rows: [
+      {
+        id: "swe-2-high",
+        name: "SWE-2 High",
+        contextWindow: 262000,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        effort: "high",
+      },
+      {
+        id: "swe-2-medium",
+        name: "SWE-2 Medium",
+        contextWindow: 262000,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        effort: "medium",
+      },
+      {
+        id: "swe-2-max",
+        name: "SWE-2 Max",
+        contextWindow: 262000,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        effort: "max",
+      },
+    ],
+  },
+  {
+    id: "claude-opus-5",
+    name: "Claude Opus 5",
+    aliases: ["opus"],
+    rows: [
+      {
+        id: "claude-opus-5-low",
+        name: "Claude Opus 5 Low",
+        contextWindow: 1000000,
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "low",
+      },
+      {
+        id: "claude-opus-5-low-fast",
+        name: "Claude Opus 5 Low Fast",
+        contextWindow: 1000000,
+        cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 0 },
+        effort: "low",
+        fast: true,
+      },
+      {
+        id: "claude-opus-5-medium",
+        name: "Claude Opus 5 Medium",
+        contextWindow: 1000000,
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "medium",
+      },
+      {
+        id: "claude-opus-5-medium-fast",
+        name: "Claude Opus 5 Medium Fast",
+        contextWindow: 1000000,
+        cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 0 },
+        effort: "medium",
+        fast: true,
+      },
+      {
+        id: "claude-opus-5-high",
+        name: "Claude Opus 5 High",
+        contextWindow: 1000000,
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "high",
+      },
+      {
+        id: "claude-opus-5-high-fast",
+        name: "Claude Opus 5 High Fast",
+        contextWindow: 1000000,
+        cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 0 },
+        effort: "high",
+        fast: true,
+      },
+      {
+        id: "claude-opus-5-xhigh",
+        name: "Claude Opus 5 Xhigh",
+        contextWindow: 1000000,
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "xhigh",
+      },
+      {
+        id: "claude-opus-5-xhigh-fast",
+        name: "Claude Opus 5 Xhigh Fast",
+        contextWindow: 1000000,
+        cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 0 },
+        effort: "xhigh",
+        fast: true,
+      },
+      {
+        id: "claude-opus-5-max",
+        name: "Claude Opus 5 Max",
+        contextWindow: 1000000,
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "max",
+      },
+      {
+        id: "claude-opus-5-max-fast",
+        name: "Claude Opus 5 Max Fast",
+        contextWindow: 1000000,
+        cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 0 },
+        effort: "max",
+        fast: true,
+      },
+    ],
+  },
+  {
+    id: "gpt-5.5",
+    name: "GPT-5.5",
+    aliases: [],
+    rows: [
+      {
+        id: "gpt-5-5-none",
+        name: "GPT-5.5 No Thinking",
+        contextWindow: 272000,
+        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "none",
+      },
+      {
+        id: "gpt-5-5-none-priority",
+        name: "GPT-5.5 No Thinking Fast",
+        contextWindow: 272000,
+        cost: { input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 0 },
+        effort: "none",
+        fast: true,
+      },
+      {
+        id: "gpt-5-5-low",
+        name: "GPT-5.5 Low Thinking",
+        contextWindow: 272000,
+        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "low",
+      },
+      {
+        id: "gpt-5-5-low-priority",
+        name: "GPT-5.5 Low Thinking Fast",
+        contextWindow: 272000,
+        cost: { input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 0 },
+        effort: "low",
+        fast: true,
+      },
+      {
+        id: "gpt-5-5-medium",
+        name: "GPT-5.5 Medium Thinking",
+        contextWindow: 272000,
+        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "medium",
+      },
+      {
+        id: "gpt-5-5-medium-priority",
+        name: "GPT-5.5 Medium Thinking Fast",
+        contextWindow: 272000,
+        cost: { input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 0 },
+        effort: "medium",
+        fast: true,
+      },
+      {
+        id: "gpt-5-5-high",
+        name: "GPT-5.5 High Thinking",
+        contextWindow: 272000,
+        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "high",
+      },
+      {
+        id: "gpt-5-5-high-priority",
+        name: "GPT-5.5 High Thinking Fast",
+        contextWindow: 272000,
+        cost: { input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 0 },
+        effort: "high",
+        fast: true,
+      },
+      {
+        id: "gpt-5-5-xhigh",
+        name: "GPT-5.5 XHigh Thinking",
+        contextWindow: 272000,
+        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+        effort: "xhigh",
+      },
+      {
+        id: "gpt-5-5-xhigh-priority",
+        name: "GPT-5.5 XHigh Thinking Fast",
+        contextWindow: 272000,
+        cost: { input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 0 },
+        effort: "xhigh",
+        fast: true,
+      },
+    ],
+  },
+  {
+    id: "claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
+    aliases: ["sonnet"],
+    rows: [
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        contextWindow: 200000,
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+      },
+      {
+        id: "claude-sonnet-4-6-thinking",
+        name: "Claude Sonnet 4.6 Thinking",
+        contextWindow: 200000,
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+        thinking: true,
+      },
+      {
+        id: "claude-sonnet-4-6-1m",
+        name: "Claude Sonnet 4.6 1M",
+        contextWindow: 1000000,
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+        contextVariant: "1m",
+      },
+      {
+        id: "claude-sonnet-4-6-thinking-1m",
+        name: "Claude Sonnet 4.6 Thinking 1M",
+        contextWindow: 1000000,
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+        thinking: true,
+        contextVariant: "1m",
+      },
+    ],
+  },
+  {
+    id: "gemini-3.8-flash",
+    name: "Gemini 3.8 Flash",
+    aliases: ["flash"],
+    rows: [
+      {
+        id: "gemini-3-8-flash-low",
+        name: "Gemini 3.8 Flash Low",
+        contextWindow: 1048576,
+        cost: { input: 0.75, output: 3.75, cacheRead: 0.075, cacheWrite: 0 },
+        effort: "low",
+      },
+      {
+        id: "gemini-3-8-flash-medium",
+        name: "Gemini 3.8 Flash Medium",
+        contextWindow: 1048576,
+        cost: { input: 0.75, output: 3.75, cacheRead: 0.075, cacheWrite: 0 },
+        effort: "medium",
+      },
+      {
+        id: "gemini-3-8-flash-high",
+        name: "Gemini 3.8 Flash High",
+        contextWindow: 1048576,
+        cost: { input: 0.75, output: 3.75, cacheRead: 0.075, cacheWrite: 0 },
+        effort: "high",
+      },
+      {
+        id: "gemini-3-8-flash-xhigh",
+        name: "Gemini 3.8 Flash Xhigh",
+        contextWindow: 1048576,
+        cost: { input: 0.75, output: 3.75, cacheRead: 0.075, cacheWrite: 0 },
+        effort: "xhigh",
+      },
+    ],
+  },
+];
+
+function loadModelCache(): DevinModelCache {
+  const cached = readJson<DevinModelCache | undefined>(MODEL_CACHE_FILE, undefined);
+  if (cached && Array.isArray(cached.families) && cached.families.length > 0) {
+    return cached;
+  }
+  return { fetchedAt: 0, source: "fallback", families: FALLBACK_FAMILIES };
+}
+
+function buildProviderModels(families: DevinModelFamily[]): ProviderModelConfig[] {
+  return devinGroups(families).map((group) => ({
+    id: group.id,
+    name: group.name,
+    reasoning: group.reasoning,
+    thinkingLevelMap: groupThinkingLevelMap(group),
+    input: ["text", "image"],
+    cost: {
+      input: group.cost.input,
+      output: group.cost.output,
+      cacheRead: group.cost.cacheRead,
+      cacheWrite: group.cost.cacheWrite,
+    },
+    contextWindow: group.contextWindow || 262_144,
+    maxTokens: 64_000,
+  }));
+}
+
+function oneLine(value: string, max = 120): string {
+  const clean = value.replace(/\s+/g, " ").trim();
+  return clean.length <= max ? clean : `${clean.slice(0, max - 1)}…`;
+}
+
+function sessionStateKey(state: PersistedDevinSession): string {
+  return `${state.acpSessionId}:${state.turns}:${state.contextTokens ?? 0}`;
+}
+
+export default function piDevinExtension(pi: ExtensionAPI): void {
+  const replay = new DevinReplayStore();
+  let cwd = process.cwd();
+  let catalog = loadModelCache();
+  let sessionCtx: ExtensionContext | undefined;
+  let resolvedBinary: string | undefined;
+  let selectedModelKey: string | undefined;
+  let persistedSessionKey: string | undefined;
+  let piSessionId = "";
+
+  const runtime = createDevinRuntime(() => {
+    const client = new DevinAcpClient({
+      binary: resolvedBinary ?? process.env.DEVIN_BINARY?.trim() ?? "devin",
+      onLog: (line) => {
+        if (process.env.PI_DEVIN_DEBUG === "1") {
+          process.stderr.write(`[devin-acp] ${line}\n`);
+        }
+      },
+    });
+    client.setPermissionHandler(async (params) => {
+      const options = params.options ?? [];
+      const ui = sessionCtx?.hasUI ? sessionCtx.ui : undefined;
+      if (!ui) {
+        // Headless: deny by default; PI_DEVIN_HEADLESS_PERMISSION=allow opts in.
+        if (process.env.PI_DEVIN_HEADLESS_PERMISSION === "allow") {
+          const allow = options.find((o) => o.kind === "allow_once" || /allow/i.test(o.optionId));
+          if (allow) {
+            return { outcome: { outcome: "selected" as const, optionId: allow.optionId } };
+          }
+        }
+        return { outcome: { outcome: "cancelled" as const } };
+      }
+      const title = params.toolCall?.title ?? "tool call";
+      const picked = await ui.select(
+        `devin requests permission: ${oneLine(title, 80)}`,
+        options.map((o) => o.name ?? o.optionId),
+      );
+      if (!picked) return { outcome: { outcome: "cancelled" as const } };
+      const index = options.findIndex((o) => (o.name ?? o.optionId) === picked);
+      return index >= 0
+        ? { outcome: { outcome: "selected" as const, optionId: options[index].optionId } }
+        : { outcome: { outcome: "cancelled" as const } };
+    });
+    return client;
+  });
+  const service = runtime.runSync(DevinRuntime);
+
+  /** Append the current runtime binding to the pi session branch. */
+  const persistSessionState = async (ctx: ExtensionContext, force = false): Promise<void> => {
+    if (ctx.model?.provider !== DEVIN_PROVIDER) return;
+    const snapshot = await runDevin(runtime, service.snapshot);
+    if (!snapshot.sessionId || !snapshot.cwd) return;
+    const state: PersistedDevinSession = {
+      version: 1,
+      kind: "session",
+      sessionId: ctx.sessionManager.getSessionId(),
+      acpSessionId: snapshot.sessionId,
+      cwd: snapshot.cwd,
+      modelId: snapshot.model ?? ctx.model.id,
+      turns: snapshot.turns,
+      contextTokens: snapshot.contextTokens,
+    };
+    const key = sessionStateKey(state);
+    if (!force && key === persistedSessionKey) return;
+    persistedSessionKey = key;
+    pi.appendEntry(DEVIN_SESSION_STATE_ENTRY, state);
+  };
+
+  const appendSessionReset = (ctx: ExtensionContext) => {
+    persistedSessionKey = undefined;
+    pi.appendEntry(DEVIN_SESSION_STATE_ENTRY, {
+      version: 1,
+      kind: "reset",
+      sessionId: ctx.sessionManager.getSessionId(),
+      cwd: ctx.cwd,
+    });
+  };
+
+  // Display-only wrapper: replays recorded ACP tool results when pi executes
+  // the synthesized toolCalls. Never visible to models.
+  pi.registerTool({
+    name: WRAPPER_TOOL_NAME,
+    label: "devin",
+    description: WRAPPER_TOOL_DESCRIPTION,
+    parameters: Type.Object({
+      tool: Type.Optional(Type.String()),
+      title: Type.Optional(Type.String()),
+      kind: Type.Optional(Type.String()),
+      summary: Type.Optional(Type.String()),
+    }),
+    async execute(toolCallId) {
+      const recorded = replay.take(toolCallId);
+      if (!recorded) {
+        throw new Error("No recorded devin result for this tool call.");
+      }
+      if (recorded.error) {
+        throw new Error(recorded.error);
+      }
+      const body = recorded.output ?? "";
+      return {
+        content: [{ type: "text", text: body ? body.slice(0, 16_000) : "(no output)" }],
+        details: recorded,
+      };
+    },
+    renderCall(args, theme) {
+      return new Text(
+        formatDevinCall(
+          {
+            title: String(args.title ?? args.tool ?? "tool call"),
+            kind: typeof args.kind === "string" ? args.kind : undefined,
+            summary: typeof args.summary === "string" ? args.summary : undefined,
+          },
+          theme,
+        ),
+        0,
+        0,
+      );
+    },
+    renderResult(result, { expanded }, theme, context) {
+      const body = result.content[0]?.type === "text" ? result.content[0].text : "";
+      const details = result.details as RecordedDevinTool | undefined;
+      const title = details?.title ?? "tool";
+      if (context.isError) {
+        const message = body && body !== "(no output)" ? body.split("\n")[0] : "failed";
+        return new Text(theme.fg("error", `✗ ${oneLine(title, 60)}: ${oneLine(message)}`), 0, 0);
+      }
+      const summary = details ? summarizeDevinResult(details) : { headline: title };
+      let text = theme.fg("success", "✓ ") + theme.fg("toolTitle", oneLine(summary.headline, 140));
+      if (body && body !== "(no output)") {
+        const lines = body.split("\n");
+        const shown = expanded ? lines : lines.slice(0, 3);
+        text += `\n${shown.map((line) => theme.fg("toolOutput", line)).join("\n")}`;
+        if (!expanded && lines.length > 3) {
+          text += theme.fg("muted", `\n… +${lines.length - 3} lines (ctrl+o to expand)`);
+        }
+      }
+      return new Text(text, 0, 0);
+    },
+  });
+
+  const registerDevinProvider = (families: DevinModelFamily[]) => {
+    pi.registerProvider(DEVIN_PROVIDER, {
+      name: "Devin (acp)",
+      baseUrl: "devin://acp",
+      apiKey: "devin-local",
+      api: "devin-acp",
+      models: buildProviderModels(families),
+      streamSimple: streamDevin({
+        runtime,
+        service,
+        replay,
+        families: () => catalog.families,
+        cwd: () => cwd,
+      }),
+    });
+  };
+
+  registerDevinProvider(catalog.families);
+
+  const discoverModels = async (refresh = false): Promise<DevinModelCache> => {
+    if (!refresh) {
+      const cached = readJson<DevinModelCache | undefined>(MODEL_CACHE_FILE, undefined);
+      if (
+        cached?.families?.length &&
+        cached.fetchedAt &&
+        Date.now() - cached.fetchedAt < modelCacheTtlMs(cached.source)
+      ) {
+        catalog = cached;
+        return catalog;
+      }
+    }
+    const binary = await checkDevinBinary({ refresh });
+    if (!binary.ok) {
+      if (catalog.families.length) return catalog;
+      throw new Error(binary.message);
+    }
+    resolvedBinary = binary.binary;
+    const result = await runDevinCommand(binary.binary, ["models", "list"], {
+      timeoutMs: 20_000,
+    });
+    const families = parseDevinModels(result.stdout);
+    if (families.length === 0) {
+      if (catalog.families.length) return catalog;
+      throw new Error("devin models list returned no families");
+    }
+    catalog = { fetchedAt: Date.now(), source: "live", families };
+    try {
+      writeJson(MODEL_CACHE_FILE, catalog);
+    } catch {
+      // Cache is best-effort.
+    }
+    return catalog;
+  };
+
+  async function refreshModelsWhenSelected(): Promise<void> {
+    if (catalog.fetchedAt && Date.now() - catalog.fetchedAt < modelCacheTtlMs(catalog.source)) {
+      return;
+    }
+    try {
+      const next = await discoverModels(true);
+      registerDevinProvider(next.families);
+    } catch {
+      // Discovery failure keeps the cached/fallback catalog.
+    }
+  }
+
+  const syncWrapperToolActivation = (provider: string | undefined) => {
+    const want = provider === DEVIN_PROVIDER;
+    const active = pi.getActiveTools();
+    const has = active.includes(WRAPPER_TOOL_NAME);
+    if (want === has) return;
+    pi.setActiveTools(
+      want ? [...active, WRAPPER_TOOL_NAME] : active.filter((name) => name !== WRAPPER_TOOL_NAME),
+    );
+  };
+
+  pi.on("session_start", async (event, ctx: ExtensionContext) => {
+    sessionCtx = ctx;
+    cwd = ctx.cwd;
+    piSessionId = ctx.sessionManager.getSessionId();
+    syncWrapperToolActivation(ctx.model?.provider);
+    selectedModelKey = ctx.model ? `${ctx.model.provider}:${ctx.model.id}` : undefined;
+    const restored =
+      event.reason !== "fork" && ctx.model?.provider === DEVIN_PROVIDER
+        ? restorableDevinSession(ctx.sessionManager.getBranch(), piSessionId, ctx.cwd)
+        : undefined;
+    await runDevin(
+      runtime,
+      service.setSession(ctx.cwd, { rebootstrap: event.reason !== "new" && !restored }),
+    );
+    if (restored) {
+      await runDevin(
+        runtime,
+        service.restoreSession({
+          acpSessionId: restored.acpSessionId,
+          cwd: restored.cwd,
+          modelId: restored.modelId,
+          turns: restored.turns,
+          contextTokens: restored.contextTokens,
+        }),
+      );
+      persistedSessionKey = sessionStateKey(restored);
+    } else {
+      persistedSessionKey = undefined;
+    }
+    if (ctx.model?.provider === DEVIN_PROVIDER) {
+      await refreshModelsWhenSelected();
+    }
+  });
+
+  pi.on("model_select", async (event, ctx) => {
+    syncWrapperToolActivation(event.model?.provider);
+    const nextKey = event.model ? `${event.model.provider}:${event.model.id}` : undefined;
+    if (selectedModelKey?.startsWith(`${DEVIN_PROVIDER}:`) && selectedModelKey !== nextKey) {
+      // Another provider/model can add context the devin session never saw;
+      // re-bootstrap the next turn instead of resuming stale history.
+      await runDevin(runtime, service.setSession(ctx.cwd, { rebootstrap: true }));
+      persistedSessionKey = undefined;
+    }
+    selectedModelKey = nextKey;
+    if (event.model?.provider === DEVIN_PROVIDER) {
+      await refreshModelsWhenSelected();
+    }
+  });
+
+  pi.on("session_tree", async (_event, ctx: ExtensionContext) => {
+    // A devin session cannot be rewound to match a different pi branch.
+    await runDevin(runtime, service.setSession(ctx.cwd, { rebootstrap: true }));
+    appendSessionReset(ctx);
+  });
+
+  pi.on("agent_settled", async (_event, ctx: ExtensionContext) => {
+    await persistSessionState(ctx);
+  });
+
+  pi.on("session_compact", async (_event, ctx: ExtensionContext) => {
+    // Pi compaction changes the branch; re-anchor the same ACP session.
+    await persistSessionState(ctx, true);
+  });
+
+  pi.on("session_shutdown", async () => {
+    try {
+      await runDevin(runtime, service.close);
+    } catch {
+      // Already closed.
+    }
+    try {
+      await runtime.dispose();
+    } catch {
+      // Disposed gracefully.
+    }
+  });
+
+  pi.registerCommand("devin", {
+    description:
+      "Manage the devin backend: status | reset | models | sessions | mode | login | doctor",
+    handler: async (args, ctx) => {
+      sessionCtx = ctx;
+      const sub = args.trim().toLowerCase();
+
+      if (sub === "reset") {
+        await runDevin(runtime, service.reset);
+        appendSessionReset(ctx);
+        ctx.ui.notify("devin: session binding reset; next turn starts fresh.", "info");
+        return;
+      }
+
+      if (sub === "models") {
+        try {
+          const next = await discoverModels(true);
+          registerDevinProvider(next.families);
+          ctx.ui.notify(
+            `devin: ${devinGroups(next.families).length} models registered (${next.source}).`,
+            "info",
+          );
+        } catch (error) {
+          ctx.ui.notify(
+            `devin: model refresh failed (${error instanceof Error ? error.message : error}).`,
+            "error",
+          );
+        }
+        return;
+      }
+
+      if (sub === "sessions") {
+        try {
+          await runDevinSessionsPicker(ctx, {
+            listSessions: () => runDevin(runtime, service.listSessions),
+            currentSessionId: () =>
+              runtime
+                .runPromise(service.snapshot)
+                .then((s) => s.sessionId)
+                .catch(() => undefined),
+            loadSession: async (acpSessionId) => {
+              await runDevin(
+                runtime,
+                service.restoreSession({
+                  acpSessionId,
+                  cwd: ctx.cwd,
+                  modelId: ctx.model?.id ?? "adaptive",
+                  turns: 0,
+                }),
+              );
+              ctx.ui.notify("devin: session attached; it loads into the next turn.", "info");
+            },
+            deleteSession: async (acpSessionId) => {
+              await runDevin(runtime, service.deleteSession(acpSessionId));
+              appendSessionReset(ctx);
+            },
+          });
+        } catch (error) {
+          ctx.ui.notify(
+            `devin: sessions failed (${error instanceof Error ? error.message : error}).`,
+            "error",
+          );
+        }
+        return;
+      }
+
+      const modeMatch = sub.match(/^mode(?:\s+(\S+))?$/);
+      if (modeMatch) {
+        const requested = modeMatch[1];
+        if (!requested) {
+          const snapshot = await runDevin(runtime, service.snapshot);
+          const known = ["ask", "plan", DEFAULT_MODE, "bypass"];
+          ctx.ui.notify(
+            `devin mode: ${snapshot.modeId ?? "default"} — set with /devin mode ${known.join("|")}`,
+            "info",
+          );
+          return;
+        }
+        try {
+          await runDevin(runtime, service.setMode(requested));
+          ctx.ui.notify(`devin mode: ${requested}`, "info");
+        } catch (error) {
+          ctx.ui.notify(
+            `devin: set mode failed (${error instanceof Error ? error.message : error}).`,
+            "error",
+          );
+        }
+        return;
+      }
+
+      if (sub === "login") {
+        try {
+          await runDevin(runtime, service.authenticate("devin-browser"));
+          ctx.ui.notify("devin: authentication request sent (check your browser).", "info");
+        } catch (error) {
+          ctx.ui.notify(
+            `devin login failed (${error instanceof Error ? error.message : error}). Try \`devin auth login\` in a terminal.`,
+            "error",
+          );
+        }
+        return;
+      }
+
+      if (sub === "doctor") {
+        const lines = ["devin doctor"];
+        const binary = await checkDevinBinary({ refresh: true });
+        if (binary.ok) {
+          resolvedBinary = binary.binary;
+          lines.push(
+            `binary: ${binary.binary} (${binary.version}${binary.revision ? `, ${binary.revision}` : ""}, ${binary.source})`,
+            `minimum: ${MIN_DEVIN_VERSION}`,
+          );
+        } else {
+          lines.push(
+            `binary: ERROR [${binary.category}] ${binary.message}`,
+            `minimum: ${MIN_DEVIN_VERSION}`,
+          );
+        }
+        try {
+          const discovered = await discoverModels(true);
+          registerDevinProvider(discovered.families);
+          lines.push(`models: ${devinGroups(discovered.families).length} (live)`);
+        } catch (error) {
+          lines.push(
+            `models: ERROR ${error instanceof Error ? error.message : error}; ${devinGroups(catalog.families).length} cached (${catalog.source})`,
+          );
+        }
+        try {
+          const snapshot = await runDevin(runtime, service.snapshot);
+          lines.push(
+            `session: ${snapshot.sessionId ?? "none"}${snapshot.title ? ` "${snapshot.title}"` : ""}`,
+            `mode: ${snapshot.modeId ?? "default"} · model: ${snapshot.concreteModel ?? snapshot.model ?? "none"}`,
+            `turns: ${snapshot.turns} · context: ${snapshot.contextTokens ?? "?"}/${snapshot.contextSize ?? "?"}`,
+            `client: spawned=${snapshot.client.spawned} pid=${snapshot.client.pid ?? "none"} requests=${snapshot.client.requestsSent} notifications=${snapshot.client.notificationsReceived}`,
+          );
+        } catch (error) {
+          lines.push(`runtime: ERROR ${error instanceof Error ? error.message : error}`);
+        }
+        ctx.ui.notify(lines.join("\n"), binary.ok ? "info" : "error");
+        return;
+      }
+
+      if (sub) {
+        ctx.ui.notify(
+          `devin: unknown argument "${sub}". Use reset | models | sessions | mode | login | doctor.`,
+          "error",
+        );
+        return;
+      }
+
+      const snapshot = await runDevin(runtime, service.snapshot);
+      const details = [
+        `model: ${snapshot.concreteModel ?? snapshot.model ?? "unselected"}`,
+        `mode: ${snapshot.modeId ?? "default"}`,
+        `turns: ${snapshot.turns}`,
+        snapshot.contextTokens === undefined
+          ? undefined
+          : `context: ${snapshot.contextTokens}/${snapshot.contextSize ?? "?"}`,
+        snapshot.lastTurnStats?.tokensPerSec === undefined
+          ? undefined
+          : `last turn: ${snapshot.lastTurnStats.tokensPerSec.toFixed(1)} tok/s`,
+      ].filter((part): part is string => part !== undefined);
+      ctx.ui.notify(
+        `devin: ${snapshot.title ?? snapshot.sessionId ?? "no session yet"}\nsession: ${snapshot.sessionId ?? "none"}\n${details.join(" · ")}`,
+        "info",
+      );
+    },
+  });
+}

--- a/packages/pi-devin/lib/acp-client.ts
+++ b/packages/pi-devin/lib/acp-client.ts
@@ -1,0 +1,365 @@
+/**
+ * DevinAcpClient — owns the `devin acp` child process and the ACP
+ * JSON-RPC connection over stdio, via @agentclientprotocol/sdk.
+ *
+ * One client hosts many ACP sessions; session/update notifications are
+ * routed to per-session listeners registered by the runtime. During
+ * `session/load` devin replays the whole transcript as updates, so loads
+ * buffer and drop replayed content kinds while still forwarding state
+ * updates (usage, config, mode, title) that arrive with the replay tail.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+import * as acp from "@agentclientprotocol/sdk";
+
+export type DevinSessionUpdate = acp.SessionUpdate;
+export type DevinContentBlock = acp.ContentBlock;
+export type DevinSessionListener = (update: DevinSessionUpdate) => void;
+
+export interface DevinPromptResult {
+  stopReason?: string;
+  usage?: { totalTokens?: number; inputTokens?: number; outputTokens?: number };
+  meta?: Record<string, unknown>;
+}
+
+export interface DevinNewSessionResult {
+  sessionId: string;
+  modes?: { currentModeId?: string; availableModes?: { id: string; name: string }[] };
+  configOptions?: DevinConfigOption[];
+}
+
+export interface DevinConfigOption {
+  id: string;
+  name?: string;
+  category?: string;
+  type?: string;
+  currentValue?: string;
+  options?: { value: string; name: string; description?: string }[];
+}
+
+export interface DevinListSessionInfo {
+  sessionId: string;
+  cwd?: string;
+  title?: string;
+  updatedAt?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface DevinRequestPermissionParams {
+  sessionId: string;
+  toolCall: { toolCallId?: string; title?: string; kind?: string; rawInput?: unknown };
+  options: { optionId: string; name?: string; kind?: string }[];
+}
+
+export type DevinPermissionHandler = (
+  params: DevinRequestPermissionParams,
+) => Promise<acp.RequestPermissionResponse>;
+
+export type DevinCustomNotificationHandler = (method: string, params: unknown) => void;
+
+export interface DevinClientStats {
+  pid?: number;
+  spawned: number;
+  requestsSent: number;
+  notificationsReceived: number;
+}
+
+export interface DevinAcpClientOptions {
+  binary: string;
+  /** Extra argv after `acp` (e.g. --model). */
+  args?: string[];
+  env?: NodeJS.ProcessEnv;
+  clientInfo?: { name: string; version: string };
+  onLog?: (line: string) => void;
+  /** Test seam — replace process spawn. */
+  spawnProcess?: (binary: string, args: string[], env: NodeJS.ProcessEnv) => ChildProcess;
+}
+
+const LOG_LIMIT = 64 * 1024;
+
+export class DevinAcpClient {
+  #options: DevinAcpClientOptions;
+  #child: ChildProcess | undefined;
+  #connection: acp.ClientConnection | undefined;
+  #agent: acp.ClientContext | undefined;
+  #startPromise: Promise<void> | undefined;
+  #sessionListeners = new Map<string, DevinSessionListener>();
+  #loadingBuffers = new Map<string, acp.SessionUpdate[]>();
+  #permissionHandler: DevinPermissionHandler | undefined;
+  #customHandler: DevinCustomNotificationHandler | undefined;
+  #closed = false;
+  #stats = { spawned: 0, requestsSent: 0, notificationsReceived: 0 };
+  #stderrTail = "";
+  #onClose: (() => void) | undefined;
+
+  constructor(options: DevinAcpClientOptions) {
+    this.#options = options;
+  }
+
+  setPermissionHandler(handler: DevinPermissionHandler | undefined): void {
+    this.#permissionHandler = handler;
+  }
+
+  setCustomNotificationHandler(handler: DevinCustomNotificationHandler | undefined): void {
+    this.#customHandler = handler;
+  }
+
+  setSessionListener(sessionId: string, listener: DevinSessionListener | undefined): void {
+    if (listener) this.#sessionListeners.set(sessionId, listener);
+    else this.#sessionListeners.delete(sessionId);
+  }
+
+  setOnClose(handler: (() => void) | undefined): void {
+    this.#onClose = handler;
+  }
+
+  get stats(): DevinClientStats {
+    return { pid: this.#child?.pid, ...this.#stats };
+  }
+
+  get stderrTail(): string {
+    return this.#stderrTail;
+  }
+
+  /** Spawn the child and perform the ACP initialize handshake exactly once. */
+  ensureStarted(): Promise<void> {
+    if (this.#closed) return Promise.reject(new Error("devin ACP client is closed."));
+    if (this.#startPromise) return this.#startPromise;
+    this.#startPromise = this.#start().catch((error) => {
+      this.#startPromise = undefined;
+      throw error;
+    });
+    return this.#startPromise;
+  }
+
+  async #start(): Promise<void> {
+    const spawnImpl =
+      this.#options.spawnProcess ??
+      ((binary: string, args: string[], env: NodeJS.ProcessEnv) =>
+        spawn(binary, args, { env, stdio: ["pipe", "pipe", "pipe"] }));
+    const child = spawnImpl(this.#options.binary, ["acp", ...(this.#options.args ?? [])], {
+      ...process.env,
+      ...this.#options.env,
+    });
+    this.#child = child;
+    this.#stats.spawned += 1;
+
+    child.stderr?.on("data", (chunk) => {
+      const text = String(chunk);
+      this.#stderrTail = (this.#stderrTail + text).slice(-LOG_LIMIT);
+      for (const line of text.split("\n")) {
+        if (line.trim()) this.#options.onLog?.(line);
+      }
+    });
+    child.on("exit", () => this.#onClose?.());
+
+    const stream = acp.ndJsonStream(
+      Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>,
+      Readable.toWeb(child.stdout!) as unknown as ReadableStream<Uint8Array>,
+    );
+
+    const passthrough = (params: unknown) => params;
+    const app = acp
+      .client(this.#options.clientInfo ?? { name: "pi-devin" })
+      .onRequest(
+        acp.methods.client.session.requestPermission,
+        async (ctx): Promise<acp.RequestPermissionResponse> => {
+          const params = ctx.params as unknown as DevinRequestPermissionParams;
+          if (!this.#permissionHandler) return { outcome: { outcome: "cancelled" } };
+          return this.#permissionHandler(params);
+        },
+      )
+      .onNotification(acp.methods.client.session.update, (ctx) => {
+        this.#stats.notificationsReceived += 1;
+        this.#dispatchSessionUpdate(ctx.params.sessionId, ctx.params.update);
+      });
+    // Cognition extension notifications; also lets tests see raw traffic.
+    for (const method of [
+      "_cognition.ai/agent_stopped",
+      "_cognition.ai/turn_stats",
+      "_cognition.ai/thinking_complete",
+      "_cognition.ai/output",
+      "_cognition.ai/mcp/serversChanged",
+    ]) {
+      app.onNotification(method, passthrough, (ctx) => {
+        this.#stats.notificationsReceived += 1;
+        this.#customHandler?.(method, ctx.params);
+      });
+    }
+
+    this.#connection = app.connect(stream);
+    this.#agent = this.#connection.agent;
+    this.#connection.closed.then(() => this.#onClose?.());
+    await this.#agent.request(acp.methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {
+        fs: { readTextFile: false, writeTextFile: false },
+        terminal: false,
+      },
+      clientInfo: this.#options.clientInfo ?? { name: "pi-devin", version: "0.0.0" },
+    });
+  }
+
+  #dispatchSessionUpdate(sessionId: string, update: acp.SessionUpdate): void {
+    const buffer = this.#loadingBuffers.get(sessionId);
+    if (buffer) {
+      buffer.push(update);
+      return;
+    }
+    this.#sessionListeners.get(sessionId)?.(update);
+  }
+
+  async newSession(cwd: string): Promise<DevinNewSessionResult> {
+    await this.ensureStarted();
+    this.#stats.requestsSent += 1;
+    const result = (await this.#agent!.request(acp.methods.agent.session.new, {
+      cwd,
+      mcpServers: [],
+    })) as DevinNewSessionResult;
+    return result;
+  }
+
+  /**
+   * Load a persisted session. History replays as session/update notifications
+   * before the response resolves; replayed content kinds are dropped and
+   * trailing state updates are forwarded to the registered listener.
+   */
+  async loadSession(acpSessionId: string, cwd: string): Promise<DevinNewSessionResult> {
+    await this.ensureStarted();
+    this.#stats.requestsSent += 1;
+    this.#loadingBuffers.set(acpSessionId, []);
+    try {
+      const result = (await this.#agent!.request(acp.methods.agent.session.load, {
+        sessionId: acpSessionId,
+        cwd,
+        mcpServers: [],
+      })) as DevinNewSessionResult;
+      const buffered = this.#loadingBuffers.get(acpSessionId) ?? [];
+      const listener = this.#sessionListeners.get(acpSessionId);
+      if (listener) {
+        for (const update of buffered) {
+          if (isReplayedContentUpdate(update)) continue;
+          listener(update);
+        }
+      }
+      return result;
+    } finally {
+      this.#loadingBuffers.delete(acpSessionId);
+    }
+  }
+
+  async prompt(sessionId: string, prompt: DevinContentBlock[]): Promise<DevinPromptResult> {
+    await this.ensureStarted();
+    this.#stats.requestsSent += 1;
+    const result = (await this.#agent!.request(acp.methods.agent.session.prompt, {
+      sessionId,
+      prompt,
+    })) as acp.PromptResponse;
+    return {
+      stopReason: result.stopReason,
+      usage: result.usage as DevinPromptResult["usage"],
+      meta: result._meta ?? undefined,
+    };
+  }
+
+  async cancel(sessionId: string): Promise<void> {
+    if (!this.#agent) return;
+    await this.#agent.notify(acp.methods.agent.session.cancel, { sessionId });
+  }
+
+  async setMode(sessionId: string, modeId: string): Promise<void> {
+    await this.ensureStarted();
+    this.#stats.requestsSent += 1;
+    await this.#agent!.request(acp.methods.agent.session.setMode, { sessionId, modeId });
+  }
+
+  async setConfigOption(
+    sessionId: string,
+    configId: string,
+    value: string,
+  ): Promise<DevinConfigOption[]> {
+    await this.ensureStarted();
+    this.#stats.requestsSent += 1;
+    const result = (await this.#agent!.request(acp.methods.agent.session.setConfigOption, {
+      sessionId,
+      configId,
+      value,
+    })) as { configOptions?: DevinConfigOption[] };
+    return result.configOptions ?? [];
+  }
+
+  async listSessions(): Promise<DevinListSessionInfo[]> {
+    await this.ensureStarted();
+    this.#stats.requestsSent += 1;
+    const result = (await this.#agent!.request(acp.methods.agent.session.list, {})) as {
+      sessions?: Array<{
+        sessionId: string;
+        cwd?: string;
+        title?: string;
+        updatedAt?: string;
+        _meta?: Record<string, unknown>;
+      }>;
+    };
+    return (result.sessions ?? []).map((session) => ({
+      sessionId: session.sessionId,
+      cwd: session.cwd,
+      title: session.title,
+      updatedAt: session.updatedAt,
+      meta: session._meta ?? undefined,
+    }));
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.ensureStarted();
+    this.#stats.requestsSent += 1;
+    await this.#agent!.request(acp.methods.agent.session.delete, { sessionId });
+  }
+
+  async authenticate(methodId: string): Promise<void> {
+    await this.ensureStarted();
+    this.#stats.requestsSent += 1;
+    await this.#agent!.request(acp.methods.agent.authenticate, { methodId });
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#sessionListeners.clear();
+    try {
+      this.#connection?.close();
+    } catch {
+      // best-effort
+    }
+    const child = this.#child;
+    this.#child = undefined;
+    if (child && child.exitCode === null) {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // already gone
+      }
+      setTimeout(() => {
+        try {
+          if (child.exitCode === null) child.kill("SIGKILL");
+        } catch {
+          // already gone
+        }
+      }, 2_000).unref?.();
+    }
+  }
+}
+
+/** Update kinds that replay transcript content during session/load. */
+function isReplayedContentUpdate(update: acp.SessionUpdate): boolean {
+  return (
+    update.sessionUpdate === "user_message_chunk" ||
+    update.sessionUpdate === "agent_message_chunk" ||
+    update.sessionUpdate === "agent_thought_chunk" ||
+    update.sessionUpdate === "tool_call" ||
+    update.sessionUpdate === "tool_call_update" ||
+    update.sessionUpdate === "plan" ||
+    update.sessionUpdate === "plan_update" ||
+    update.sessionUpdate === "plan_removed"
+  );
+}

--- a/packages/pi-devin/lib/acp-client.ts
+++ b/packages/pi-devin/lib/acp-client.ts
@@ -153,6 +153,14 @@ export class DevinAcpClient {
       }
     });
     child.on("exit", () => this.#onClose?.());
+    // Spawn failures (ENOENT/EACCES on the resolved binary) emit "error"
+    // without "exit"; surface them through the same close path so the
+    // runtime recovers deterministically instead of relying on stdio
+    // teardown.
+    child.on("error", (error) => {
+      this.#options.onLog?.(`child error: ${error.message}`);
+      this.#onClose?.();
+    });
 
     const stream = acp.ndJsonStream(
       Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>,

--- a/packages/pi-devin/lib/config.ts
+++ b/packages/pi-devin/lib/config.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/** Absolute path to a machine-local pi config directory: ~/.pi/<name>. */
+export function piConfigDir(name: string): string {
+  return path.join(os.homedir(), ".pi", name);
+}
+
+/** Read and parse a JSON file, returning fallback if it is missing or invalid. */
+export function readJson<T>(file: string, fallback: T): T {
+  try {
+    if (!fs.existsSync(file)) return fallback;
+    return JSON.parse(fs.readFileSync(file, "utf-8")) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Write a JSON file, creating parent directories. Throws on failure. */
+export function writeJson(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}

--- a/packages/pi-devin/lib/diagnostics.ts
+++ b/packages/pi-devin/lib/diagnostics.ts
@@ -1,0 +1,236 @@
+/**
+ * devin binary discovery and compatibility checks.
+ *
+ * Selection policy: `DEVIN_BINARY` is a strict override (no fallback when it
+ * fails); otherwise `devin` from PATH. `devin version` prints
+ * `devin X.Y.Z (<commit>)`; the minimum supported version is enforced.
+ */
+
+import { spawn } from "node:child_process";
+import { gte, valid } from "semver";
+import which from "which";
+
+export const MIN_DEVIN_VERSION = "3000.10.0";
+export const DEVIN_VERSION_TIMEOUT_MS = 5_000;
+const OUTPUT_LIMIT = 64 * 1024;
+
+export type DevinBinarySource = "override" | "path";
+
+export type DevinBinaryFailureCategory =
+  | "not-found"
+  | "permission-denied"
+  | "timeout"
+  | "spawn-failed"
+  | "invalid-version"
+  | "unsupported-version";
+
+export interface DevinBinarySuccess {
+  ok: true;
+  configured: string;
+  binary: string;
+  source: DevinBinarySource;
+  version: string;
+  revision?: string;
+  message?: string;
+}
+
+export interface DevinBinaryFailure {
+  ok: false;
+  configured: string;
+  binary?: string;
+  source?: DevinBinarySource;
+  category: DevinBinaryFailureCategory;
+  message: string;
+}
+
+export type DevinBinaryCheck = DevinBinarySuccess | DevinBinaryFailure;
+
+export class DevinCompatibilityError extends Error {
+  readonly diagnostic: DevinBinaryFailure;
+  constructor(diagnostic: DevinBinaryFailure) {
+    super(diagnostic.message);
+    this.name = "DevinCompatibilityError";
+    this.diagnostic = diagnostic;
+  }
+}
+
+export interface CheckDevinBinaryOptions {
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  spawnOverride?: typeof spawn;
+  whichOverride?: (command: string) => Promise<string>;
+}
+
+let cachedSuccess: { key: string; result: DevinBinarySuccess } | undefined;
+
+export function resetDevinBinaryCache(): void {
+  cachedSuccess = undefined;
+}
+
+/** Extract `X.Y.Z` and the parenthesized commit from `devin version` output. */
+export function parseDevinVersion(
+  output: string,
+): { version: string; revision?: string } | undefined {
+  const match = output.match(/devin\s+(\d+\.\d+\.\d+)(?:\s*\(([^)]+)\))?/i);
+  if (!match || !valid(match[1])) return undefined;
+  return { version: match[1], revision: match[2] };
+}
+
+export interface DevinCommandResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+}
+
+/** Run a devin subcommand with a bounded capture; used for models/version. */
+export function runDevinCommand(
+  binary: string,
+  args: string[],
+  options: { timeoutMs?: number; env?: NodeJS.ProcessEnv; spawnOverride?: typeof spawn } = {},
+): Promise<DevinCommandResult> {
+  const spawnImpl = options.spawnOverride ?? spawn;
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof spawnImpl> | undefined;
+    try {
+      child = spawnImpl(binary, args, {
+        env: options.env ?? process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      reject(error);
+      return;
+    }
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const finish = (error: Error | undefined, code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve({ stdout, stderr, code });
+    };
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish(new Error(`devin ${args.join(" ")} timed out after ${timeoutMs}ms`), null);
+    }, timeoutMs);
+    timer.unref?.();
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk);
+      if (stdout.length > OUTPUT_LIMIT) stdout = stdout.slice(0, OUTPUT_LIMIT);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+      if (stderr.length > OUTPUT_LIMIT) stderr = stderr.slice(0, OUTPUT_LIMIT);
+    });
+    child.on("error", (error) => finish(error, null));
+    child.on("close", (code) => {
+      if (code !== 0 && !stdout.trim()) {
+        finish(
+          new Error(`devin ${args.join(" ")} exited ${code}: ${stderr.trim().slice(0, 400)}`),
+          code,
+        );
+        return;
+      }
+      finish(undefined, code);
+    });
+  });
+}
+
+async function probeBinary(
+  binary: string,
+  configured: string,
+  source: DevinBinarySource,
+  options: CheckDevinBinaryOptions,
+): Promise<DevinBinaryCheck> {
+  const timeoutMs = options.timeoutMs ?? DEVIN_VERSION_TIMEOUT_MS;
+  let result: DevinCommandResult;
+  try {
+    result = await runDevinCommand(binary, ["version"], { ...options, timeoutMs });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    const category: DevinBinaryFailureCategory =
+      code === "ENOENT"
+        ? "not-found"
+        : code === "EACCES"
+          ? "permission-denied"
+          : /timed out/.test((error as Error).message)
+            ? "timeout"
+            : "spawn-failed";
+    return {
+      ok: false,
+      configured,
+      binary,
+      source,
+      category,
+      message: `${binary} version probe failed: ${(error as Error).message}`,
+    };
+  }
+  const parsed = parseDevinVersion(`${result.stdout}\n${result.stderr}`);
+  if (!parsed) {
+    return {
+      ok: false,
+      configured,
+      binary,
+      source,
+      category: "invalid-version",
+      message: `${binary} version output unrecognized: ${(result.stdout || result.stderr).trim().slice(0, 160)}`,
+    };
+  }
+  if (!gte(parsed.version, MIN_DEVIN_VERSION)) {
+    return {
+      ok: false,
+      configured,
+      binary,
+      source,
+      category: "unsupported-version",
+      message: `${binary} is devin ${parsed.version}, below the supported minimum ${MIN_DEVIN_VERSION}.`,
+    };
+  }
+  return {
+    ok: true,
+    configured,
+    binary,
+    source,
+    version: parsed.version,
+    revision: parsed.revision,
+  };
+}
+
+/**
+ * Resolve and validate the devin binary. The successful result is cached by
+ * the resolution key (override env or PATH); a failed probe never caches.
+ */
+export async function checkDevinBinary(
+  options: CheckDevinBinaryOptions & { refresh?: boolean } = {},
+): Promise<DevinBinaryCheck> {
+  const env = options.env ?? process.env;
+  const configured = env.DEVIN_BINARY?.trim() || "devin";
+  const cacheKey = `${env.DEVIN_BINARY ?? ""}|${env.PATH ?? ""}`;
+  if (!options.refresh && cachedSuccess?.key === cacheKey) return cachedSuccess.result;
+
+  let binary = configured;
+  const source: DevinBinarySource = env.DEVIN_BINARY?.trim() ? "override" : "path";
+  if (source === "path") {
+    try {
+      const whichImpl = options.whichOverride ?? which;
+      binary = await whichImpl("devin");
+    } catch {
+      return {
+        ok: false,
+        configured,
+        source,
+        category: "not-found",
+        message:
+          "devin not found on PATH. Install the Devin CLI or set DEVIN_BINARY to its absolute path.",
+      };
+    }
+  }
+
+  const result = await probeBinary(binary, configured, source, options);
+  if (result.ok && source === "path") {
+    cachedSuccess = { key: cacheKey, result };
+  }
+  return result;
+}

--- a/packages/pi-devin/lib/models.ts
+++ b/packages/pi-devin/lib/models.ts
@@ -1,0 +1,296 @@
+/**
+ * devin model discovery. `devin models list` prints families of concrete
+ * model rows; each row carries thinking-level, fast (priority), and
+ * context-window-variant markers as id suffixes. Families collapse into one
+ * Pi model per (context variant, fast) group; a Pi thinking level resolves
+ * to the group's concrete devin model id at turn time.
+ */
+
+import type { ThinkingLevel } from "@earendil-works/pi-ai";
+
+export type DevinEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
+const EFFORT_ORDER: DevinEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+export interface DevinModelPricing {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+export interface DevinModelRow {
+  /** Concrete devin model id, e.g. "claude-opus-5-high" or "MODEL_GPT_5_2_LOW". */
+  id: string;
+  name: string;
+  contextWindow: number;
+  cost: DevinModelPricing;
+  /** Trailing effort marker, when the row id carries one. */
+  effort?: DevinEffort;
+  /** Binary thinking row ("-thinking") — any-level fallback. */
+  thinking?: boolean;
+  /** Fast/priority serving tier ("-fast" or "-priority"). */
+  fast?: boolean;
+  /** Context-window variant marker ("-1m"), lowercased. */
+  contextVariant?: string;
+}
+
+export interface DevinModelGroup {
+  /** Pi model id, e.g. "claude-opus-5", "claude-opus-4.6-1m", "gpt-5.4-fast". */
+  id: string;
+  name: string;
+  contextWindow: number;
+  cost: DevinModelPricing;
+  /** Whether any row supports a thinking control (levels or "-thinking"). */
+  reasoning: boolean;
+  /** Default row when the user specifies no thinking level. */
+  defaultRow: DevinModelRow;
+  rows: DevinModelRow[];
+}
+
+export interface DevinModelFamily {
+  /** Family slug as printed in `devin models list`, e.g. "claude-opus-5". */
+  id: string;
+  name: string;
+  aliases: string[];
+  rows: DevinModelRow[];
+}
+
+const EFFORT_TOKENS = new Set<DevinEffort>(EFFORT_ORDER);
+const FAST_TOKENS = new Set(["fast", "priority"]);
+const CONTEXT_TOKEN = /^\d+[km]$/i;
+
+/**
+ * Split a row id's trailing markers from its base. Suffix tokens are
+ * `-`/`_`-separated; recognized markers strip repeatedly from the end:
+ * `claude-opus-4-6-thinking-1m` → ctx=1m, thinking; `gpt-5-4-none-priority`
+ * → fast, effort=none; `MODEL_GPT_5_2_XHIGH` → effort=xhigh.
+ */
+export function rowMarkers(id: string): {
+  effort?: DevinEffort;
+  thinking: boolean;
+  fast: boolean;
+  contextVariant?: string;
+} {
+  const tokens = id.split(/[-_]/);
+  let effort: DevinEffort | undefined;
+  let thinking = false;
+  let fast = false;
+  let contextVariant: string | undefined;
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const token = tokens[i].toLowerCase();
+    if (fast === false && FAST_TOKENS.has(token)) {
+      fast = true;
+      continue;
+    }
+    if (contextVariant === undefined && CONTEXT_TOKEN.test(token)) {
+      contextVariant = token;
+      continue;
+    }
+    if (!thinking && token === "thinking") {
+      thinking = true;
+      continue;
+    }
+    if (effort === undefined && (EFFORT_TOKENS.has as (v: string) => boolean)(token)) {
+      effort = token as DevinEffort;
+      continue;
+    }
+    break;
+  }
+  return { effort, thinking, fast, contextVariant };
+}
+
+function parseContextWindow(meta: string): number {
+  const match = meta.match(/([\d.,]+)\s*(k|m)?\s*context/i);
+  if (!match) return 0;
+  const value = Number(match[1].replace(/,/g, ""));
+  if (!Number.isFinite(value)) return 0;
+  const suffix = match[2]?.toLowerCase();
+  const scale = suffix === "m" ? 1_000_000 : suffix === "k" ? 1_000 : 1;
+  return Math.round(value * scale);
+}
+
+const PRICE = /\$([\d.]+)\s*\/\s*1M\s*(input|cached input|output)/gi;
+
+/** Parse the `[…]` meta section: context size plus per-Mtok USD rates or Free. */
+export function parseRowMeta(meta: string): { contextWindow: number; cost: DevinModelPricing } {
+  const cost: DevinModelPricing = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  for (const match of meta.matchAll(PRICE)) {
+    const value = Number(match[1]);
+    if (!Number.isFinite(value)) continue;
+    const kind = match[2].toLowerCase();
+    if (kind === "input") cost.input = value;
+    else if (kind === "cached input") cost.cacheRead = value;
+    else if (kind === "output") cost.output = value;
+  }
+  return { contextWindow: parseContextWindow(meta), cost };
+}
+
+const FAMILY_LINE = /^(\S.*)\s\(([^()\s]+)\)\s*$/;
+const ALIASES_LINE = /^\s+aliases:\s*(.+)$/;
+const ROW_LINE = /^\s{2,}(\S+)\s{2,}(\S.*?)\s{2,}\[([^\]]*)\]\s*$/;
+
+/**
+ * Parse `devin models list` output. Non-matching lines (header, footer,
+ * blank) are ignored; families keep printed order.
+ */
+export function parseDevinModels(text: string): DevinModelFamily[] {
+  const families: DevinModelFamily[] = [];
+  let current: { id: string; name: string; aliases: string[]; rows: DevinModelRow[] } | undefined;
+  for (const line of text.split("\n")) {
+    const aliases = line.match(ALIASES_LINE);
+    if (aliases && current) {
+      current.aliases = aliases[1]
+        .split(",")
+        .map((alias) => alias.trim())
+        .filter(Boolean);
+      continue;
+    }
+    const row = line.match(ROW_LINE);
+    if (row && current) {
+      const { contextWindow, cost } = parseRowMeta(row[3]);
+      const markers = rowMarkers(row[1]);
+      current.rows.push({
+        id: row[1],
+        name: row[2].trim(),
+        contextWindow,
+        cost,
+        effort: markers.effort,
+        thinking: markers.thinking || undefined,
+        fast: markers.fast || undefined,
+        contextVariant: markers.contextVariant,
+      });
+      continue;
+    }
+    const family = line.match(FAMILY_LINE);
+    if (family) {
+      current = { id: family[2], name: family[1].trim(), aliases: [], rows: [] };
+      families.push(current);
+      continue;
+    }
+    // A non-indented non-family line ends the family block tolerance-free:
+    // rows/aliases only apply while a family header preceded them.
+    if (line.trim() !== "" && !line.startsWith(" ") && !line.startsWith("\t")) {
+      current = undefined;
+    }
+  }
+  return families;
+}
+
+/** Effort rank for nearest-at-or-below resolution. */
+function effortRank(effort: DevinEffort | undefined): number {
+  return effort === undefined ? -1 : EFFORT_ORDER.indexOf(effort);
+}
+
+/**
+ * Pick the row a bare pi model resolves to: prefer `medium`, then a binary
+ * `thinking` row, then an unmarked row, then the first listed.
+ */
+function defaultRow(rows: DevinModelRow[]): DevinModelRow {
+  return (
+    rows.find((row) => row.effort === "medium") ??
+    rows.find((row) => row.thinking) ??
+    rows.find((row) => row.effort === undefined) ??
+    rows[0]
+  );
+}
+
+/** Split one family's rows into pi models keyed by (context variant, fast). */
+export function buildGroups(family: {
+  id: string;
+  name: string;
+  rows: DevinModelRow[];
+}): DevinModelGroup[] {
+  const byKey = new Map<string, DevinModelRow[]>();
+  for (const row of family.rows) {
+    const key = `${row.contextVariant ?? ""}|${row.fast ? "fast" : ""}`;
+    const group = byKey.get(key) ?? [];
+    group.push(row);
+    byKey.set(key, group);
+  }
+  const single = byKey.size === 1;
+  const groups: DevinModelGroup[] = [];
+  for (const rows of byKey.values()) {
+    const first = rows[0];
+    const suffix =
+      single || !first
+        ? ""
+        : `${first.contextVariant ? `-${first.contextVariant}` : ""}${first.fast ? "-fast" : ""}`;
+    const reasoning = rows.some((row) => row.thinking === true || row.effort !== undefined);
+    groups.push({
+      id: `${family.id}${suffix}`,
+      name: `${family.name}${suffix ? ` ${suffix.slice(1).replace(/-/g, " ")}` : ""}`.trim(),
+      contextWindow: first?.contextWindow ?? 0,
+      cost: first ? { ...first.cost } : { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      reasoning,
+      defaultRow: defaultRow(rows),
+      rows,
+    });
+  }
+  return groups;
+}
+
+/**
+ * Resolve a pi thinking level to the group's concrete devin model id.
+ * - undefined → the group's default row;
+ * - "off" → a `none` effort row, else an unmarked row, else the default;
+ * - an exact effort row wins, then the highest effort at or below the
+ *   request, then a binary `-thinking` row, then the default.
+ */
+export function resolveDevinModelRow(
+  group: DevinModelGroup,
+  level: ThinkingLevel | "off" | undefined,
+): DevinModelRow {
+  const rows = group.rows;
+  if (level === undefined) return group.defaultRow;
+  if (level === "off") {
+    return (
+      rows.find((row) => row.effort === "none") ??
+      rows.find((row) => row.effort === undefined && !row.thinking) ??
+      group.defaultRow
+    );
+  }
+  const wanted = level as DevinEffort;
+  const exact = rows.find((row) => row.effort === wanted);
+  if (exact) return exact;
+  const ranked = rows
+    .filter((row) => row.effort !== undefined)
+    .sort((a, b) => effortRank(b.effort) - effortRank(a.effort));
+  const atOrBelow = ranked.find((row) => effortRank(row.effort) <= effortRank(wanted));
+  if (atOrBelow) return atOrBelow;
+  const thinking = rows.find((row) => row.thinking);
+  if (thinking) return thinking;
+  return ranked[0] ?? group.defaultRow;
+}
+
+/** Pi model list metadata for one group (registration-time view). */
+export function groupThinkingLevelMap(
+  group: DevinModelGroup,
+): Partial<Record<ThinkingLevel | "off", string | null>> | undefined {
+  if (!group.reasoning) return undefined;
+  const map: Partial<Record<ThinkingLevel | "off", string | null>> = {};
+  for (const level of ["minimal", "low", "medium", "high", "xhigh", "max", "off"] as const) {
+    map[level] = resolveDevinModelRow(group, level).id;
+  }
+  return map;
+}
+
+/** Flatten families into the pi-registerable group list. */
+export function devinGroups(families: DevinModelFamily[]): DevinModelGroup[] {
+  return families.flatMap((family) => buildGroups(family));
+}
+
+/** Find a group by pi model id (family slug + variant suffix). */
+export function findDevinGroup(
+  families: DevinModelFamily[],
+  modelId: string,
+): DevinModelGroup | undefined {
+  return devinGroups(families).find((group) => group.id === modelId);
+}
+
+export const LIVE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+export const FALLBACK_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export function modelCacheTtlMs(source: "live" | "fallback" | undefined): number {
+  return source === "fallback" ? FALLBACK_CACHE_TTL_MS : LIVE_CACHE_TTL_MS;
+}

--- a/packages/pi-devin/lib/prompt.ts
+++ b/packages/pi-devin/lib/prompt.ts
@@ -1,0 +1,48 @@
+/**
+ * Model-facing text for the devin extension, kept separate from runtime
+ * logic per repo convention.
+ */
+
+/**
+ * Display-only wrapper tool that replays recorded devin tool results.
+ *
+ * Intentionally invisible to models: empty description, no parameter
+ * descriptions — it must not occupy the system prompt or the API tools
+ * payload. The provider synthesizes its toolCalls from ACP tool_call
+ * updates; execute() only replays stored output.
+ */
+export const WRAPPER_TOOL_NAME = "devin";
+export const WRAPPER_TOOL_DESCRIPTION = "";
+
+/** Replay text when a devin tool call ended without a terminal update. */
+export function devinIncompleteToolError(title: string): string {
+  return `devin did not report a result for "${title}". The tool may still have run server-side; verify before retrying.`;
+}
+
+/** `devin acp` has no system-role input; relay Pi instructions as a labeled resource. */
+export function piSystemInstructionsPrompt(instructions: string): string {
+  return [
+    "## Current Pi instructions",
+    "The following is Pi's current instruction snapshot, relayed as attached context because this ACP channel has no system-prompt role. It replaces any earlier Pi instruction snapshot in this session; your native system instructions still take precedence.",
+    "These instructions do not register tools. Use only the tools actually available to you, while respecting applicable project and user guidance.",
+    instructions ||
+      "Pi's instruction snapshot is now empty. Stop applying earlier relayed Pi instructions.",
+    "## End of Pi instructions",
+  ].join("\n\n");
+}
+
+/** Rehydrate a fresh devin session from the active branch of a pi session. */
+export function restoredPiContextPrompt(transcript: string): string {
+  return [
+    "## Restored pi conversation context",
+    "",
+    "This session continues the active pi history, including any work done with another provider, session resume, fork, or branch move. Treat the transcript below as prior conversation context, then answer the current user request that follows it.",
+    "",
+    transcript,
+    "",
+    "## Current user request",
+  ].join("\n");
+}
+
+export const HISTORY_RESOURCE_URI = "pi://session/history";
+export const INSTRUCTIONS_RESOURCE_URI = "pi://session/instructions";

--- a/packages/pi-devin/lib/render.ts
+++ b/packages/pi-devin/lib/render.ts
@@ -1,0 +1,52 @@
+/**
+ * Renderers for the display-only `devin` wrapper tool card.
+ */
+
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences } from "@earendil-works/pi-tui";
+import type { RecordedDevinTool } from "./replay.ts";
+import type { DevinToolView } from "./tool-content.ts";
+
+const MAX_FIELD = 160;
+
+function oneLine(value: string, maxLength = MAX_FIELD): string {
+  return stripTerminalSequences(value)
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+/** First card line for a tool_call as it starts streaming. */
+export function formatDevinCall(
+  view: Pick<DevinToolView, "title" | "kind"> & { summary?: string },
+  theme: Theme,
+): string {
+  const title = oneLine(view.title || view.kind || "tool call");
+  const summary = view.summary ? oneLine(view.summary, 100) : "";
+  return (
+    theme.fg("accent", "devin ") +
+    theme.fg("toolTitle", title) +
+    (summary ? theme.fg("dim", ` ${summary}`) : "")
+  );
+}
+
+/** Result line(s) for a completed tool card. */
+export function summarizeDevinResult(recorded: RecordedDevinTool): {
+  headline: string;
+  body?: string;
+} {
+  if (recorded.error) {
+    return { headline: recorded.error };
+  }
+  if (recorded.diff?.length) {
+    const lines = recorded.diff.map((part) => {
+      const added = part.newText?.split("\n").length ?? 0;
+      const removed = part.oldText?.split("\n").length ?? 0;
+      return `${part.path} (+${added}/-${removed})`;
+    });
+    const body = recorded.output;
+    return { headline: lines.join(", "), body };
+  }
+  return { headline: recorded.title, body: recorded.output };
+}

--- a/packages/pi-devin/lib/replay.ts
+++ b/packages/pi-devin/lib/replay.ts
@@ -1,0 +1,42 @@
+/**
+ * Replay store for display-only devin tool cards.
+ *
+ * The provider records each ACP tool_call's terminal state under the
+ * synthetic pi toolCall id before ending the assistant message; the
+ * registered `devin` wrapper tool looks the record up by id when pi
+ * "executes" the call. No tool work ever runs inside pi — results are
+ * recorded devin output.
+ */
+
+export interface RecordedDevinTool {
+  /** ACP kind: read/edit/execute/fetch/search/think/switch_mode/other. */
+  kind?: string;
+  /** Devin's human-readable tool title. */
+  title: string;
+  /** Devin-native tool name when exposed (`_meta` inferenceToolName). */
+  tool?: string;
+  /** Flattened result text for the card body. */
+  output?: string;
+  /** Diff content when the tool produced an edit. */
+  diff?: { path: string; oldText?: string; newText?: string }[];
+  error?: string;
+}
+
+export class DevinReplayStore {
+  #results = new Map<string, RecordedDevinTool>();
+
+  record(toolCallId: string, result: RecordedDevinTool): void {
+    this.#results.set(toolCallId, result);
+  }
+
+  /** Consume the recorded result for a tool call id. */
+  take(toolCallId: string): RecordedDevinTool | undefined {
+    const result = this.#results.get(toolCallId);
+    this.#results.delete(toolCallId);
+    return result;
+  }
+
+  get size(): number {
+    return this.#results.size;
+  }
+}

--- a/packages/pi-devin/lib/session-state.ts
+++ b/packages/pi-devin/lib/session-state.ts
@@ -1,0 +1,97 @@
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+
+export const DEVIN_SESSION_STATE_ENTRY = "pi-devin-session-state";
+
+export interface PersistedDevinSession {
+  version: 1;
+  kind: "session";
+  /** Owning pi session id — a fork gets a new id and cannot resume. */
+  sessionId: string;
+  /** Devin ACP session id. */
+  acpSessionId: string;
+  cwd: string;
+  /** Pi model id (family group) last used with this session. */
+  modelId: string;
+  turns: number;
+  /** Latest context occupancy (tokens) from usage_update. */
+  contextTokens?: number;
+}
+
+export interface PersistedDevinReset {
+  version: 1;
+  kind: "reset";
+  sessionId: string;
+  cwd: string;
+}
+
+export type PersistedDevinState = PersistedDevinSession | PersistedDevinReset;
+
+const CONTEXT_CHANGING_ENTRY_TYPES = new Set([
+  "message",
+  "model_change",
+  "compaction",
+  "branch_summary",
+  "custom_message",
+]);
+
+function isBoundedString(value: unknown, maxLength = 4_096): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= maxLength;
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+export function parsePersistedDevinState(value: unknown): PersistedDevinState | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (record.version !== 1 || !isBoundedString(record.sessionId, 256)) return undefined;
+  if (!isBoundedString(record.cwd)) return undefined;
+  if (record.kind === "reset") {
+    return { version: 1, kind: "reset", sessionId: record.sessionId, cwd: record.cwd };
+  }
+  if (record.kind !== "session") return undefined;
+  if (!isBoundedString(record.acpSessionId, 256)) return undefined;
+  if (!isBoundedString(record.modelId, 256)) return undefined;
+  if (!Number.isSafeInteger(record.turns) || (record.turns as number) < 0) return undefined;
+  if (record.contextTokens !== undefined && !isNonNegativeNumber(record.contextTokens)) {
+    return undefined;
+  }
+  return {
+    version: 1,
+    kind: "session",
+    sessionId: record.sessionId,
+    acpSessionId: record.acpSessionId,
+    cwd: record.cwd,
+    modelId: record.modelId,
+    turns: record.turns as number,
+    contextTokens: record.contextTokens as number | undefined,
+  };
+}
+
+/**
+ * Find an ACP session binding that exactly owns the active Pi branch.
+ * Mirrors pi-antigravity's conversation-state rules: the newest marker is
+ * authoritative, a reset/malformed marker ends the chain, and any
+ * context-changing entry after the marker makes it stale.
+ */
+export function restorableDevinSession(
+  branch: readonly SessionEntry[],
+  sessionId: string,
+  cwd: string,
+): PersistedDevinSession | undefined {
+  for (let index = branch.length - 1; index >= 0; index -= 1) {
+    const entry = branch[index];
+    if (entry.type !== "custom" || entry.customType !== DEVIN_SESSION_STATE_ENTRY) continue;
+    const state = parsePersistedDevinState(entry.data);
+    if (!state || state.kind === "reset") return undefined;
+    if (state.sessionId !== sessionId || state.cwd !== cwd) return undefined;
+    if (
+      branch.slice(index + 1).some((candidate) => CONTEXT_CHANGING_ENTRY_TYPES.has(candidate.type))
+    ) {
+      return undefined;
+    }
+    return state;
+  }
+  return undefined;
+}

--- a/packages/pi-devin/lib/tool-content.ts
+++ b/packages/pi-devin/lib/tool-content.ts
@@ -1,0 +1,119 @@
+/**
+ * Normalize ACP `tool_call` / `tool_call_update` payloads into a flat display
+ * shape for the replay store and the `devin` wrapper card renderer.
+ */
+
+import type { ToolCall, ToolCallContent, ToolCallUpdate } from "@agentclientprotocol/sdk";
+
+export interface DevinToolDiff {
+  path: string;
+  oldText?: string;
+  newText?: string;
+}
+
+export interface DevinToolView {
+  id: string;
+  /** Devin's human-readable title ("Wrote /tmp/x.txt"); absent on updates. */
+  title?: string;
+  /** ACP kind bucket: read/edit/execute/search/… */
+  kind?: string;
+  status?: string;
+  /** Devin-native tool name from `_meta["cognition.ai/inferenceToolName"]`. */
+  tool?: string;
+  /** Flattened text content for the card body. */
+  output?: string;
+  diff?: DevinToolDiff[];
+  locations?: string[];
+  rawInput?: unknown;
+}
+
+function metaToolName(meta: unknown): string | undefined {
+  if (typeof meta !== "object" || meta === null) return undefined;
+  const value = (meta as Record<string, unknown>)["cognition.ai/inferenceToolName"];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function contentToDisplay(content: ToolCallContent[] | null | undefined): {
+  output?: string;
+  diff?: DevinToolDiff[];
+} {
+  if (!Array.isArray(content) || content.length === 0) return {};
+  const texts: string[] = [];
+  const diff: DevinToolDiff[] = [];
+  for (const part of content) {
+    if (part.type === "content") {
+      const inner = part.content;
+      if (inner?.type === "text" && typeof inner.text === "string") {
+        texts.push(inner.text);
+      } else if (inner?.type === "resource" && "text" in inner.resource) {
+        texts.push(inner.resource.text);
+      }
+      continue;
+    }
+    if (part.type === "diff") {
+      diff.push({
+        path: part.path,
+        oldText: part.oldText ?? undefined,
+        newText: part.newText ?? undefined,
+      });
+    }
+    // terminal and unknown content kinds: nothing flat to display.
+  }
+  return {
+    output: texts.length ? texts.join("\n") : undefined,
+    diff: diff.length ? diff : undefined,
+  };
+}
+
+function locationPaths(locations: { path: string }[] | null | undefined): string[] | undefined {
+  if (!Array.isArray(locations) || locations.length === 0) return undefined;
+  const paths = locations
+    .map((location) => location.path)
+    .filter((path): path is string => typeof path === "string" && path.length > 0);
+  return paths.length ? paths : undefined;
+}
+
+/** Merge a tool_call start with its latest update into one view. */
+export function mergeDevinTool(
+  start: ToolCall | undefined,
+  update: ToolCall | ToolCallUpdate | undefined,
+): DevinToolView {
+  const merged = { ...(start ?? {}), ...(update ?? {}) } as ToolCall & ToolCallUpdate;
+  const { output, diff } = contentToDisplay(merged.content);
+  // Only include defined fields so view-level spreads (start → update) don't
+  // clobber a real value with an absent one.
+  const view: DevinToolView = { id: merged.toolCallId };
+  const title = merged.title ?? start?.title;
+  if (title !== undefined) view.title = title;
+  const kind = merged.kind ?? start?.kind ?? undefined;
+  if (kind !== undefined) view.kind = kind;
+  const status = merged.status ?? start?.status ?? undefined;
+  if (status !== undefined) view.status = status;
+  const tool = metaToolName(merged._meta) ?? metaToolName(start?._meta);
+  if (tool !== undefined) view.tool = tool;
+  if (output !== undefined) view.output = output;
+  if (diff !== undefined) view.diff = diff;
+  const locations = locationPaths(merged.locations ?? start?.locations);
+  if (locations !== undefined) view.locations = locations;
+  const rawInput = merged.rawInput ?? start?.rawInput;
+  if (rawInput !== undefined) view.rawInput = rawInput;
+  return view;
+}
+
+/** Small summary of args for the call card's first line. */
+export function summarizeDevinCall(view: DevinToolView): string {
+  const bits: string[] = [];
+  if (view.kind) bits.push(view.kind);
+  if (view.locations?.length) bits.push(view.locations.join(", "));
+  if (view.rawInput && typeof view.rawInput === "object") {
+    const input = view.rawInput as Record<string, unknown>;
+    for (const key of ["command", "cmd", "query", "pattern", "file_path", "path", "url"]) {
+      const value = input[key];
+      if (typeof value === "string" && value) {
+        bits.push(value.length > 80 ? `${value.slice(0, 77)}…` : value);
+        break;
+      }
+    }
+  }
+  return bits.join(" · ");
+}

--- a/packages/pi-devin/package.json
+++ b/packages/pi-devin/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@tian.zuo/pi-devin",
+  "version": "0.0.1",
+  "description": "Use Devin (devin acp) models inside the pi coding agent over the Agent Client Protocol, with pi as the UI.",
+  "type": "module",
+  "keywords": [
+    "pi",
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "devin",
+    "acp",
+    "agent-client-protocol",
+    "swe"
+  ],
+  "author": "Tian Zuo",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TianZuo555/pi-extensions.git",
+    "directory": "packages/pi-devin"
+  },
+  "homepage": "https://github.com/TianZuo555/pi-extensions#devin",
+  "bugs": {
+    "url": "https://github.com/TianZuo555/pi-extensions/issues"
+  },
+  "files": [
+    "index.ts",
+    "lib",
+    "src",
+    "CHANGELOG.md"
+  ],
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "scripts": {
+    "check": "tsc --noEmit -p .",
+    "test": "node --test --experimental-strip-types test/*.test.ts"
+  },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "1.4.0",
+    "effect": "4.0.0-beta.101",
+    "semver": "^7.8.5",
+    "which": "^7.0.0",
+    "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
+  },
+  "devDependencies": {
+    "@effect/language-service": "^0.87.2",
+    "@types/semver": "^7.8.0",
+    "@types/which": "^3.0.4",
+    "typescript": "^7.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/pi-devin/src/provider.ts
+++ b/packages/pi-devin/src/provider.ts
@@ -439,7 +439,6 @@ export function streamDevin(deps: DevinProviderDeps) {
                 textMessageId = activity.messageId;
                 stream.push({ type: "text_start", contentIndex: textIndex, partial: output });
               }
-              controller.recordEmittedText(activity.delta);
               textBuffer += activity.delta;
               const block = output.content[textIndex];
               if (block.type === "text") block.text = textBuffer;

--- a/packages/pi-devin/src/provider.ts
+++ b/packages/pi-devin/src/provider.ts
@@ -1,0 +1,592 @@
+/**
+ * streamSimple adapter — runs one devin ACP turn per pi request and
+ * translates session/update notifications into pi AssistantMessageEvents.
+ *
+ * `agent_message_chunk` streams into pi's text channel and
+ * `agent_thought_chunk` into thinking blocks, keyed by ACP messageId. ACP
+ * `tool_call` updates render as display-only tool cards: the provider
+ * records the terminal result in the replay store and ends the assistant
+ * message with stopReason "toolUse"; pi executes the `devin` wrapper tool,
+ * then re-invokes this adapter, which re-attaches to the still-running
+ * session/prompt via the runtime's turn controller.
+ */
+
+import {
+  calculateCost,
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type AssistantMessageEventStream,
+  type Context,
+  type Model,
+  type SimpleStreamOptions,
+} from "@earendil-works/pi-ai";
+import type { ContentBlock } from "@agentclientprotocol/sdk";
+import type { DevinRuntimeInstance, DevinRuntimeShape } from "./runtime.ts";
+import type { DevinActivity, DevinTurnController, DevinUsage } from "./turn.ts";
+import type { DevinReplayStore } from "../lib/replay.ts";
+import { devinIncompleteToolError } from "../lib/prompt.ts";
+import { summarizeDevinCall, type DevinToolView } from "../lib/tool-content.ts";
+import type { DevinModelFamily } from "../lib/models.ts";
+import { findDevinGroup, resolveDevinModelRow } from "../lib/models.ts";
+
+interface TextPart {
+  type: "text";
+  text: string;
+}
+
+interface ImagePart {
+  type: "image";
+  data?: unknown;
+  mimeType?: unknown;
+  [k: string]: unknown;
+}
+
+/**
+ * Preserve the latest contiguous user-message batch in order. Trailing
+ * assistant/tool messages are tool-loop re-entry, not new user input.
+ */
+function latestUserBatch(context: Context): {
+  start: number;
+  prompt: string;
+  images: ImagePart[];
+} {
+  for (let i = context.messages.length - 1; i >= 0; i--) {
+    if (context.messages[i].role !== "user") continue;
+    const end = i + 1;
+    while (i > 0 && context.messages[i - 1].role === "user") i--;
+    const texts: string[] = [];
+    const images: ImagePart[] = [];
+    for (const message of context.messages.slice(i, end)) {
+      if (typeof message.content === "string") {
+        if (message.content.trim()) texts.push(message.content);
+        continue;
+      }
+      const parts = Array.isArray(message.content) ? message.content : [];
+      for (const part of parts as (TextPart | ImagePart)[]) {
+        if (part?.type === "text" && typeof part.text === "string" && part.text.trim()) {
+          texts.push(part.text);
+        } else if (part?.type === "image") {
+          images.push(part);
+        }
+      }
+    }
+    if (texts.length === 0 && images.length === 0) continue;
+    return { start: i, prompt: texts.join("\n"), images };
+  }
+  return { start: -1, prompt: "", images: [] };
+}
+
+// A fresh devin session can safely receive roughly 60k transcript tokens
+// while leaving the working window room for system/tools and the response.
+const MAX_RESTORED_HISTORY_CHARS = 240_000;
+
+/** Serialize the active pi branch before its latest user request. */
+export function piHistoryBootstrap(context: Context): string | undefined {
+  const { start: latestUser } = latestUserBatch(context);
+  if (latestUser <= 0) return undefined;
+
+  const entries: string[] = [];
+  for (const raw of context.messages.slice(0, latestUser)) {
+    const message = raw as { role?: string; toolName?: string; content?: unknown };
+    const parts = Array.isArray(message.content) ? message.content : [];
+    const rendered: string[] =
+      typeof message.content === "string" && message.content.trim() ? [message.content] : [];
+    for (const part of parts as Array<Record<string, unknown>>) {
+      if (part?.type === "text" && typeof part.text === "string" && part.text.trim()) {
+        rendered.push(part.text);
+      } else if (part?.type === "toolCall" && typeof part.name === "string") {
+        const args = JSON.stringify(part.arguments ?? {});
+        rendered.push(`[tool call: ${part.name}${args === "{}" ? "" : ` ${args}`}]`);
+      } else if (part?.type === "thinking" && typeof part.thinking === "string") {
+        if (part.thinking.trim()) rendered.push(`[thinking: ${part.thinking.trim()}]`);
+      }
+    }
+    if (rendered.length === 0) continue;
+    const role =
+      message.role === "toolResult"
+        ? `tool ${message.toolName ?? "result"}`
+        : (message.role ?? "message");
+    entries.push(`${role}:\n${rendered.join("\n")}`);
+  }
+  if (entries.length === 0) return undefined;
+  const transcript = entries.join("\n\n");
+  return transcript.length <= MAX_RESTORED_HISTORY_CHARS
+    ? transcript
+    : `[Earlier history omitted]\n${transcript.slice(-MAX_RESTORED_HISTORY_CHARS)}`;
+}
+
+/**
+ * pi's compaction and branch summarization arrive as standalone requests
+ * whose only user message is `<conversation>\n…</conversation>`. They run in
+ * disposable ACP sessions so internal summary prompts never become user
+ * input in the real devin session.
+ */
+export function isSummarizationRequest(prompt: string): boolean {
+  return prompt.startsWith("<conversation>\n");
+}
+
+/** Map devin usage fields to pi usage fields. */
+export function mapUsage(u: DevinUsage | undefined): AssistantMessage["usage"] {
+  return {
+    input: u?.inputTokens ?? 0,
+    output: u?.outputTokens ?? 0,
+    reasoning: undefined,
+    cacheRead: u?.cachedReadTokens ?? 0,
+    cacheWrite: 0,
+    totalTokens: u?.contextUsed ?? (u?.inputTokens ?? 0) + (u?.outputTokens ?? 0),
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+/** ACP stopReason → pi terminal event kind. */
+const STOP_REASON_MAP: Record<string, "stop" | "length" | "aborted" | "error"> = {
+  end_turn: "stop",
+  max_tokens: "length",
+  cancelled: "aborted",
+  refusal: "error",
+  max_turn_requests: "error",
+};
+
+export interface DevinProviderDeps {
+  runtime: DevinRuntimeInstance;
+  service: DevinRuntimeShape;
+  replay: DevinReplayStore;
+  families: () => DevinModelFamily[];
+  cwd: () => string;
+  /** Model-facing surface for turn activity (e.g. widget updates). */
+  onActivity?: (activity: DevinActivity) => void;
+}
+
+export function streamDevin(deps: DevinProviderDeps) {
+  const { runtime, service, replay } = deps;
+
+  return (
+    model: Model<import("@earendil-works/pi-ai").Api>,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ): AssistantMessageEventStream => {
+    const stream = createAssistantMessageEventStream();
+
+    (async () => {
+      const output: AssistantMessage = {
+        role: "assistant",
+        content: [],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: mapUsage(undefined),
+        stopReason: "pending",
+        timestamp: Date.now(),
+      };
+
+      let turnCleared = false;
+      const clearTurn = () => {
+        if (turnCleared) return;
+        turnCleared = true;
+        void runtime.runPromise(service.finishTurn).catch(() => {});
+      };
+
+      const fail = (message: string) => {
+        output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+        output.errorMessage = message;
+        clearTurn();
+        stream.push({
+          type: "error",
+          reason: output.stopReason as "error" | "aborted",
+          error: output,
+        });
+        stream.end();
+      };
+
+      try {
+        stream.push({ type: "start", partial: output });
+
+        const { prompt, images } = latestUserBatch(context);
+        if (!prompt && images.length === 0) {
+          throw new Error("devin: no user content found in the request context.");
+        }
+
+        const summaryRequest = isSummarizationRequest(prompt);
+        if (summaryRequest) {
+          const result = await runtime.runPromise(
+            service.runSummaryTurn(prompt, options?.signal),
+            options?.signal ? { signal: options.signal } : undefined,
+          );
+          output.content.push({ type: "text", text: result.text });
+          stream.push({ type: "text_start", contentIndex: 0, partial: output });
+          stream.push({
+            type: "text_delta",
+            contentIndex: 0,
+            delta: result.text,
+            partial: output,
+          });
+          stream.push({
+            type: "text_end",
+            contentIndex: 0,
+            content: result.text,
+            partial: output,
+          });
+          output.stopReason = "stop";
+          stream.push({ type: "done", reason: "stop", message: output });
+          clearTurn();
+          stream.end();
+          return;
+        }
+
+        const group = findDevinGroup(deps.families(), model.id);
+        const concreteModelId = group
+          ? resolveDevinModelRow(group, options?.reasoning).id
+          : model.id;
+
+        const blocks: ContentBlock[] = images
+          .filter(
+            (image): image is ImagePart & { data: string; mimeType: string } =>
+              typeof image.data === "string" && typeof image.mimeType === "string",
+          )
+          .map((image) => ({
+            type: "image" as const,
+            data: image.data,
+            mimeType: image.mimeType,
+          }));
+        blocks.push({ type: "text", text: prompt });
+
+        const controller: DevinTurnController = await runtime.runPromise(
+          service.beginStreamTurn({
+            prompt,
+            blocks,
+            modelId: model.id,
+            concreteModelId,
+            cwd: deps.cwd(),
+            systemPrompt: context.systemPrompt ?? undefined,
+            historyBootstrap: piHistoryBootstrap(context),
+            signal: options?.signal,
+          }),
+        );
+
+        let usage: DevinUsage | undefined = controller.lastUsage;
+        let textIndex: number | null = null;
+        let textBuffer = "";
+        let textMessageId: string | undefined;
+        let thinkingIndex: number | null = null;
+        let thinkingBuffer = "";
+        let thinkingMessageId: string | undefined;
+        let replayCallSeq = 0;
+        const pendingTools = new Map<string, { id: string; index: number }>();
+
+        const closeThinking = () => {
+          if (thinkingIndex === null) return;
+          stream.push({
+            type: "thinking_end",
+            contentIndex: thinkingIndex,
+            content: thinkingBuffer,
+            partial: output,
+          });
+          thinkingIndex = null;
+          thinkingBuffer = "";
+          thinkingMessageId = undefined;
+        };
+
+        const closeText = () => {
+          if (textIndex === null) return;
+          stream.push({
+            type: "text_end",
+            contentIndex: textIndex,
+            content: textBuffer,
+            partial: output,
+          });
+          textIndex = null;
+          textBuffer = "";
+          textMessageId = undefined;
+        };
+
+        const attachUsage = (u: DevinUsage | undefined) => {
+          output.usage = mapUsage(u);
+          calculateCost(model, output.usage);
+        };
+
+        const endWithToolUse = () => {
+          closeThinking();
+          closeText();
+          attachUsage(usage);
+          output.stopReason = "toolUse";
+          stream.push({ type: "done", reason: "toolUse", message: output });
+          stream.end();
+        };
+
+        /** Emit a pending card for a just-started devin tool call. */
+        const emitToolStart = (view: DevinToolView): void => {
+          closeText();
+          closeThinking();
+          const id = `devin-replay-${++replayCallSeq}`;
+          const toolCall = {
+            type: "toolCall" as const,
+            id,
+            name: "devin",
+            arguments: {
+              tool: view.tool ?? view.title ?? "tool",
+              title: view.title ?? "tool call",
+              kind: view.kind,
+              summary: summarizeDevinCall(view),
+            },
+          };
+          output.content.push(toolCall);
+          const index = output.content.length - 1;
+          pendingTools.set(view.id, { id, index });
+          stream.push({ type: "toolcall_start", contentIndex: index, partial: output });
+        };
+
+        /** Close a tool card and record its replayed result. */
+        const emitToolEnd = (view: DevinToolView): void => {
+          const pending = pendingTools.get(view.id);
+          const id = pending?.id ?? `devin-replay-${++replayCallSeq}`;
+          replay.record(id, {
+            title: view.title ?? "tool call",
+            kind: view.kind,
+            tool: view.tool,
+            output: view.output,
+            diff: view.diff,
+            error: view.status === "failed" ? (view.output ?? "tool call failed") : undefined,
+          });
+          const toolCall = {
+            type: "toolCall" as const,
+            id,
+            name: "devin",
+            arguments: {
+              tool: view.tool ?? view.title ?? "tool",
+              title: view.title ?? "tool call",
+              kind: view.kind,
+              summary: summarizeDevinCall(view),
+            },
+          };
+          const index = pending?.index ?? output.content.length;
+          if (!pending) {
+            output.content.push(toolCall);
+            stream.push({ type: "toolcall_start", contentIndex: index, partial: output });
+          }
+          stream.push({ type: "toolcall_end", contentIndex: index, toolCall, partial: output });
+          pendingTools.delete(view.id);
+        };
+
+        /**
+         * Tool calls that never reached a terminal status get failed replay
+         * cards so pi's toolUse loop stays consistent.
+         */
+        const sweepIncompleteTools = (): number => {
+          const incomplete = controller.takeIncompleteTools();
+          for (const view of incomplete) {
+            const pending = pendingTools.get(view.id);
+            const id = pending?.id ?? `devin-replay-${++replayCallSeq}`;
+            replay.record(id, {
+              title: view.title ?? "tool call",
+              kind: view.kind,
+              tool: view.tool,
+              error: devinIncompleteToolError(view.title ?? "tool call"),
+            });
+            const index = pending?.index ?? output.content.length;
+            const toolCall = pending
+              ? output.content[index]
+              : {
+                  type: "toolCall" as const,
+                  id,
+                  name: "devin",
+                  arguments: { tool: view.tool ?? view.title ?? "tool", title: view.title },
+                };
+            if (!pending) {
+              output.content.push(toolCall as never);
+              stream.push({ type: "toolcall_start", contentIndex: index, partial: output });
+            }
+            stream.push({
+              type: "toolcall_end",
+              contentIndex: index,
+              toolCall: toolCall as never,
+              partial: output,
+            });
+            pendingTools.delete(view.id);
+          }
+          return incomplete.length;
+        };
+
+        while (true) {
+          const activity = await controller.next();
+          if (activity === null) {
+            if (sweepIncompleteTools() > 0) {
+              // Defer an error result so the re-entry after pi's replay
+              // toolUse terminates this turn instead of re-prompting.
+              controller.deferResult({
+                type: "result",
+                stopReason: "interrupted",
+              });
+              endWithToolUse();
+              return;
+            }
+            throw new Error("devin turn ended without a result.");
+          }
+
+          try {
+            deps.onActivity?.(activity);
+          } catch {
+            // UI side channels are best-effort and never fail the turn.
+          }
+
+          switch (activity.type) {
+            case "text": {
+              if (textIndex === null || activity.messageId !== textMessageId) {
+                closeText();
+                closeThinking();
+                output.content.push({ type: "text", text: "" });
+                textIndex = output.content.length - 1;
+                textBuffer = "";
+                textMessageId = activity.messageId;
+                stream.push({ type: "text_start", contentIndex: textIndex, partial: output });
+              }
+              controller.recordEmittedText(activity.delta);
+              textBuffer += activity.delta;
+              const block = output.content[textIndex];
+              if (block.type === "text") block.text = textBuffer;
+              stream.push({
+                type: "text_delta",
+                contentIndex: textIndex,
+                delta: activity.delta,
+                partial: output,
+              });
+              break;
+            }
+            case "thought": {
+              if (thinkingIndex === null || activity.messageId !== thinkingMessageId) {
+                closeThinking();
+                output.content.push({ type: "thinking", thinking: "" });
+                thinkingIndex = output.content.length - 1;
+                thinkingBuffer = "";
+                thinkingMessageId = activity.messageId;
+                stream.push({
+                  type: "thinking_start",
+                  contentIndex: thinkingIndex,
+                  partial: output,
+                });
+              }
+              thinkingBuffer += activity.delta;
+              const block = output.content[thinkingIndex];
+              if (block.type === "thinking") block.thinking = thinkingBuffer;
+              stream.push({
+                type: "thinking_delta",
+                contentIndex: thinkingIndex,
+                delta: activity.delta,
+                partial: output,
+              });
+              break;
+            }
+            case "tool_start":
+              emitToolStart(activity.view);
+              break;
+            case "tool_update": {
+              const pending = pendingTools.get(activity.view.id);
+              if (pending) {
+                emitToolEnd(activity.view);
+              }
+              // Terminal updates for tools pi never saw started still get a card.
+              if (
+                !pending &&
+                (activity.view.status === "completed" || activity.view.status === "failed")
+              ) {
+                emitToolEnd(activity.view);
+              }
+              if (
+                pendingTools.size === 0 &&
+                (activity.view.status === "completed" || activity.view.status === "failed")
+              ) {
+                endWithToolUse();
+                return;
+              }
+              break;
+            }
+            case "plan": {
+              closeText();
+              closeThinking();
+              const lines = activity.entries
+                .map(
+                  (entry) =>
+                    `  ${entry.status === "completed" ? "☑" : entry.status === "in_progress" ? "◐" : "☐"} ${entry.content}`,
+                )
+                .join("\n");
+              output.content.push({ type: "thinking", thinking: `Plan\n${lines}` });
+              const index = output.content.length - 1;
+              stream.push({ type: "thinking_start", contentIndex: index, partial: output });
+              stream.push({
+                type: "thinking_delta",
+                contentIndex: index,
+                delta: `Plan\n${lines}`,
+                partial: output,
+              });
+              stream.push({
+                type: "thinking_end",
+                contentIndex: index,
+                content: `Plan\n${lines}`,
+                partial: output,
+              });
+              break;
+            }
+            case "compaction": {
+              closeText();
+              closeThinking();
+              output.content.push({ type: "thinking", thinking: "devin compacted context" });
+              const index = output.content.length - 1;
+              stream.push({ type: "thinking_start", contentIndex: index, partial: output });
+              stream.push({
+                type: "thinking_delta",
+                contentIndex: index,
+                delta: "devin compacted context",
+                partial: output,
+              });
+              stream.push({
+                type: "thinking_end",
+                contentIndex: index,
+                content: "devin compacted context",
+                partial: output,
+              });
+              break;
+            }
+            case "usage":
+              usage = { ...usage, ...activity.usage };
+              controller.lastUsage = usage;
+              break;
+            case "stopped":
+            case "mode":
+            case "config":
+            case "title":
+            case "commands":
+              break;
+            case "result": {
+              if (sweepIncompleteTools() > 0) {
+                controller.deferResult(activity);
+                endWithToolUse();
+                return;
+              }
+              closeText();
+              closeThinking();
+              attachUsage(usage);
+
+              const reason = STOP_REASON_MAP[activity.stopReason] ?? "error";
+              if (reason === "stop" || reason === "length") {
+                output.stopReason = reason;
+                stream.push({ type: "done", reason, message: output });
+              } else {
+                output.stopReason = reason;
+                if (reason === "error") {
+                  output.errorMessage = `devin ended the turn with stopReason "${activity.stopReason}".`;
+                }
+                stream.push({ type: "error", reason, error: output });
+              }
+              clearTurn();
+              stream.end();
+              return;
+            }
+          }
+        }
+      } catch (error) {
+        fail(error instanceof Error ? error.message : String(error));
+      }
+    })();
+
+    return stream;
+  };
+}

--- a/packages/pi-devin/src/provider.ts
+++ b/packages/pi-devin/src/provider.ts
@@ -147,6 +147,21 @@ const STOP_REASON_MAP: Record<string, "stop" | "length" | "aborted" | "error"> =
   max_turn_requests: "error",
 };
 
+/**
+ * Merge usage snapshots. Update payloads omit fields they do not carry, and
+ * those omissions must not clobber values an earlier update established.
+ */
+export function mergeDevinUsage(
+  base: DevinUsage | undefined,
+  next: DevinUsage | undefined,
+): DevinUsage {
+  const merged: DevinUsage = { ...(base ?? {}) };
+  for (const [key, value] of Object.entries(next ?? {})) {
+    if (value !== undefined) merged[key as keyof DevinUsage] = value;
+  }
+  return merged;
+}
+
 export interface DevinProviderDeps {
   runtime: DevinRuntimeInstance;
   service: DevinRuntimeShape;
@@ -478,21 +493,14 @@ export function streamDevin(deps: DevinProviderDeps) {
               emitToolStart(activity.view);
               break;
             case "tool_update": {
-              const pending = pendingTools.get(activity.view.id);
-              if (pending) {
-                emitToolEnd(activity.view);
-              }
-              // Terminal updates for tools pi never saw started still get a card.
-              if (
-                !pending &&
-                (activity.view.status === "completed" || activity.view.status === "failed")
-              ) {
-                emitToolEnd(activity.view);
-              }
-              if (
-                pendingTools.size === 0 &&
-                (activity.view.status === "completed" || activity.view.status === "failed")
-              ) {
+              // Progress-only updates keep the card pending; the controller
+              // merges the view so the terminal update renders the full
+              // picture without duplicate cards.
+              const terminal =
+                activity.view.status === "completed" || activity.view.status === "failed";
+              if (!terminal) break;
+              emitToolEnd(activity.view);
+              if (pendingTools.size === 0) {
                 endWithToolUse();
                 return;
               }
@@ -545,7 +553,7 @@ export function streamDevin(deps: DevinProviderDeps) {
               break;
             }
             case "usage":
-              usage = { ...usage, ...activity.usage };
+              usage = mergeDevinUsage(usage, activity.usage);
               controller.lastUsage = usage;
               break;
             case "stopped":
@@ -562,6 +570,10 @@ export function streamDevin(deps: DevinProviderDeps) {
               }
               closeText();
               closeThinking();
+              // The prompt response carries the canonical turn usage; merge
+              // it over whatever usage_update reported during streaming.
+              usage = mergeDevinUsage(usage, activity.usage);
+              controller.lastUsage = usage;
               attachUsage(usage);
 
               const reason = STOP_REASON_MAP[activity.stopReason] ?? "error";

--- a/packages/pi-devin/src/runtime.ts
+++ b/packages/pi-devin/src/runtime.ts
@@ -1,0 +1,625 @@
+/**
+ * DevinRuntime — Effect service owning the `devin acp` child process, the
+ * pi-session ↔ ACP-session binding, and turn execution.
+ *
+ * Continuity policy: devin owns authoritative session history server-side
+ * (`session/load` resumes a persisted session), so the binding is reused
+ * across turns and dropped only on /devin reset, a pi branch move, or a
+ * failed load.
+ */
+
+import { Context, Data, Effect, Layer, ManagedRuntime, Exit, Cause, Result } from "effect";
+import type { ContentBlock } from "@agentclientprotocol/sdk";
+import type { DevinAcpClient, DevinConfigOption, DevinListSessionInfo } from "../lib/acp-client.ts";
+import {
+  HISTORY_RESOURCE_URI,
+  INSTRUCTIONS_RESOURCE_URI,
+  piSystemInstructionsPrompt,
+  restoredPiContextPrompt,
+} from "../lib/prompt.ts";
+import { acpUpdateToActivities, agentStoppedToActivity } from "./updates.ts";
+import { DevinTurnController, type DevinTurnStats } from "./turn.ts";
+
+export class DevinRuntimeClosedError extends Data.TaggedError("DevinRuntimeClosedError")<{
+  readonly message: string;
+}> {}
+
+export class DevinSessionError extends Data.TaggedError("DevinSessionError")<{
+  readonly message: string;
+}> {}
+
+export type DevinRuntimeError = DevinRuntimeClosedError | DevinSessionError;
+
+export interface DevinSessionBindingState {
+  acpSessionId: string;
+  cwd: string;
+  modelId: string;
+  turns: number;
+  contextTokens?: number;
+}
+
+export interface DevinStateSnapshot {
+  sessionId: string | undefined;
+  title: string | undefined;
+  model: string | undefined;
+  /** Concrete devin model id synced into the ACP session. */
+  concreteModel: string | undefined;
+  modeId: string | undefined;
+  cwd: string | undefined;
+  turns: number;
+  contextTokens: number | undefined;
+  contextSize: number | undefined;
+  configOptions: DevinConfigOption[] | undefined;
+  availableCommands: { name: string; description?: string; hint?: string }[] | undefined;
+  lastTurnStats: DevinTurnStats | undefined;
+  client: { pid?: number; spawned: number; requestsSent: number; notificationsReceived: number };
+}
+
+export interface DevinTurnRequest {
+  /** Base user prompt text (used for re-attach matching). */
+  readonly prompt: string;
+  /** Full ACP content blocks for the prompt (text + images + bootstrap). */
+  readonly blocks: ContentBlock[];
+  /** Pi model id (group) this turn is for. */
+  readonly modelId: string;
+  /** Concrete devin model id resolved from the group + thinking level. */
+  readonly concreteModelId: string;
+  readonly cwd: string;
+  readonly systemPrompt?: string;
+  /** Serialized pi history, sent only when the session needs bootstrapping. */
+  readonly historyBootstrap?: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface DevinSummaryResult {
+  text: string;
+}
+
+export interface DevinRuntimeShape {
+  /** Point the runtime at a cwd; a changed cwd drops the session binding. */
+  readonly setSession: (
+    cwd: string,
+    opts?: { rebootstrap?: boolean },
+  ) => Effect.Effect<void, DevinRuntimeClosedError>;
+  /** Mark a persisted ACP session for lazy `session/load` on the next turn. */
+  readonly restoreSession: (
+    state: DevinSessionBindingState,
+  ) => Effect.Effect<void, DevinRuntimeClosedError>;
+  /** Start a devin turn or re-attach to the still-running one. */
+  readonly beginStreamTurn: (
+    request: DevinTurnRequest,
+  ) => Effect.Effect<DevinTurnController, DevinRuntimeClosedError | DevinSessionError>;
+  readonly finishTurn: Effect.Effect<void>;
+  /** Run a standalone prompt in a throwaway ACP session (pi summaries). */
+  readonly runSummaryTurn: (
+    prompt: string,
+    signal?: AbortSignal,
+  ) => Effect.Effect<DevinSummaryResult, DevinRuntimeClosedError | DevinSessionError>;
+  /** Set the desired devin session mode (ask/plan/accept-edits/bypass). */
+  readonly setMode: (
+    modeId: string,
+  ) => Effect.Effect<void, DevinRuntimeClosedError | DevinSessionError>;
+  readonly reset: Effect.Effect<void, DevinRuntimeClosedError>;
+  readonly snapshot: Effect.Effect<DevinStateSnapshot, DevinRuntimeClosedError>;
+  readonly listSessions: Effect.Effect<
+    DevinListSessionInfo[],
+    DevinRuntimeClosedError | DevinSessionError
+  >;
+  readonly deleteSession: (
+    sessionId: string,
+  ) => Effect.Effect<void, DevinRuntimeClosedError | DevinSessionError>;
+  readonly authenticate: (
+    methodId: string,
+  ) => Effect.Effect<void, DevinRuntimeClosedError | DevinSessionError>;
+  readonly close: Effect.Effect<void, DevinRuntimeClosedError>;
+}
+
+export class DevinRuntime extends Context.Service<DevinRuntime, DevinRuntimeShape>()(
+  "pi-devin/DevinRuntime",
+) {}
+
+export type DevinClientFactory = () => DevinAcpClient;
+
+const makeRuntime = (createClient: DevinClientFactory) =>
+  Effect.gen(function* () {
+    let client: DevinAcpClient | undefined;
+    let sessionId: string | undefined;
+    let sessionCwd: string | undefined;
+    let model: string | undefined;
+    let modeId: string | undefined;
+    let desiredModeId: string | undefined;
+    let title: string | undefined;
+    let turns = 0;
+    let contextTokens: number | undefined;
+    let contextSize: number | undefined;
+    let configOptions: DevinConfigOption[] | undefined;
+    let availableCommands: DevinStateSnapshot["availableCommands"];
+    let lastTurnStats: DevinTurnStats | undefined;
+    /** Concrete devin model id the live session was last synced to. */
+    let syncedModelId: string | undefined;
+    /** Session marked for lazy load on the next turn. */
+    let pendingLoadId: string | undefined;
+    let needsBootstrap = false;
+    let lastSentSystemPrompt: string | undefined;
+    let closed = false;
+    let active: DevinTurnController | undefined;
+    let activeAbort: AbortController | undefined;
+    let generation = 0;
+
+    const ensureClient = (): DevinAcpClient => {
+      if (!client) {
+        client = createClient();
+        client.setOnClose(() => {
+          const turn = active;
+          active = undefined;
+          turn?.fail(new Error("devin acp process exited."));
+          client = undefined;
+          sessionId = undefined;
+          syncedModelId = undefined;
+        });
+        client.setCustomNotificationHandler((method, params) => {
+          if (method !== "_cognition.ai/agent_stopped") return;
+          const activity = agentStoppedToActivity(params);
+          if (activity?.type !== "stopped") return;
+          lastTurnStats = activity.stats;
+          active?.push(activity);
+        });
+      }
+      return client;
+    };
+
+    const invalidateActiveTurn = () => {
+      generation += 1;
+      activeAbort?.abort();
+      activeAbort = undefined;
+      if (active) {
+        const turn = active;
+        active = undefined;
+        turn.fail(new Error("devin turn was superseded."));
+      }
+    };
+
+    const dropSession = (bootstrap: boolean) => {
+      invalidateActiveTurn();
+      if (sessionId && client) {
+        const id = sessionId;
+        client.setSessionListener(id, undefined);
+      }
+      sessionId = undefined;
+      sessionCwd = undefined;
+      syncedModelId = undefined;
+      pendingLoadId = undefined;
+      turns = 0;
+      contextTokens = undefined;
+      contextSize = undefined;
+      title = undefined;
+      configOptions = undefined;
+      needsBootstrap = bootstrap;
+      lastSentSystemPrompt = undefined;
+    };
+
+    const ensureOpen: Effect.Effect<void, DevinRuntimeClosedError> = Effect.suspend(() =>
+      closed
+        ? Effect.fail(new DevinRuntimeClosedError({ message: "devin runtime is shut down." }))
+        : Effect.void,
+    );
+
+    const failSession = (error: unknown): DevinSessionError =>
+      new DevinSessionError({
+        message: error instanceof Error ? error.message : String(error),
+      });
+
+    /**
+     * Apply state-only updates (mode/config/title/commands/usage) arriving
+     * outside a turn — including the tail of a session/load replay.
+     */
+    const applyStateUpdate = (activities: ReturnType<typeof acpUpdateToActivities>) => {
+      for (const activity of activities) {
+        if (activity.type === "mode") modeId = activity.modeId;
+        else if (activity.type === "config") configOptions = activity.options;
+        else if (activity.type === "title") title = activity.title;
+        else if (activity.type === "commands") availableCommands = activity.commands;
+        else if (activity.type === "usage") {
+          contextTokens = activity.usage.contextUsed ?? contextTokens;
+          contextSize = activity.usage.contextSize ?? contextSize;
+        }
+      }
+    };
+
+    /** Wire a live controller to a session's update stream. */
+    const attachSessionListener = (id: string, controller: DevinTurnController) => {
+      ensureClient().setSessionListener(id, (update) => {
+        const activities = acpUpdateToActivities(update);
+        applyStateUpdate(activities);
+        for (const activity of activities) controller.push(activity);
+      });
+    };
+
+    /**
+     * Ensure a live ACP session for the current cwd. Loads the pending
+     * persisted session when marked; falls back to session/new when the load
+     * reports a missing session. The session listener must already be wired
+     * to the turn controller so replayed state updates are captured.
+     */
+    const ensureSession = async (cwd: string, controller: DevinTurnController): Promise<string> => {
+      const acp = ensureClient();
+      await acp.ensureStarted();
+      if (sessionId && sessionCwd === cwd && !pendingLoadId) {
+        // Re-point the session listener at this turn's controller — the
+        // previous turn's controller is closed.
+        attachSessionListener(sessionId, controller);
+        return sessionId;
+      }
+      if (sessionId && sessionCwd !== cwd) dropSession(true);
+      if (pendingLoadId) {
+        const loadId = pendingLoadId;
+        sessionId = loadId;
+        sessionCwd = cwd;
+        attachSessionListener(loadId, controller);
+        try {
+          await acp.loadSession(loadId, cwd);
+          return loadId;
+        } catch {
+          acp.setSessionListener(loadId, undefined);
+          sessionId = undefined;
+          syncedModelId = undefined;
+          needsBootstrap = true;
+          lastSentSystemPrompt = undefined;
+        } finally {
+          pendingLoadId = undefined;
+        }
+      }
+      const created = await acp.newSession(cwd);
+      sessionId = created.sessionId;
+      sessionCwd = cwd;
+      modeId = created.modes?.currentModeId ?? modeId;
+      configOptions = created.configOptions ?? configOptions;
+      attachSessionListener(created.sessionId, controller);
+      return created.sessionId;
+    };
+
+    const syncConfig = async (id: string, concreteModelId: string): Promise<void> => {
+      const acp = ensureClient();
+      if (desiredModeId && desiredModeId !== modeId) {
+        await acp.setMode(id, desiredModeId);
+        modeId = desiredModeId;
+      }
+      if (concreteModelId && syncedModelId !== concreteModelId) {
+        await acp.setConfigOption(id, "model", concreteModelId);
+        syncedModelId = concreteModelId;
+      }
+    };
+
+    return DevinRuntime.of({
+      setSession: (cwd, opts) =>
+        ensureOpen.pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              const cwdChanged = sessionCwd !== undefined && sessionCwd !== cwd;
+              if (opts?.rebootstrap || cwdChanged) {
+                dropSession(true);
+              }
+              if (!sessionCwd) sessionCwd = cwd;
+            }),
+          ),
+        ),
+
+      restoreSession: (state) =>
+        ensureOpen.pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              invalidateActiveTurn();
+              sessionId = state.acpSessionId;
+              sessionCwd = state.cwd;
+              model = state.modelId;
+              turns = state.turns;
+              contextTokens = state.contextTokens;
+              pendingLoadId = state.acpSessionId;
+              needsBootstrap = false;
+              lastSentSystemPrompt = undefined;
+              syncedModelId = undefined;
+            }),
+          ),
+        ),
+
+      beginStreamTurn: (request) =>
+        ensureOpen.pipe(
+          Effect.andThen(
+            Effect.tryPromise({
+              try: async () => {
+                if (
+                  active &&
+                  active.prompt === request.prompt &&
+                  (!active.isClosed() || active.hasPending())
+                ) {
+                  return active;
+                }
+                if (active) invalidateActiveTurn();
+
+                const acp = ensureClient();
+                await acp.ensureStarted();
+                const controller = new DevinTurnController(request.prompt, "");
+                const liveSessionId = await ensureSession(request.cwd, controller);
+                controller.sessionId = liveSessionId;
+                await syncConfig(liveSessionId, request.concreteModelId);
+
+                model = request.modelId;
+
+                const turnAbort = new AbortController();
+                activeAbort = turnAbort;
+                const turnGeneration = generation;
+                if (request.signal) {
+                  if (request.signal.aborted) turnAbort.abort();
+                  else
+                    request.signal.addEventListener("abort", () => turnAbort.abort(), {
+                      once: true,
+                    });
+                }
+
+                // Compose prompt blocks: bootstrap resources on fresh
+                // sessions, an instruction snapshot when pi's system prompt
+                // changed, then the request's content blocks.
+                const blocks: ContentBlock[] = [];
+                if (needsBootstrap && request.historyBootstrap) {
+                  blocks.push({
+                    type: "resource",
+                    resource: {
+                      uri: HISTORY_RESOURCE_URI,
+                      mimeType: "text/plain",
+                      text: restoredPiContextPrompt(request.historyBootstrap),
+                    },
+                  });
+                }
+                if (
+                  request.systemPrompt !== undefined &&
+                  request.systemPrompt !== lastSentSystemPrompt
+                ) {
+                  blocks.push({
+                    type: "resource",
+                    resource: {
+                      uri: INSTRUCTIONS_RESOURCE_URI,
+                      mimeType: "text/plain",
+                      text: piSystemInstructionsPrompt(request.systemPrompt),
+                    },
+                  });
+                  lastSentSystemPrompt = request.systemPrompt;
+                }
+                blocks.push(...request.blocks);
+                needsBootstrap = false;
+
+                const cancelled = new Promise<never>((_resolve, reject) => {
+                  turnAbort.signal.addEventListener(
+                    "abort",
+                    () => reject(new Error("devin turn was aborted.")),
+                    { once: true },
+                  );
+                  if (turnAbort.signal.aborted) {
+                    reject(new Error("devin turn was aborted."));
+                  }
+                });
+
+                const promptPromise = acp.prompt(liveSessionId, blocks);
+                void Promise.race([promptPromise, cancelled])
+                  .then((result) => {
+                    if (turnGeneration !== generation) {
+                      controller.close();
+                      return;
+                    }
+                    turns += 1;
+                    controller.push({
+                      type: "result",
+                      stopReason: result.stopReason ?? "end_turn",
+                      usage: {
+                        inputTokens: result.usage?.inputTokens,
+                        outputTokens: result.usage?.outputTokens,
+                      },
+                    });
+                    controller.close();
+                  })
+                  .catch((cause: unknown) => {
+                    if (turnGeneration !== generation) {
+                      controller.close();
+                      return;
+                    }
+                    controller.fail(cause instanceof Error ? cause : new Error(String(cause)));
+                  });
+
+                turnAbort.signal.addEventListener(
+                  "abort",
+                  () => {
+                    void acp.cancel(liveSessionId).catch(() => {});
+                  },
+                  { once: true },
+                );
+
+                active = controller;
+                return controller;
+              },
+              catch: (error) => failSession(error),
+            }),
+          ),
+        ),
+
+      finishTurn: Effect.sync(() => {
+        if (active?.isClosed()) active = undefined;
+      }),
+
+      runSummaryTurn: (prompt, signal) =>
+        ensureOpen.pipe(
+          Effect.andThen(
+            Effect.tryPromise({
+              try: async () => {
+                const acp = ensureClient();
+                await acp.ensureStarted();
+                const created = await acp.newSession(sessionCwd ?? process.cwd());
+                const collected: string[] = [];
+                acp.setSessionListener(created.sessionId, (update) => {
+                  for (const activity of acpUpdateToActivities(update)) {
+                    if (activity.type === "text") collected.push(activity.delta);
+                  }
+                });
+                try {
+                  const abort = new AbortController();
+                  const onAbort = () => {
+                    abort.abort();
+                    void acp.cancel(created.sessionId).catch(() => {});
+                  };
+                  signal?.addEventListener("abort", onAbort, { once: true });
+                  try {
+                    await Promise.race([
+                      acp.prompt(created.sessionId, [{ type: "text", text: prompt }]),
+                      new Promise<never>((_r, reject) =>
+                        abort.signal.addEventListener(
+                          "abort",
+                          () => reject(new Error("devin summary turn aborted.")),
+                          { once: true },
+                        ),
+                      ),
+                    ]);
+                  } finally {
+                    signal?.removeEventListener("abort", onAbort);
+                  }
+                } finally {
+                  acp.setSessionListener(created.sessionId, undefined);
+                  void acp.deleteSession(created.sessionId).catch(() => {});
+                }
+                return { text: collected.join("") };
+              },
+              catch: (error) => failSession(error),
+            }),
+          ),
+        ),
+
+      setMode: (next) =>
+        ensureOpen.pipe(
+          Effect.andThen(
+            Effect.tryPromise({
+              try: async () => {
+                desiredModeId = next;
+                if (sessionId && !pendingLoadId) {
+                  await ensureClient().setMode(sessionId, next);
+                  modeId = next;
+                }
+              },
+              catch: (error) => failSession(error),
+            }),
+          ),
+        ),
+
+      reset: ensureOpen.pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            desiredModeId = undefined;
+            dropSession(false);
+          }),
+        ),
+      ),
+
+      snapshot: Effect.suspend(() =>
+        ensureOpen.pipe(
+          Effect.map(() => ({
+            sessionId,
+            title,
+            model,
+            concreteModel: syncedModelId,
+            modeId,
+            cwd: sessionCwd,
+            turns,
+            contextTokens,
+            contextSize,
+            configOptions,
+            availableCommands,
+            lastTurnStats,
+            client: client?.stats ?? {
+              spawned: 0,
+              requestsSent: 0,
+              notificationsReceived: 0,
+            },
+          })),
+        ),
+      ),
+
+      listSessions: ensureOpen.pipe(
+        Effect.andThen(
+          Effect.tryPromise({
+            try: async () => {
+              const acp = ensureClient();
+              await acp.ensureStarted();
+              return await acp.listSessions();
+            },
+            catch: (error) => failSession(error),
+          }),
+        ),
+      ),
+
+      deleteSession: (id) =>
+        ensureOpen.pipe(
+          Effect.andThen(
+            Effect.tryPromise({
+              try: async () => {
+                await ensureClient().deleteSession(id);
+                if (id === sessionId) dropSession(false);
+              },
+              catch: (error) => failSession(error),
+            }),
+          ),
+        ),
+
+      authenticate: (methodId) =>
+        ensureOpen.pipe(
+          Effect.andThen(
+            Effect.tryPromise({
+              try: async () => {
+                const acp = ensureClient();
+                await acp.ensureStarted();
+                await acp.authenticate(methodId);
+              },
+              catch: (error) => failSession(error),
+            }),
+          ),
+        ),
+
+      close: Effect.suspend(() =>
+        ensureOpen.pipe(
+          Effect.andThen(
+            Effect.promise(async () => {
+              closed = true;
+              invalidateActiveTurn();
+              const current = client;
+              client = undefined;
+              sessionId = undefined;
+              if (current) await current.close();
+            }),
+          ),
+        ),
+      ),
+    });
+  });
+
+const runtimeLayer = (createClient: DevinClientFactory): Layer.Layer<DevinRuntime> =>
+  Layer.effect(DevinRuntime, makeRuntime(createClient));
+
+export function createDevinRuntime(createClient: DevinClientFactory) {
+  return ManagedRuntime.make(runtimeLayer(createClient));
+}
+
+export type DevinRuntimeInstance = ReturnType<typeof createDevinRuntime>;
+
+export async function runDevin<A, E>(
+  runtime: DevinRuntimeInstance,
+  effect: Effect.Effect<A, E>,
+  options: { signal?: AbortSignal } = {},
+): Promise<A> {
+  const exit = await runtime.runPromiseExit(
+    effect,
+    options.signal ? { signal: options.signal } : undefined,
+  );
+  if (Exit.isSuccess(exit)) return exit.value;
+  if (Cause.hasInterruptsOnly(exit.cause)) {
+    throw new Error("devin operation was aborted.");
+  }
+  const failure = Cause.findFail(exit.cause);
+  if (Result.isSuccess(failure)) throw failure.success.error;
+  const [first] = Cause.prettyErrors(exit.cause);
+  throw new Error(first?.message ?? Cause.pretty(exit.cause));
+}

--- a/packages/pi-devin/src/runtime.ts
+++ b/packages/pi-devin/src/runtime.ts
@@ -153,9 +153,15 @@ const makeRuntime = (createClient: DevinClientFactory) =>
           const turn = active;
           active = undefined;
           turn?.fail(new Error("devin acp process exited."));
-          client = undefined;
+          if (sessionId && !pendingLoadId) {
+            // Devin persists sessions server-side: retry session/load on the
+            // next turn; its failure path falls back to a fresh session
+            // bootstrapped from pi history.
+            pendingLoadId = sessionId;
+          }
           sessionId = undefined;
           syncedModelId = undefined;
+          client = undefined;
         });
         client.setCustomNotificationHandler((method, params) => {
           if (method !== "_cognition.ai/agent_stopped") return;
@@ -265,6 +271,11 @@ const makeRuntime = (createClient: DevinClientFactory) =>
           syncedModelId = undefined;
           needsBootstrap = true;
           lastSentSystemPrompt = undefined;
+          // The loaded session never materialized; drop its stale counters.
+          turns = 0;
+          contextTokens = undefined;
+          contextSize = undefined;
+          title = undefined;
         } finally {
           pendingLoadId = undefined;
         }

--- a/packages/pi-devin/src/sessions-ui.ts
+++ b/packages/pi-devin/src/sessions-ui.ts
@@ -1,0 +1,70 @@
+/**
+ * /devin sessions — pick an ACP session to attach or delete. Kept to
+ * ctx.ui.select/confirm prompts (no custom overlay) for v1.
+ */
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { DevinListSessionInfo } from "../lib/acp-client.ts";
+
+function shortId(id: string): string {
+  return id.length <= 14 ? id : `${id.slice(0, 12)}…`;
+}
+
+function describeSession(session: DevinListSessionInfo, currentId?: string): string {
+  const title = session.title?.trim() || "(untitled)";
+  const locked = session.meta?.["cognition.ai/isLocked"] === true ? " 🔒" : "";
+  const here = session.sessionId === currentId ? " — current" : "";
+  const updated = session.updatedAt
+    ? new Date(session.updatedAt).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "";
+  return `${title} (${shortId(session.sessionId)})${locked}${here}${updated ? ` · ${updated}` : ""}`;
+}
+
+export interface DevinSessionsUiDeps {
+  listSessions: () => Promise<DevinListSessionInfo[]>;
+  loadSession: (sessionId: string) => Promise<void> | void;
+  deleteSession: (sessionId: string) => Promise<void>;
+  currentSessionId: () => Promise<string | undefined> | string | undefined;
+}
+
+/** Run the /devin sessions flow. Returns a user-facing summary line. */
+export async function runDevinSessionsPicker(
+  ctx: ExtensionContext,
+  deps: DevinSessionsUiDeps,
+): Promise<void> {
+  const sessions = await deps.listSessions();
+  if (sessions.length === 0) {
+    ctx.ui.notify("devin: no sessions found.", "info");
+    return;
+  }
+  const current = await deps.currentSessionId();
+  const labels = sessions.map((session) => describeSession(session, current));
+  const picked = await ctx.ui.select("devin sessions", labels);
+  if (!picked) return;
+  const session = sessions[labels.indexOf(picked)];
+  if (!session) return;
+
+  const action = await ctx.ui.select(`${session.title ?? session.sessionId}`, [
+    "Attach to this session",
+    "Delete session",
+    "Cancel",
+  ]);
+  if (action === "Attach to this session") {
+    await deps.loadSession(session.sessionId);
+    return;
+  }
+  if (action === "Delete session") {
+    const sure = await ctx.ui.confirm(
+      "Delete devin session",
+      `Delete "${session.title ?? session.sessionId}"? This cannot be undone.`,
+    );
+    if (!sure) return;
+    await deps.deleteSession(session.sessionId);
+    ctx.ui.notify(`devin: deleted session ${shortId(session.sessionId)}.`, "info");
+  }
+}

--- a/packages/pi-devin/src/turn.ts
+++ b/packages/pi-devin/src/turn.ts
@@ -70,7 +70,6 @@ export class DevinTurnController {
   #closed = false;
   #failure: Error | undefined;
   #incompleteTools = new Map<string, DevinToolView>();
-  #emittedText = "";
 
   constructor(prompt: string, sessionId: string) {
     this.prompt = prompt;
@@ -121,11 +120,6 @@ export class DevinTurnController {
    */
   deferResult(result: Extract<DevinActivity, { type: "result" }>): void {
     this.#queue.unshift(result);
-  }
-
-  /** Track rendered text so the terminal result can compute the suffix. */
-  recordEmittedText(delta: string): void {
-    this.#emittedText += delta;
   }
 
   close(): void {

--- a/packages/pi-devin/src/turn.ts
+++ b/packages/pi-devin/src/turn.ts
@@ -1,0 +1,170 @@
+/**
+ * DevinTurnController — one ACP prompt turn shared across sequential pi
+ * provider calls.
+ *
+ * The provider ends its assistant message at each completed devin tool call
+ * (stopReason "toolUse") so pi can render tool cards and execute the
+ * display-only replay wrapper. pi then re-invokes the provider, which
+ * re-attaches to the same controller and keeps consuming buffered updates
+ * while `session/prompt` is still running underneath.
+ */
+
+import type { DevinConfigOption } from "../lib/acp-client.ts";
+import type { DevinToolView } from "../lib/tool-content.ts";
+
+export interface DevinUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedReadTokens?: number;
+  /** Context occupancy: `used` of `size` tokens. */
+  contextUsed?: number;
+  contextSize?: number;
+}
+
+export interface DevinTurnStats {
+  toolCalls?: number;
+  filesChanged?: number;
+  commandsRun?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  ttftMs?: number;
+  tokensPerSec?: number;
+  totalTimeMs?: number;
+  modelLabel?: string;
+}
+
+export type DevinActivity =
+  | { type: "text"; delta: string; messageId?: string }
+  | { type: "thought"; delta: string; messageId?: string }
+  | { type: "tool_start"; view: DevinToolView }
+  | { type: "tool_update"; view: DevinToolView }
+  | { type: "usage"; usage: DevinUsage }
+  | { type: "mode"; modeId: string }
+  | { type: "config"; options: DevinConfigOption[] }
+  | { type: "title"; title: string }
+  | {
+      type: "commands";
+      commands: { name: string; description?: string; hint?: string }[];
+    }
+  | { type: "plan"; entries: { content: string; status?: string }[] }
+  | { type: "compaction" }
+  | { type: "result"; stopReason: string; usage?: DevinUsage }
+  | { type: "stopped"; stats: DevinTurnStats };
+
+type Waiter = (activity: DevinActivity | null, error: Error | undefined) => void;
+
+const TERMINAL_TOOL_STATUSES = new Set(["completed", "failed"]);
+
+export class DevinTurnController {
+  /** The base user prompt text, used to match provider re-attachment. */
+  readonly prompt: string;
+  /** Assigned once the ACP session id is known (session/new or load). */
+  sessionId: string;
+  /**
+   * Latest usage_update seen this turn, carried across pi message
+   * boundaries so each re-entered segment reports the cumulative counters.
+   */
+  lastUsage?: DevinUsage;
+  #queue: DevinActivity[] = [];
+  #waiters: Waiter[] = [];
+  #closed = false;
+  #failure: Error | undefined;
+  #incompleteTools = new Map<string, DevinToolView>();
+  #emittedText = "";
+
+  constructor(prompt: string, sessionId: string) {
+    this.prompt = prompt;
+    this.sessionId = sessionId;
+  }
+
+  isClosed(): boolean {
+    return this.#closed;
+  }
+
+  hasPending(): boolean {
+    return this.#queue.length > 0;
+  }
+
+  push(activity: DevinActivity): void {
+    if (this.#closed) return;
+    let delivered = activity;
+    if (activity.type === "tool_start") {
+      this.#incompleteTools.set(activity.view.id, activity.view);
+    } else if (activity.type === "tool_update") {
+      // Updates carry only changed fields (no title/kind/locations) — merge
+      // over the started view so cards keep the full picture.
+      const started = this.#incompleteTools.get(activity.view.id);
+      if (started) {
+        delivered = { ...activity, view: { ...started, ...activity.view } };
+      }
+      if (TERMINAL_TOOL_STATUSES.has(activity.view.status ?? "")) {
+        this.#incompleteTools.delete(activity.view.id);
+      } else if (started && delivered.type === "tool_update") {
+        this.#incompleteTools.set(activity.view.id, delivered.view);
+      }
+    }
+    const waiter = this.#waiters.shift();
+    if (waiter) waiter(delivered, undefined);
+    else this.#queue.push(delivered);
+  }
+
+  /** Tool calls that never reached a terminal status. */
+  takeIncompleteTools(): DevinToolView[] {
+    const tools = [...this.#incompleteTools.values()];
+    this.#incompleteTools.clear();
+    return tools;
+  }
+
+  /**
+   * Keep the terminal result pending while pi executes incomplete-tool
+   * replay. Unlike push(), this also works after the turn closed.
+   */
+  deferResult(result: Extract<DevinActivity, { type: "result" }>): void {
+    this.#queue.unshift(result);
+  }
+
+  /** Track rendered text so the terminal result can compute the suffix. */
+  recordEmittedText(delta: string): void {
+    this.#emittedText += delta;
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const waiter of this.#waiters.splice(0)) waiter(null, undefined);
+  }
+
+  fail(error: Error): void {
+    if (this.#closed) return;
+    this.#failure = error;
+    for (const waiter of this.#waiters.splice(0)) waiter(null, error);
+    this.#closed = true;
+  }
+
+  /**
+   * Resolve the next activity, waiting when the queue is empty.
+   * Returns null when the turn ended; rejects when the turn failed.
+   */
+  next(): Promise<DevinActivity | null> {
+    return new Promise<DevinActivity | null>((resolve, reject) => {
+      const queued = this.#queue.shift();
+      if (queued !== undefined) {
+        resolve(queued);
+        return;
+      }
+      if (this.#failure) {
+        reject(this.#failure);
+        return;
+      }
+      if (this.#closed) {
+        resolve(null);
+        return;
+      }
+      this.#waiters.push((activity, error) => {
+        if (error) reject(error);
+        else if (activity) resolve(activity);
+        else resolve(null);
+      });
+    });
+  }
+}

--- a/packages/pi-devin/src/updates.ts
+++ b/packages/pi-devin/src/updates.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure mapping from ACP session/update payloads to DevinActivity items the
+ * provider drains. Kept separate so it is directly unit-testable.
+ */
+
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import type { DevinConfigOption } from "../lib/acp-client.ts";
+import { mergeDevinTool } from "../lib/tool-content.ts";
+import type { DevinActivity, DevinUsage } from "./turn.ts";
+
+function metaNumber(update: { _meta?: unknown }, key: string): number | undefined {
+  const meta = update._meta;
+  if (typeof meta !== "object" || meta === null) return undefined;
+  const value = (meta as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function textOf(update: { content?: unknown }): string | undefined {
+  const content = update.content;
+  if (
+    typeof content === "object" &&
+    content !== null &&
+    (content as { type?: string }).type === "text"
+  ) {
+    return (content as { text?: string }).text;
+  }
+  return undefined;
+}
+
+function messageIdOf(update: { messageId?: unknown }): string | undefined {
+  return typeof update.messageId === "string" ? update.messageId : undefined;
+}
+
+export function acpUpdateToActivities(update: SessionUpdate): DevinActivity[] {
+  switch (update.sessionUpdate) {
+    case "agent_message_chunk": {
+      const delta = textOf(update);
+      if (!delta) return [];
+      return [{ type: "text", delta, messageId: messageIdOf(update) }];
+    }
+    case "agent_thought_chunk": {
+      const delta = textOf(update);
+      if (!delta) return [];
+      return [{ type: "thought", delta, messageId: messageIdOf(update) }];
+    }
+    case "tool_call":
+      return [{ type: "tool_start", view: mergeDevinTool(update, undefined) }];
+    case "tool_call_update":
+      return [{ type: "tool_update", view: mergeDevinTool(undefined, update) }];
+    case "plan": {
+      const entries = Array.isArray(update.entries) ? update.entries : [];
+      return [
+        {
+          type: "plan",
+          entries: entries.map((entry) => ({
+            content: String(entry.content ?? ""),
+            status: typeof entry.status === "string" ? entry.status : undefined,
+          })),
+        },
+      ];
+    }
+    case "usage_update": {
+      const usage: DevinUsage = {
+        contextUsed: typeof update.used === "number" ? update.used : undefined,
+        contextSize: typeof update.size === "number" ? update.size : undefined,
+        inputTokens: metaNumber(update, "cognition.ai/inputTokens"),
+        outputTokens: metaNumber(update, "cognition.ai/outputTokens"),
+        cachedReadTokens: metaNumber(update, "cognition.ai/cachedReadTokens"),
+      };
+      return [{ type: "usage", usage }];
+    }
+    case "current_mode_update":
+      return [{ type: "mode", modeId: update.currentModeId }];
+    case "config_option_update":
+      return [{ type: "config", options: (update.configOptions ?? []) as DevinConfigOption[] }];
+    case "session_info_update":
+      return update.title ? [{ type: "title", title: update.title }] : [];
+    case "available_commands_update": {
+      const commands = Array.isArray(update.availableCommands) ? update.availableCommands : [];
+      return [
+        {
+          type: "commands",
+          commands: commands.map((command) => ({
+            name: String(command.name ?? ""),
+            description: typeof command.description === "string" ? command.description : undefined,
+            hint:
+              typeof command.input === "object" && command.input !== null
+                ? ((command.input as { hint?: string }).hint ?? undefined)
+                : undefined,
+          })),
+        },
+      ];
+    }
+    case "compaction_update":
+      return [{ type: "compaction" }];
+    default:
+      return [];
+  }
+}
+
+/** Cognition `_cognition.ai/agent_stopped` params → stats activity. */
+export function agentStoppedToActivity(params: unknown): DevinActivity | undefined {
+  if (typeof params !== "object" || params === null) return undefined;
+  const record = params as Record<string, unknown>;
+  const stats = (record.stats ?? {}) as Record<string, unknown>;
+  const num = (key: string): number | undefined =>
+    typeof stats[key] === "number" && Number.isFinite(stats[key])
+      ? (stats[key] as number)
+      : undefined;
+  return {
+    type: "stopped",
+    stats: {
+      toolCalls: num("toolCalls"),
+      filesChanged: num("filesChanged"),
+      commandsRun: num("commandsRun"),
+      inputTokens: num("inputTokens"),
+      outputTokens: num("outputTokens"),
+      ttftMs: num("ttftMs"),
+      tokensPerSec: num("tokensPerSec"),
+      totalTimeMs: num("totalTimeMs"),
+      modelLabel: typeof stats.modelLabel === "string" ? stats.modelLabel : undefined,
+    },
+  };
+}

--- a/packages/pi-devin/test/acp-client.test.ts
+++ b/packages/pi-devin/test/acp-client.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Integration test against a real `devin acp` process. Skipped when the
+ * devin binary is unavailable or unauthenticated (CI machines). Runs a full
+ * initialize → session/new → prompt round-trip plus a custom-notification
+ * check, bounded by hard timeouts.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DevinAcpClient } from "../lib/acp-client.ts";
+import { checkDevinBinary } from "../lib/diagnostics.ts";
+
+const binary = await checkDevinBinary();
+const skipReason = binary.ok ? undefined : `devin binary unavailable: ${binary.message}`;
+
+test("DevinAcpClient performs a real ACP prompt round-trip", {
+  skip: skipReason,
+  timeout: 120_000,
+}, async () => {
+  const custom: string[] = [];
+  const updates: string[] = [];
+  const client = new DevinAcpClient({
+    binary: binary.ok ? binary.binary : "devin",
+  });
+  client.setCustomNotificationHandler((method) => custom.push(method));
+  try {
+    await client.ensureStarted();
+    const created = await client.newSession(process.cwd());
+    assert.ok(created.sessionId, "session/new must return a sessionId");
+
+    client.setSessionListener(created.sessionId, (update) => {
+      updates.push(update.sessionUpdate);
+    });
+
+    const result = await client.prompt(created.sessionId, [
+      { type: "text", text: "Reply with the single word: pong" },
+    ]);
+    assert.ok(result.stopReason, "prompt must resolve with a stopReason");
+    assert.ok(updates.includes("agent_message_chunk"), "expected streamed agent message chunks");
+    assert.ok(updates.includes("usage_update"), "expected a usage_update during the turn");
+    assert.ok(
+      custom.includes("_cognition.ai/agent_stopped"),
+      "expected the Cognition agent_stopped notification",
+    );
+  } finally {
+    await client.close();
+  }
+});

--- a/packages/pi-devin/test/acp-client.test.ts
+++ b/packages/pi-devin/test/acp-client.test.ts
@@ -23,9 +23,10 @@ test("DevinAcpClient performs a real ACP prompt round-trip", {
     binary: binary.ok ? binary.binary : "devin",
   });
   client.setCustomNotificationHandler((method) => custom.push(method));
+  let created: { sessionId: string } | undefined;
   try {
     await client.ensureStarted();
-    const created = await client.newSession(process.cwd());
+    created = await client.newSession(process.cwd());
     assert.ok(created.sessionId, "session/new must return a sessionId");
 
     client.setSessionListener(created.sessionId, (update) => {
@@ -43,6 +44,13 @@ test("DevinAcpClient performs a real ACP prompt round-trip", {
       "expected the Cognition agent_stopped notification",
     );
   } finally {
+    if (created) {
+      try {
+        await client.deleteSession(created.sessionId);
+      } catch {
+        // Best-effort cleanup; the round-trip itself already passed.
+      }
+    }
     await client.close();
   }
 });

--- a/packages/pi-devin/test/models.test.ts
+++ b/packages/pi-devin/test/models.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
-  buildGroups,
   devinGroups,
   findDevinGroup,
   modelCacheTtlMs,

--- a/packages/pi-devin/test/models.test.ts
+++ b/packages/pi-devin/test/models.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildGroups,
+  devinGroups,
+  findDevinGroup,
+  modelCacheTtlMs,
+  parseDevinModels,
+  parseRowMeta,
+  resolveDevinModelRow,
+  rowMarkers,
+} from "../lib/models.ts";
+
+const MODELS_OUTPUT = `Available models (47 families)
+
+Adaptive (adaptive)
+  adaptive                               Adaptive  [$0.5 / 1M Input · $0.1 / 1M Cached input · $2 / 1M Output]
+
+Claude Opus 5 (claude-opus-5)
+  aliases: opus
+  claude-opus-5-low                      Claude Opus 5 Low  [1M context, $5 / 1M Input · $0.5 / 1M Cached input · $25 / 1M Output]
+  claude-opus-5-medium                   Claude Opus 5 Medium  [1M context, $5 / 1M Input · $0.5 / 1M Cached input · $25 / 1M Output]
+  claude-opus-5-high                     Claude Opus 5 High  [1M context, $5 / 1M Input · $0.5 / 1M Cached input · $25 / 1M Output]
+  claude-opus-5-xhigh                    Claude Opus 5 XHigh  [1M context, $5 / 1M Input · $0.5 / 1M Cached input · $25 / 1M Output]
+  claude-opus-5-max                      Claude Opus 5 Max  [1M context, $5 / 1M Input · $0.5 / 1M Cached input · $25 / 1M Output]
+  claude-opus-5-low-fast                 Claude Opus 5 Low Fast  [1M context, $10 / 1M Input · $1 / 1M Cached input · $50 / 1M Output]
+  claude-opus-5-medium-fast              Claude Opus 5 Medium Fast  [1M context, $10 / 1M Input · $1 / 1M Cached input · $50 / 1M Output]
+  claude-opus-5-high-fast                Claude Opus 5 High Fast  [1M context, $10 / 1M Input · $1 / 1M Cached input · $50 / 1M Output]
+
+GPT-5.4 (gpt-5.4)
+  gpt-5-4-none                           GPT-5.4 No Thinking  [272K context, $2.5 / 1M Input · $0.25 / 1M Cached input · $15 / 1M Output]
+  gpt-5-4-low                            GPT-5.4 Low Thinking  [272K context, $2.5 / 1M Input · $0.25 / 1M Cached input · $15 / 1M Output]
+  gpt-5-4-medium                         GPT-5.4 Medium Thinking  [272K context, $2.5 / 1M Input · $0.25 / 1M Cached input · $15 / 1M Output]
+  gpt-5-4-high                           GPT-5.4 High Thinking  [272K context, $2.5 / 1M Input · $0.25 / 1M Cached input · $15 / 1M Output]
+  gpt-5-4-none-priority                  GPT-5.4 No Thinking Fast  [272K context, $5 / 1M Input · $0.5 / 1M Cached input · $30 / 1M Output]
+  gpt-5-4-high-priority                  GPT-5.4 High Thinking Fast  [272K context, $5 / 1M Input · $0.5 / 1M Cached input · $30 / 1M Output]
+
+GPT-5.2 (gpt-5.2)
+  MODEL_GPT_5_2_LOW                      GPT-5.2 Low Thinking  [384K context, $1.75 / 1M Input · $0.17 / 1M Cached input · $14 / 1M Output]
+  MODEL_GPT_5_2_MEDIUM                   GPT-5.2 Medium Thinking  [384K context, $1.75 / 1M Input · $0.17 / 1M Cached input · $14 / 1M Output]
+  MODEL_GPT_5_2_NONE                     GPT-5.2 No Thinking  [384K context, $1.75 / 1M Input · $0.17 / 1M Cached input · $14 / 1M Output]
+  MODEL_GPT_5_2_HIGH                     GPT-5.2 High Thinking  [384K context, $1.75 / 1M Input · $0.17 / 1M Cached input · $14 / 1M Output]
+
+Claude Sonnet 4.6 (claude-sonnet-4.6)
+  claude-sonnet-4-6                      Claude Sonnet 4.6  [200K context, $3 / 1M Input · $0.3 / 1M Cached input · $15 / 1M Output]
+  claude-sonnet-4-6-thinking             Claude Sonnet 4.6 Thinking  [200K context, $3 / 1M Input · $0.3 / 1M Cached input · $15 / 1M Output]
+  claude-sonnet-4-6-1m                   Claude Sonnet 4.6 1M  [1M context, $3 / 1M Input · $0.3 / 1M Cached input · $15 / 1M Output]
+  claude-sonnet-4-6-thinking-1m          Claude Sonnet 4.6 Thinking 1M  [1M context, $3 / 1M Input · $0.3 / 1M Cached input · $15 / 1M Output]
+
+SWE-2 (swe-2)
+  aliases: swe
+  swe-2-high                             SWE-2 High  [262K context, Free]
+  swe-2-medium                           SWE-2 Medium  [262K context, Free]
+  swe-2-max                              SWE-2 Max  [262K context, Free]
+
+SWE-1.6 Fast (swe-1.6-fast)
+  swe-1-6-fast                           SWE-1.6 Fast  [200K context, $0.5 / 1M Input · $0.2 / 1M Cached input · $2.5 / 1M Output]
+
+Pass a family slug, alias, or model UID to \`--model\` (e.g. \`--model opus\`)
+or switch models in a session with \`/model <name>\`.
+`;
+
+test("rowMarkers extracts effort/fast/context suffixes", () => {
+  assert.deepEqual(rowMarkers("claude-opus-5-high"), {
+    effort: "high",
+    thinking: false,
+    fast: false,
+    contextVariant: undefined,
+  });
+  assert.deepEqual(rowMarkers("gpt-5-4-none-priority"), {
+    effort: "none",
+    thinking: false,
+    fast: true,
+    contextVariant: undefined,
+  });
+  assert.deepEqual(rowMarkers("claude-sonnet-4-6-thinking-1m"), {
+    effort: undefined,
+    thinking: true,
+    fast: false,
+    contextVariant: "1m",
+  });
+  assert.deepEqual(rowMarkers("MODEL_GPT_5_2_XHIGH"), {
+    effort: "xhigh",
+    thinking: false,
+    fast: false,
+    contextVariant: undefined,
+  });
+  assert.deepEqual(rowMarkers("swe-1-6-fast"), {
+    effort: undefined,
+    thinking: false,
+    fast: true,
+    contextVariant: undefined,
+  });
+});
+
+test("parseRowMeta parses context window and pricing", () => {
+  const meta = parseRowMeta("1M context, $5 / 1M Input · $0.5 / 1M Cached input · $25 / 1M Output");
+  assert.equal(meta.contextWindow, 1_000_000);
+  assert.equal(meta.cost.input, 5);
+  assert.equal(meta.cost.cacheRead, 0.5);
+  assert.equal(meta.cost.output, 25);
+  const free = parseRowMeta("262K context, Free");
+  assert.equal(free.contextWindow, 262_000);
+  assert.equal(free.cost.input, 0);
+});
+
+test("parseDevinModels parses families, aliases, and rows; skips noise", () => {
+  const families = parseDevinModels(MODELS_OUTPUT);
+  assert.equal(families.length, 7);
+  const opus = families.find((f) => f.id === "claude-opus-5");
+  assert.ok(opus);
+  assert.equal(opus.name, "Claude Opus 5");
+  assert.deepEqual(opus.aliases, ["opus"]);
+  assert.equal(opus.rows.length, 8);
+  assert.equal(opus.rows[0].id, "claude-opus-5-low");
+  assert.equal(opus.rows[0].effort, "low");
+  assert.equal(opus.rows[5].fast, true);
+  const gpt52 = families.find((f) => f.id === "gpt-5.2");
+  assert.equal(gpt52?.rows[0].id, "MODEL_GPT_5_2_LOW");
+});
+
+test("buildGroups splits fast and context variants into separate pi models", () => {
+  const families = parseDevinModels(MODELS_OUTPUT);
+  const groups = devinGroups(families);
+  const ids = groups.map((g) => g.id);
+  assert.ok(ids.includes("claude-opus-5"));
+  assert.ok(ids.includes("claude-opus-5-fast"));
+  assert.ok(ids.includes("gpt-5.4"));
+  assert.ok(ids.includes("gpt-5.4-fast"));
+  // claude-sonnet-4.6 splits by context variant: base + 1m
+  assert.ok(ids.includes("claude-sonnet-4.6"));
+  assert.ok(ids.includes("claude-sonnet-4.6-1m"));
+  // swe-1.6-fast family has a single (fast) group → keeps its own slug
+  const sweFast = groups.find((g) => g.id === "swe-1.6-fast");
+  assert.ok(sweFast);
+  assert.equal(sweFast.rows.length, 1);
+});
+
+test("resolveDevinModelRow maps thinking levels to concrete variants", () => {
+  const families = parseDevinModels(MODELS_OUTPUT);
+  const opus = findDevinGroup(families, "claude-opus-5")!;
+  assert.equal(resolveDevinModelRow(opus, "high").id, "claude-opus-5-high");
+  assert.equal(resolveDevinModelRow(opus, "max").id, "claude-opus-5-max");
+  assert.equal(resolveDevinModelRow(opus, undefined).id, "claude-opus-5-medium");
+  assert.equal(resolveDevinModelRow(opus, "off").id, "claude-opus-5-medium");
+
+  const gpt = findDevinGroup(families, "gpt-5.4")!;
+  assert.equal(resolveDevinModelRow(gpt, "off").id, "gpt-5-4-none");
+  // xhigh missing in fixture → falls back to highest at-or-below
+  assert.equal(resolveDevinModelRow(gpt, "xhigh").id, "gpt-5-4-high");
+
+  const fast = findDevinGroup(families, "gpt-5.4-fast")!;
+  assert.equal(resolveDevinModelRow(fast, "high").id, "gpt-5-4-high-priority");
+
+  // Binary-thinking family: any level → thinking row; off → plain row
+  const sonnet = findDevinGroup(families, "claude-sonnet-4.6")!;
+  assert.equal(resolveDevinModelRow(sonnet, "high").id, "claude-sonnet-4-6-thinking");
+  assert.equal(resolveDevinModelRow(sonnet, "off").id, "claude-sonnet-4-6");
+
+  // MODEL_* enum-style ids resolve through the same path
+  const gpt52 = findDevinGroup(families, "gpt-5.2")!;
+  assert.equal(resolveDevinModelRow(gpt52, "medium").id, "MODEL_GPT_5_2_MEDIUM");
+
+  const adaptive = findDevinGroup(families, "adaptive")!;
+  assert.equal(resolveDevinModelRow(adaptive, "high").id, "adaptive");
+});
+
+test("modelCacheTtlMs distinguishes live and fallback caches", () => {
+  assert.ok(modelCacheTtlMs("live") > modelCacheTtlMs("fallback"));
+});

--- a/packages/pi-devin/test/provider.test.ts
+++ b/packages/pi-devin/test/provider.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { AssistantMessageEvent } from "@earendil-works/pi-ai";
+import { DevinReplayStore } from "../lib/replay.ts";
+import { streamDevin } from "../src/provider.ts";
+import { DevinTurnController, type DevinActivity } from "../src/turn.ts";
+import type { DevinRuntimeInstance, DevinRuntimeShape } from "../src/runtime.ts";
+import type { DevinModelFamily } from "../lib/models.ts";
+
+const FAMILIES: DevinModelFamily[] = [
+  {
+    id: "swe-2",
+    name: "SWE-2",
+    aliases: [],
+    rows: [
+      {
+        id: "swe-2-medium",
+        name: "SWE-2 Medium",
+        contextWindow: 262_000,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        effort: "medium",
+      },
+      {
+        id: "swe-2-max",
+        name: "SWE-2 Max",
+        contextWindow: 262_000,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        effort: "max",
+      },
+    ],
+  },
+];
+
+/** Drive a canned activity sequence through a real controller. */
+function fakeRuntime(activities: DevinActivity[], capture: { prompts?: number } = {}) {
+  const controllers: DevinTurnController[] = [];
+  const service = {
+    beginStreamTurn: () => {
+      capture.prompts = (capture.prompts ?? 0) + 1;
+      const controller = new DevinTurnController("do it", "sess-1");
+      controllers.push(controller);
+      // Push on the next tick so the provider's drain loop is waiting.
+      queueMicrotask(() => {
+        for (const activity of activities) controller.push(activity);
+        controller.push({ type: "result", stopReason: "end_turn" });
+        controller.close();
+      });
+      return controller;
+    },
+    finishTurn: { pipe: () => ({}) },
+    runSummaryTurn: () => Promise.resolve({ text: "summary" }),
+  } as unknown as DevinRuntimeShape;
+  const runtime = {
+    runPromise: (effect: unknown) =>
+      // The fake service returns plain values, not Effects — runPromise gets
+      // called with the fake's return; make it passthrough-friendly.
+      Promise.resolve(
+        typeof effect === "object" && effect && "pipe" in effect ? undefined : effect,
+      ),
+    runPromiseExit: async () => ({ _tag: "Success", value: undefined }),
+    dispose: async () => {},
+  } as unknown as DevinRuntimeInstance;
+  return { service, runtime, controllers, capture };
+}
+
+const MODEL = {
+  id: "swe-2",
+  name: "SWE-2",
+  api: "devin-acp",
+  provider: "devin",
+  baseUrl: "devin://acp",
+  reasoning: true,
+  input: ["text", "image"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 262_000,
+  maxTokens: 64_000,
+} as const;
+
+const CONTEXT = {
+  systemPrompt: undefined,
+  messages: [{ role: "user", content: "do it" }],
+} as never;
+
+async function drain(stream: AsyncIterable<AssistantMessageEvent>) {
+  const events: AssistantMessageEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+test("streamDevin emits text deltas then done", async () => {
+  const { service, runtime } = fakeRuntime([
+    { type: "thought", delta: "hmm", messageId: "t1" },
+    { type: "text", delta: "Hello", messageId: "m1" },
+    { type: "text", delta: " world", messageId: "m1" },
+    {
+      type: "usage",
+      usage: { inputTokens: 10, outputTokens: 5, contextUsed: 15, contextSize: 262000 },
+    },
+  ]);
+  const replay = new DevinReplayStore();
+  const stream = streamDevin({
+    runtime,
+    service,
+    replay,
+    families: () => FAMILIES,
+    cwd: () => "/tmp",
+  })(MODEL as never, CONTEXT, undefined);
+  const events = await drain(stream);
+  const types = events.map((e) => e.type);
+  assert.ok(types.includes("thinking_start"));
+  assert.ok(types.includes("text_start"));
+  assert.equal(events.filter((e) => e.type === "text_delta").length, 2);
+  const done = events.find((e) => e.type === "done");
+  assert.ok(done && done.type === "done");
+  assert.equal(done.message.stopReason, "stop");
+  assert.equal(done.message.usage.input, 10);
+  assert.equal(done.message.usage.output, 5);
+});
+
+test("streamDevin ends with toolUse after a completed tool call and replays the result", async () => {
+  const { service, runtime } = fakeRuntime([
+    {
+      type: "tool_start",
+      view: { id: "write_1", title: "Wrote /tmp/x", kind: "edit", tool: "write" },
+    },
+    {
+      type: "tool_update",
+      view: {
+        id: "write_1",
+        title: "Wrote /tmp/x",
+        kind: "edit",
+        tool: "write",
+        status: "completed",
+        output: "done",
+      },
+    },
+  ]);
+  const replay = new DevinReplayStore();
+  const stream = streamDevin({
+    runtime,
+    service,
+    replay,
+    families: () => FAMILIES,
+    cwd: () => "/tmp",
+  })(MODEL as never, CONTEXT, undefined);
+  const events = await drain(stream);
+  const done = events.find((e) => e.type === "done");
+  assert.ok(done && done.type === "done");
+  assert.equal(done.reason, "toolUse");
+  const toolCalls = done.message.content.filter((c) => c.type === "toolCall");
+  assert.equal(toolCalls.length, 1);
+  assert.equal(toolCalls[0].name, "devin");
+  // The replay store holds the recorded result for pi's wrapper execution.
+  const recorded = replay.take(toolCalls[0].id);
+  assert.equal(recorded?.output, "done");
+  assert.equal(recorded?.title, "Wrote /tmp/x");
+});

--- a/packages/pi-devin/test/provider.test.ts
+++ b/packages/pi-devin/test/provider.test.ts
@@ -155,3 +155,91 @@ test("streamDevin ends with toolUse after a completed tool call and replays the 
   assert.equal(recorded?.output, "done");
   assert.equal(recorded?.title, "Wrote /tmp/x");
 });
+
+test("non-terminal tool updates keep the card pending; the terminal update closes it once", async () => {
+  const { service, runtime } = fakeRuntime([
+    {
+      type: "tool_start",
+      view: { id: "cmd_1", title: "Ran tests", kind: "execute", tool: "shell" },
+    },
+    {
+      type: "tool_update",
+      view: { id: "cmd_1", status: "in_progress", output: "partial…" },
+    },
+    {
+      type: "tool_update",
+      view: { id: "cmd_1", status: "in_progress", output: "still running" },
+    },
+    {
+      type: "tool_update",
+      view: { id: "cmd_1", status: "completed", output: "all passed" },
+    },
+  ]);
+  const replay = new DevinReplayStore();
+  const stream = streamDevin({
+    runtime,
+    service,
+    replay,
+    families: () => FAMILIES,
+    cwd: () => "/tmp",
+  })(MODEL as never, CONTEXT, undefined);
+  const events = await drain(stream);
+  const done = events.find((e) => e.type === "done");
+  assert.ok(done && done.type === "done");
+  assert.equal(done.reason, "toolUse");
+  const toolCalls = done.message.content.filter((c) => c.type === "toolCall");
+  assert.equal(toolCalls.length, 1, "one card despite progress updates");
+  // Exactly one start/end pair for that card.
+  assert.equal(events.filter((e) => e.type === "toolcall_start").length, 1);
+  assert.equal(events.filter((e) => e.type === "toolcall_end").length, 1);
+  const recorded = replay.take(toolCalls[0].id);
+  assert.equal(recorded?.output, "all passed");
+});
+
+test("usage merge never clobbers known fields and honors the prompt response", async () => {
+  const { service, runtime } = fakeRuntime([
+    {
+      type: "usage",
+      usage: { inputTokens: 10, outputTokens: 5, cachedReadTokens: 3 },
+    },
+    // A context-only usage_update (no token counters) must not zero them.
+    { type: "usage", usage: { contextUsed: 15, contextSize: 262000 } },
+    {
+      type: "result",
+      stopReason: "end_turn",
+      usage: { inputTokens: 12, outputTokens: 6 },
+    },
+  ]);
+  const stream = streamDevin({
+    runtime,
+    service,
+    replay: new DevinReplayStore(),
+    families: () => FAMILIES,
+    cwd: () => "/tmp",
+  })(MODEL as never, CONTEXT, undefined);
+  const events = await drain(stream);
+  const done = events.find((e) => e.type === "done");
+  assert.ok(done && done.type === "done");
+  assert.equal(done.message.usage.input, 12);
+  assert.equal(done.message.usage.output, 6);
+  assert.equal(done.message.usage.cacheRead, 3);
+  assert.equal(done.message.usage.totalTokens, 15);
+});
+
+test("turns without usage_update still report the prompt-response usage", async () => {
+  const { service, runtime } = fakeRuntime([
+    { type: "result", stopReason: "end_turn", usage: { inputTokens: 7, outputTokens: 4 } },
+  ]);
+  const stream = streamDevin({
+    runtime,
+    service,
+    replay: new DevinReplayStore(),
+    families: () => FAMILIES,
+    cwd: () => "/tmp",
+  })(MODEL as never, CONTEXT, undefined);
+  const events = await drain(stream);
+  const done = events.find((e) => e.type === "done");
+  assert.ok(done && done.type === "done");
+  assert.equal(done.message.usage.input, 7);
+  assert.equal(done.message.usage.output, 4);
+});

--- a/packages/pi-devin/test/runtime.test.ts
+++ b/packages/pi-devin/test/runtime.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ContentBlock } from "@agentclientprotocol/sdk";
+import type { DevinAcpClient } from "../lib/acp-client.ts";
+import {
+  createDevinRuntime,
+  DevinRuntime,
+  runDevin,
+  type DevinRuntimeShape,
+} from "../src/runtime.ts";
+import type { DevinSessionListener } from "../lib/acp-client.ts";
+
+/**
+ * Fake DevinAcpClient: implements the surface the runtime consumes. Pushes
+ * canned updates through the registered session listener when prompted.
+ */
+class FakeClient {
+  started = false;
+  sessions = new Map<string, DevinSessionListener>();
+  createdSessions: string[] = [];
+  prompts: { sessionId: string; blocks: ContentBlock[] }[] = [];
+  nextId = 0;
+  failLoads = new Set<string>();
+  deleted: string[] = [];
+  modes: string[] = [];
+  configSets: { configId: string; value: string }[] = [];
+
+  async ensureStarted() {
+    this.started = true;
+  }
+  setSessionListener(id: string, fn: DevinSessionListener | undefined) {
+    if (fn) this.sessions.set(id, fn);
+    else this.sessions.delete(id);
+  }
+  setCustomNotificationHandler() {}
+  setPermissionHandler() {}
+  setOnClose() {}
+  async newSession(_cwd: string) {
+    const id = `sess-${++this.nextId}`;
+    this.createdSessions.push(id);
+    return { sessionId: id, modes: { currentModeId: "accept-edits" } };
+  }
+  async loadSession(id: string) {
+    if (this.failLoads.has(id)) throw new Error("Session not found");
+    return { sessionId: id };
+  }
+  async prompt(sessionId: string, blocks: ContentBlock[]) {
+    this.prompts.push({ sessionId, blocks });
+    const listener = this.sessions.get(sessionId);
+    listener?.({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "answer" },
+    } as never);
+    return { stopReason: "end_turn" };
+  }
+  async cancel() {}
+  async setMode(_id: string, modeId: string) {
+    this.modes.push(modeId);
+  }
+  async setConfigOption(_id: string, configId: string, value: string) {
+    this.configSets.push({ configId, value });
+    return [];
+  }
+  async listSessions() {
+    return [];
+  }
+  async deleteSession(id: string) {
+    this.deleted.push(id);
+  }
+  async authenticate() {}
+  async close() {}
+}
+
+const TURN = (over: Partial<Parameters<DevinRuntimeShape["beginStreamTurn"]>[0]> = {}) => ({
+  prompt: "hi",
+  blocks: [{ type: "text" as const, text: "hi" }],
+  modelId: "swe-2",
+  concreteModelId: "swe-2-medium",
+  cwd: "/tmp/proj",
+  ...over,
+});
+
+async function makeRuntime() {
+  const fake = new FakeClient();
+  const runtime = createDevinRuntime(() => fake as unknown as DevinAcpClient);
+  const service = runtime.runSync(DevinRuntime);
+  return { fake, runtime, service };
+}
+
+test("beginStreamTurn creates a session, syncs model, and streams a result", async () => {
+  const { fake, runtime, service } = await makeRuntime();
+  const controller = await runDevin(runtime, service.beginStreamTurn(TURN()));
+  assert.equal(fake.createdSessions.length, 1);
+  assert.deepEqual(fake.configSets, [{ configId: "model", value: "swe-2-medium" }]);
+  const activities = [];
+  for (;;) {
+    const a = await controller.next();
+    if (a === null) break;
+    activities.push(a);
+  }
+  assert.ok(activities.some((a) => a.type === "text" && a.delta === "answer"));
+  assert.equal(activities.at(-1)?.type, "result");
+  const snapshot = await runDevin(runtime, service.snapshot);
+  assert.equal(snapshot.sessionId, "sess-1");
+  assert.equal(snapshot.turns, 1);
+  await runtime.dispose();
+});
+
+test("re-attach returns the same controller for the same prompt", async () => {
+  const { fake, runtime, service } = await makeRuntime();
+  // Turn whose prompt never resolves: re-attach must not re-prompt.
+  fake.prompt = async (sessionId: string, blocks: ContentBlock[]) => {
+    fake.prompts.push({ sessionId, blocks });
+    return new Promise(() => {});
+  };
+  const first = await runDevin(runtime, service.beginStreamTurn(TURN()));
+  const again = await runDevin(runtime, service.beginStreamTurn(TURN()));
+  assert.equal(first, again);
+  assert.equal(fake.prompts.length, 1);
+  await runtime.dispose();
+});
+
+test("failed session/load falls back to a fresh session with bootstrap", async () => {
+  const { fake, runtime, service } = await makeRuntime();
+  await runDevin(
+    runtime,
+    service.restoreSession({
+      acpSessionId: "old-session",
+      cwd: "/tmp/proj",
+      modelId: "swe-2",
+      turns: 2,
+    }),
+  );
+  fake.failLoads.add("old-session");
+  const controller = await runDevin(
+    runtime,
+    service.beginStreamTurn(TURN({ historyBootstrap: "user:\nprevious question" })),
+  );
+  assert.equal(fake.createdSessions.length, 1);
+  const sent = fake.prompts[0];
+  assert.equal(sent.sessionId, "sess-1");
+  assert.ok(
+    sent.blocks.some((b) => b.type === "resource"),
+    "expected bootstrap/resource blocks after fallback",
+  );
+  for (;;) {
+    if ((await controller.next()) === null) break;
+  }
+  await runtime.dispose();
+});
+
+test("runSummaryTurn uses a disposable session and cleans up", async () => {
+  const { fake, runtime, service } = await makeRuntime();
+  const result = await runDevin(
+    runtime,
+    service.runSummaryTurn("<conversation>\nx\n</conversation>"),
+  );
+  assert.equal(result.text, "answer");
+  assert.equal(fake.deleted.length, 1);
+  const snapshot = await runDevin(runtime, service.snapshot);
+  assert.equal(snapshot.sessionId, undefined);
+  await runtime.dispose();
+});
+
+test("reset drops the session binding", async () => {
+  const { runtime, service } = await makeRuntime();
+  const controller = await runDevin(runtime, service.beginStreamTurn(TURN()));
+  for (;;) {
+    if ((await controller.next()) === null) break;
+  }
+  await runDevin(runtime, service.reset);
+  const snapshot = await runDevin(runtime, service.snapshot);
+  assert.equal(snapshot.sessionId, undefined);
+  assert.equal(snapshot.turns, 0);
+  await runtime.dispose();
+});

--- a/packages/pi-devin/test/runtime.test.ts
+++ b/packages/pi-devin/test/runtime.test.ts
@@ -18,12 +18,14 @@ class FakeClient {
   started = false;
   sessions = new Map<string, DevinSessionListener>();
   createdSessions: string[] = [];
+  loaded: string[] = [];
   prompts: { sessionId: string; blocks: ContentBlock[] }[] = [];
   nextId = 0;
   failLoads = new Set<string>();
   deleted: string[] = [];
   modes: string[] = [];
   configSets: { configId: string; value: string }[] = [];
+  onClose: (() => void) | undefined;
 
   async ensureStarted() {
     this.started = true;
@@ -34,13 +36,16 @@ class FakeClient {
   }
   setCustomNotificationHandler() {}
   setPermissionHandler() {}
-  setOnClose() {}
+  setOnClose(fn: (() => void) | undefined) {
+    this.onClose = fn;
+  }
   async newSession(_cwd: string) {
     const id = `sess-${++this.nextId}`;
     this.createdSessions.push(id);
     return { sessionId: id, modes: { currentModeId: "accept-edits" } };
   }
   async loadSession(id: string) {
+    this.loaded.push(id);
     if (this.failLoads.has(id)) throw new Error("Session not found");
     return { sessionId: id };
   }
@@ -172,5 +177,54 @@ test("reset drops the session binding", async () => {
   const snapshot = await runDevin(runtime, service.snapshot);
   assert.equal(snapshot.sessionId, undefined);
   assert.equal(snapshot.turns, 0);
+  await runtime.dispose();
+});
+
+test("devin acp process exit retries the same session via session/load", async () => {
+  const { fake, runtime, service } = await makeRuntime();
+  const first = await runDevin(runtime, service.beginStreamTurn(TURN()));
+  for (;;) {
+    if ((await first.next()) === null) break;
+  }
+  // Simulate the child process dying.
+  fake.onClose?.();
+  const snapshot = await runDevin(runtime, service.snapshot);
+  assert.equal(snapshot.sessionId, undefined);
+
+  const controller = await runDevin(runtime, service.beginStreamTurn(TURN()));
+  assert.deepEqual(fake.loaded, ["sess-1"], "next turn reloads the same session");
+  assert.equal(fake.createdSessions.length, 1, "no fresh session while load succeeds");
+  assert.equal(fake.prompts.at(-1)?.sessionId, "sess-1");
+  for (;;) {
+    if ((await controller.next()) === null) break;
+  }
+  await runtime.dispose();
+});
+
+test("devin acp process exit falls back to a bootstrapped fresh session", async () => {
+  const { fake, runtime, service } = await makeRuntime();
+  const first = await runDevin(runtime, service.beginStreamTurn(TURN()));
+  for (;;) {
+    if ((await first.next()) === null) break;
+  }
+  fake.failLoads.add("sess-1");
+  fake.onClose?.();
+
+  const controller = await runDevin(
+    runtime,
+    service.beginStreamTurn(TURN({ historyBootstrap: "user:\nprevious question" })),
+  );
+  assert.equal(fake.createdSessions.length, 2, "load failure creates a fresh session");
+  const sent = fake.prompts.at(-1);
+  assert.ok(
+    sent?.blocks.some((b) => b.type === "resource"),
+    "fresh session receives the pi history bootstrap",
+  );
+  for (;;) {
+    if ((await controller.next()) === null) break;
+  }
+  const snapshot = await runDevin(runtime, service.snapshot);
+  assert.equal(snapshot.sessionId, "sess-2");
+  assert.equal(snapshot.turns, 1, "stale counters from the dead session are dropped");
   await runtime.dispose();
 });

--- a/packages/pi-devin/test/session-state.test.ts
+++ b/packages/pi-devin/test/session-state.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import {
+  DEVIN_SESSION_STATE_ENTRY,
+  parsePersistedDevinState,
+  restorableDevinSession,
+  type PersistedDevinSession,
+} from "../lib/session-state.ts";
+
+function customEntry(data: unknown): SessionEntry {
+  return { type: "custom", customType: DEVIN_SESSION_STATE_ENTRY, data } as SessionEntry;
+}
+
+function messageEntry(): SessionEntry {
+  return { type: "message", id: "m1" } as unknown as SessionEntry;
+}
+
+const STATE: PersistedDevinSession = {
+  version: 1,
+  kind: "session",
+  sessionId: "pi-session-1",
+  acpSessionId: "near-swan",
+  cwd: "/tmp",
+  modelId: "claude-opus-5",
+  turns: 3,
+  contextTokens: 12000,
+};
+
+test("restorableDevinSession returns the binding when branch ends cleanly", () => {
+  const branch = [messageEntry(), customEntry(STATE)];
+  assert.deepEqual(restorableDevinSession(branch, "pi-session-1", "/tmp"), STATE);
+});
+
+test("restorableDevinSession rejects stale bindings after context-changing entries", () => {
+  const branch = [customEntry(STATE), messageEntry()];
+  assert.equal(restorableDevinSession(branch, "pi-session-1", "/tmp"), undefined);
+});
+
+test("restorableDevinSession honors reset markers and foreign sessions", () => {
+  const reset = { version: 1, kind: "reset", sessionId: "pi-session-1", cwd: "/tmp" };
+  assert.equal(
+    restorableDevinSession([customEntry(STATE), customEntry(reset)], "pi-session-1", "/tmp"),
+    undefined,
+  );
+  assert.equal(restorableDevinSession([customEntry(STATE)], "other-pi-session", "/tmp"), undefined);
+  assert.equal(restorableDevinSession([customEntry(STATE)], "pi-session-1", "/other"), undefined);
+});
+
+test("parsePersistedDevinState validates shape", () => {
+  assert.equal(parsePersistedDevinState(STATE)?.kind, "session");
+  assert.equal(parsePersistedDevinState({ ...STATE, turns: -1 }), undefined);
+  assert.equal(parsePersistedDevinState({ ...STATE, acpSessionId: "" }), undefined);
+  assert.equal(parsePersistedDevinState({ version: 2 }), undefined);
+  assert.equal(parsePersistedDevinState("nope"), undefined);
+});

--- a/packages/pi-devin/test/turn.test.ts
+++ b/packages/pi-devin/test/turn.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DevinTurnController } from "../src/turn.ts";
+import type { DevinToolView } from "../lib/tool-content.ts";
+
+const view = (id: string, status?: string): DevinToolView => ({
+  id,
+  title: `tool ${id}`,
+  status,
+});
+
+test("controller queues activities and resolves waiters in order", async () => {
+  const c = new DevinTurnController("p", "s1");
+  const first = c.next();
+  c.push({ type: "text", delta: "a" });
+  assert.deepEqual(await first, { type: "text", delta: "a" });
+  c.push({ type: "text", delta: "b" });
+  c.close();
+  assert.deepEqual(await c.next(), { type: "text", delta: "b" });
+  assert.equal(await c.next(), null);
+});
+
+test("incomplete tools are tracked until terminal updates", () => {
+  const c = new DevinTurnController("p", "s1");
+  c.push({ type: "tool_start", view: view("t1", "in_progress") });
+  c.push({ type: "tool_start", view: view("t2", "in_progress") });
+  c.push({ type: "tool_update", view: view("t1", "completed") });
+  assert.deepEqual(
+    c.takeIncompleteTools().map((v) => v.id),
+    ["t2"],
+  );
+  assert.deepEqual(c.takeIncompleteTools(), []);
+});
+
+test("deferResult keeps a result pending for re-entry after close", async () => {
+  const c = new DevinTurnController("p", "s1");
+  c.push({ type: "result", stopReason: "end_turn" });
+  c.close();
+  assert.equal(c.isClosed(), true);
+  const result = await c.next();
+  assert.deepEqual(result, { type: "result", stopReason: "end_turn" });
+  assert.equal(c.hasPending(), false);
+  c.deferResult(result as never);
+  assert.equal(c.hasPending(), true);
+  assert.deepEqual(await c.next(), { type: "result", stopReason: "end_turn" });
+  assert.equal(await c.next(), null);
+});
+
+test("fail rejects pending and future next() calls", async () => {
+  const c = new DevinTurnController("p", "s1");
+  const pending = c.next();
+  c.fail(new Error("boom"));
+  await assert.rejects(pending, /boom/);
+  await assert.rejects(c.next(), /boom/);
+});

--- a/packages/pi-devin/test/updates.test.ts
+++ b/packages/pi-devin/test/updates.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import { acpUpdateToActivities, agentStoppedToActivity } from "../src/updates.ts";
+
+test("agent_message_chunk maps to text delta with messageId", () => {
+  const update = {
+    sessionUpdate: "agent_message_chunk",
+    content: { type: "text", text: "Hello " },
+    messageId: "m1",
+  } as unknown as SessionUpdate;
+  assert.deepEqual(acpUpdateToActivities(update), [
+    { type: "text", delta: "Hello ", messageId: "m1" },
+  ]);
+});
+
+test("agent_thought_chunk maps to thought delta", () => {
+  const update = {
+    sessionUpdate: "agent_thought_chunk",
+    content: { type: "text", text: "thinking…" },
+  } as unknown as SessionUpdate;
+  assert.deepEqual(acpUpdateToActivities(update), [
+    { type: "thought", delta: "thinking…", messageId: undefined },
+  ]);
+});
+
+test("tool_call maps to tool_start with normalized view", () => {
+  const update = {
+    sessionUpdate: "tool_call",
+    toolCallId: "write_1",
+    title: "Wrote /tmp/x.txt",
+    kind: "edit",
+    status: "in_progress",
+    content: [{ type: "diff", path: "/tmp/x.txt", newText: "hello" }],
+    locations: [{ path: "/tmp/x.txt" }],
+    rawInput: { file_path: "/tmp/x.txt" },
+    _meta: { "cognition.ai/inferenceToolName": "write" },
+  } as unknown as SessionUpdate;
+  const [activity] = acpUpdateToActivities(update);
+  assert.equal(activity.type, "tool_start");
+  if (activity.type !== "tool_start") return;
+  assert.equal(activity.view.id, "write_1");
+  assert.equal(activity.view.tool, "write");
+  assert.equal(activity.view.kind, "edit");
+  assert.equal(activity.view.diff?.[0].path, "/tmp/x.txt");
+  assert.deepEqual(activity.view.locations, ["/tmp/x.txt"]);
+});
+
+test("tool_call_update merges content and status", () => {
+  const update = {
+    sessionUpdate: "tool_call_update",
+    toolCallId: "read_0",
+    status: "completed",
+    content: [{ type: "content", content: { type: "text", text: "file body" } }],
+    _meta: { "cognition.ai/inferenceToolName": "read" },
+  } as unknown as SessionUpdate;
+  const [activity] = acpUpdateToActivities(update);
+  assert.equal(activity.type, "tool_update");
+  if (activity.type !== "tool_update") return;
+  assert.equal(activity.view.status, "completed");
+  assert.equal(activity.view.output, "file body");
+});
+
+test("usage_update maps _meta token counters and context occupancy", () => {
+  const update = {
+    sessionUpdate: "usage_update",
+    used: 13460,
+    size: 262000,
+    _meta: {
+      "cognition.ai/inputTokens": 13336,
+      "cognition.ai/outputTokens": 13,
+      "cognition.ai/cachedReadTokens": 13322,
+    },
+  } as unknown as SessionUpdate;
+  assert.deepEqual(acpUpdateToActivities(update), [
+    {
+      type: "usage",
+      usage: {
+        contextUsed: 13460,
+        contextSize: 262000,
+        inputTokens: 13336,
+        outputTokens: 13,
+        cachedReadTokens: 13322,
+      },
+    },
+  ]);
+});
+
+test("session_info_update and mode updates map to state activities", () => {
+  const info = {
+    sessionUpdate: "session_info_update",
+    title: "My task",
+  } as unknown as SessionUpdate;
+  assert.deepEqual(acpUpdateToActivities(info), [{ type: "title", title: "My task" }]);
+  const mode = {
+    sessionUpdate: "current_mode_update",
+    currentModeId: "plan",
+  } as unknown as SessionUpdate;
+  assert.deepEqual(acpUpdateToActivities(mode), [{ type: "mode", modeId: "plan" }]);
+});
+
+test("plan updates map to plan activity", () => {
+  const update = {
+    sessionUpdate: "plan",
+    entries: [
+      { content: "Step one", status: "completed" },
+      { content: "Step two", status: "in_progress" },
+    ],
+  } as unknown as SessionUpdate;
+  const [activity] = acpUpdateToActivities(update);
+  assert.equal(activity.type, "plan");
+  if (activity.type !== "plan") return;
+  assert.equal(activity.entries.length, 2);
+  assert.equal(activity.entries[1].status, "in_progress");
+});
+
+test("user_message_chunk and unknown updates are ignored", () => {
+  const user = {
+    sessionUpdate: "user_message_chunk",
+    content: { type: "text", text: "echo" },
+  } as unknown as SessionUpdate;
+  assert.deepEqual(acpUpdateToActivities(user), []);
+});
+
+test("agentStoppedToActivity parses _cognition.ai/agent_stopped stats", () => {
+  const activity = agentStoppedToActivity({
+    cause: "end_turn",
+    stats: {
+      toolCalls: 6,
+      filesChanged: 1,
+      inputTokens: 14023,
+      outputTokens: 18,
+      ttftMs: 299,
+      tokensPerSec: 22.5,
+      modelLabel: "Claude Opus 5 Max",
+    },
+  });
+  assert.equal(activity?.type, "stopped");
+  if (activity?.type !== "stopped") return;
+  assert.equal(activity.stats.tokensPerSec, 22.5);
+  assert.equal(activity.stats.inputTokens, 14023);
+  assert.equal(agentStoppedToActivity("junk"), undefined);
+});

--- a/packages/pi-devin/tsconfig.json
+++ b/packages/pi-devin/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["index.ts", "lib/**/*.ts", "src/**/*.ts", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,49 @@ importers:
         specifier: ^0.84.2
         version: 0.84.2
 
+  packages/pi-devin:
+    dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: 1.4.0
+        version: 1.4.0(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: ^0.84.2
+        version: 0.84.2(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.84.2
+        version: 0.84.2(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: ^0.84.2
+        version: 0.84.2
+      effect:
+        specifier: 4.0.0-beta.101
+        version: 4.0.0-beta.101
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
+      typebox:
+        specifier: '*'
+        version: 1.3.15
+      which:
+        specifier: ^7.0.0
+        version: 7.0.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@effect/language-service':
+        specifier: ^0.87.2
+        version: 0.87.2
+      '@types/semver':
+        specifier: ^7.8.0
+        version: 7.8.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   packages/pi-edit-safe:
     dependencies:
       '@earendil-works/pi-coding-agent':
@@ -421,6 +464,11 @@ importers:
         version: 7.0.2
 
 packages:
+
+  '@agentclientprotocol/sdk@1.4.0':
+    resolution: {integrity: sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -1727,6 +1775,10 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@agentclientprotocol/sdk@1.4.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
@@ -3061,5 +3113,4 @@ snapshots:
 
   yaml@2.9.0: {}
 
-  zod@4.4.3:
-    optional: true
+  zod@4.4.3: {}


### PR DESCRIPTION
## Summary

New `@tian.zuo/pi-devin` extension: registers `devin/*` models in pi, driven by `devin acp` (Agent Client Protocol over stdio). Devin's native server-side agent loop is preserved — pi renders streamed output and display-only tool cards rather than executing tools itself.

- **Transport**: `@agentclientprotocol/sdk` NDJSON client; one `devin acp` process hosts all sessions
- **Models**: `devin models list` parsed into family-level pi models; pi thinking suffixes resolve to concrete Devin rows (`devin/claude-opus-5:high` → `claude-opus-5-high`); `-fast`/`-priority` and context variants (`-1m`) become their own pi models; catalog cached in `~/.pi/devin/models.json` with a bundled fallback
- **Sessions**: each pi branch binds to a Devin session id persisted in `pi-devin-session-state` entries; `session/load` resumes across process restarts (listeners attach before load, since ACP replays history before the response); missing sessions fall back to `session/new` with pi history bootstrap; pi compaction/summarization runs in disposable ACP sessions
- **Tools**: `tool_call`/`tool_call_update` become synthetic `devin` tool calls; pi executes them via a display-only wrapper that replays the recorded result (`toolUse` re-entry), never re-running the tool
- **Permissions**: `session/request_permission` → `ctx.ui.select`; headless denies by default (`PI_DEVIN_HEADLESS_PERMISSION=allow` opts in); Devin's own mode (`/devin mode ask|plan|accept-edits|bypass`) stays an independent gate
- **Commands**: `/devin` status, `reset`, `sessions` (attach/delete), `mode`, `models`, `login` (browser auth), `doctor` (binary/auth/catalog/runtime diagnostics)
- **Stats**: `_cognition.ai/agent_stopped` turn stats (ttft, tokens/sec) surface via the provider activity hook

Notes: Devin ACP does not implement `session/resume`, `session/fork`, or `session/close` (probed — Method not found). Empty sessions don't persist server-side.

#### Test plan
- [x] 31 unit tests: models parser, update mapping, session state, turn controller, runtime (fake client), provider event sequencing
- [x] Live integration test: real `devin acp` initialize → session/new → prompt round-trip
- [x] Manual e2e: `pi -e extensions/pi-devin.ts --model devin/swe-2 -p …` — thinking/text stream, usage, session persistence; tool-call run shows `toolUse` → wrapper replay → re-entry → final answer with correct card titles/kinds
- [x] `pnpm -w run typecheck`, `pnpm -w run check`, `pnpm -w test` (pre-push hooks green)

Generated with [Devin](https://devin.ai)
