### PR TITLE
fix(pi-antigravity): surface subagent steps, guard stale ctx, async orphan scan

### DIFF
--- a/.changeset/agy-async-orphan-scan.md
+++ b/.changeset/agy-async-orphan-scan.md
@@ -1,0 +1,13 @@
+---
+"@tian.zuo/pi-antigravity": patch
+---
+
+Move the per-tool-start orphan snapshot off the event loop: a new tool step now queues a coalesced async `ps` scan instead of running `spawnSync("ps")` inside the driver's line handler, so tool bursts no longer stall the TUI. A turn that dies while a scan is still queued settles only after the snapshot lands, preserving the "recorded before agy exits" guarantee.
+
+Task scans no longer read whole task logs on every poll — `listAgyTasks` reads only an 8 KiB head for the description line (widget rescans every 2 s, the dashboard every 1 s, and a long-lived task's log grows without bound), and a log deleted mid-scan no longer fails the whole listing.
+
+Subagent steps are no longer invisible: agy emits `invoke_subagent`/`send_message`/`manage_subagents` as `step_type: "subagent"` with the payload under `subagent_info` (not `tool_info`), and the reducer used to drop them entirely — no tool card, and `/agy-subagents` always reported nothing. They now fold into normal tool activities with normalized args, so spawns render as cards and the roster finally populates.
+
+Stale-session safety: every session-bound ctx getter throws once pi invalidates the extension runner, and `agent_settled`/`model_select` can still be dispatched around a session swap or shutdown. Handlers now probe ctx before touching it, and `persistConversationState` reads its fields before awaiting — the `extension_error` noise seen when a turn settles during `/new` or quit is gone.
+
+Smaller fixes: `stopAgyTask` no longer double-counts a holder already reached by its process-group signal; `/agy` reports the scheduling context window (1m) instead of a hardcoded `185k`; `/agy` with arguments now lists every `agy-*` command; navigating the session tree clears the subagent roster like `/agy-reset` does; the wrapper-tool activation sync tolerates unavailable tool APIs like the other tool callers; one-shot `agy` spawns and the `/usage` exec path now pass `windowsHide`; and the duplicated `agyBrainDir()` lives in `lib/agy-paths.ts`.

--- a/packages/pi-antigravity/index.ts
+++ b/packages/pi-antigravity/index.ts
@@ -52,6 +52,7 @@ import {
   type SkillLite,
 } from "./lib/skills.ts";
 import {
+  AGY_PI_SCHEDULING_CONTEXT_WINDOW,
   capabilitiesForModel,
   FALLBACK_MODELS,
   mergeAgyModels,
@@ -293,16 +294,39 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
     turns: number;
   }): string => `${state.conversationId}:${state.modelId}:${state.turns}`;
 
+  /**
+   * Every session-bound getter on a stale ctx throws once pi invalidates the
+   * extension runner (dispose/newSession/fork/switchSession/reload), and
+   * events dispatched around the swap — e.g. agent_settled landing after a
+   * /new or a shutdown — still reach our handlers. Probe first; a dead session
+   * has nothing to persist into and no widget to update.
+   */
+  function probeCtx<T>(read: () => T): { stale: true } | { stale: false; value: T } {
+    try {
+      return { stale: false, value: read() };
+    } catch {
+      return { stale: true };
+    }
+  }
+
   async function persistConversationState(ctx: ExtensionContext, force = false): Promise<void> {
-    if (ctx.model?.provider !== "antigravity") return;
+    // Read every session-bound field before the first await — the stale window
+    // widens once this handler yields.
+    const probe = probeCtx(() => ({
+      provider: ctx.model?.provider,
+      sessionId: ctx.sessionManager.getSessionId(),
+      cwd: ctx.cwd,
+    }));
+    if (probe.stale || probe.value.provider !== "antigravity") return;
+    const { sessionId, cwd } = probe.value;
     const snapshot = await runAntigravity(runtime, service.snapshot);
-    if (!snapshot.conversationId || !snapshot.model || snapshot.cwd !== ctx.cwd) return;
+    if (!snapshot.conversationId || !snapshot.model || snapshot.cwd !== cwd) return;
     const state: PersistedAgyConversation = {
       version: 1,
       kind: "conversation",
-      sessionId: ctx.sessionManager.getSessionId(),
+      sessionId,
       conversationId: snapshot.conversationId,
-      cwd: ctx.cwd,
+      cwd,
       modelId: snapshot.model,
       turns: snapshot.turns,
       usage: snapshot.conversationUsage,
@@ -310,18 +334,31 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
     };
     const key = conversationStateKey(state);
     if (!force && key === persistedConversationKey) return;
-    pi.appendEntry(AGY_CONVERSATION_STATE_ENTRY, state);
+    try {
+      pi.appendEntry(AGY_CONVERSATION_STATE_ENTRY, state);
+    } catch {
+      return; // Session went stale mid-persist.
+    }
     persistedConversationKey = key;
   }
 
   function appendConversationReset(ctx: ExtensionContext): void {
+    const probe = probeCtx(() => ({
+      sessionId: ctx.sessionManager.getSessionId(),
+      cwd: ctx.cwd,
+    }));
+    if (probe.stale) return;
     const reset: PersistedAgyReset = {
       version: 1,
       kind: "reset",
-      sessionId: ctx.sessionManager.getSessionId(),
-      cwd: ctx.cwd,
+      sessionId: probe.value.sessionId,
+      cwd: probe.value.cwd,
     };
-    pi.appendEntry(AGY_CONVERSATION_STATE_ENTRY, reset);
+    try {
+      pi.appendEntry(AGY_CONVERSATION_STATE_ENTRY, reset);
+    } catch {
+      return;
+    }
     observedContextTokens = undefined;
     persistedConversationKey = undefined;
   }
@@ -423,6 +460,8 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
    * every agy spawn), so nothing is appended to the prompt. When the bridge
    * is off OR failed to register, pi-private skills are simply unavailable —
    * warn the user once instead of stuffing the catalog into the prompt.
+   * The undefined return is intentional; the runtime's bootstrapSuffix
+   * plumbing stays so a future direct-mode catalog needs no new wiring.
    */
   const getBootstrapSuffix = () => {
     bridgeManager.warnSkillsUnavailable(bridgedSkills());
@@ -607,7 +646,11 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
           ...compaction,
           detectedAt: new Date().toISOString(),
         };
-        pi.appendEntry(AGY_COMPACTION_ENTRY, marker);
+        try {
+          pi.appendEntry(AGY_COMPACTION_ENTRY, marker);
+        } catch {
+          // Session replaced mid-activity; the marker is advisory only.
+        }
       }
       observedContextTokens = nextContextTokens;
       return;
@@ -733,16 +776,20 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
   // source while the agent or any discovered task is live, then stop when
   // both are idle. This keeps the widget current without a permanent timer.
   pi.on("agent_start", (_event, ctx) => {
-    if (ctx.model?.provider !== "antigravity") return;
+    const probe = probeCtx(() => ctx.model?.provider);
+    if (probe.stale || probe.value !== "antigravity") return;
     agyAgentActive = true;
     updateAgyTasksWidget();
     reconcileWidgetPolling();
   });
 
-  pi.on("agent_settled", (_event, ctx) => {
-    if (ctx.model?.provider !== "antigravity" && !agyAgentActive) return;
-    agyAgentActive = false;
-    updateAgyTasksWidget();
+  pi.on("agent_settled", async (_event, ctx: ExtensionContext) => {
+    const probe = probeCtx(() => ctx.model?.provider);
+    if (!probe.stale && (probe.value === "antigravity" || agyAgentActive)) {
+      agyAgentActive = false;
+      updateAgyTasksWidget();
+    }
+    await persistConversationState(ctx);
   });
 
   // The display-only `antigravity` wrapper tool only matters while an agy
@@ -751,13 +798,17 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
   // active-tool state whenever the selected model changes, including the
   // session's initial restore.
   const syncWrapperToolActivation = (provider: string | undefined) => {
-    const next = wrapperToolActiveAfterModelSwitch(
-      pi.getActiveTools(),
-      WRAPPER_TOOL_NAME,
-      provider,
-      "antigravity",
-    );
-    if (next) pi.setActiveTools([...next]);
+    try {
+      const next = wrapperToolActiveAfterModelSwitch(
+        pi.getActiveTools(),
+        WRAPPER_TOOL_NAME,
+        provider,
+        "antigravity",
+      );
+      if (next) pi.setActiveTools([...next]);
+    } catch {
+      // Tool APIs unavailable (print/RPC edge) — leave the set untouched.
+    }
   };
 
   pi.on("session_start", async (event, ctx: ExtensionContext) => {
@@ -817,14 +868,18 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
       // Another provider/model can add context that the mutable agy
       // conversation never saw. Force a branch bootstrap when agy is selected
       // again instead of silently resuming stale native history.
-      await runAntigravity(runtime, service.setSession(ctx.cwd, undefined, true));
-      observedContextTokens = undefined;
-      persistedConversationKey = undefined;
+      const cwd = probeCtx(() => ctx.cwd);
+      if (!cwd.stale) {
+        await runAntigravity(runtime, service.setSession(cwd.value, undefined, true));
+        observedContextTokens = undefined;
+        persistedConversationKey = undefined;
+      }
     }
     selectedModelKey = nextModelKey;
     // The bridge exists only while an Antigravity model is selected.
     if (event.model?.provider === "antigravity") {
-      await ensureBridgeRegistered(ctx?.ui);
+      const ui = probeCtx(() => ctx?.ui);
+      await ensureBridgeRegistered(ui.stale ? undefined : ui.value);
       await refreshStaleModelsWhenSelected();
     } else {
       await teardownBridge();
@@ -834,14 +889,13 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
   pi.on("session_tree", async (_event, ctx: ExtensionContext) => {
     // An agy conversation cannot be rewound to match a different pi branch.
     // Restart it and bootstrap the selected branch on the next provider call.
-    await runAntigravity(runtime, service.setSession(ctx.cwd, undefined, true));
+    const cwd = probeCtx(() => ctx.cwd);
+    if (cwd.stale) return;
+    await runAntigravity(runtime, service.setSession(cwd.value, undefined, true));
     appendConversationReset(ctx);
+    subagentRoster.clear();
     setAgyTasksWidget(0);
     setAgyArtifactsWidget(0);
-  });
-
-  pi.on("agent_settled", async (_event, ctx: ExtensionContext) => {
-    await persistConversationState(ctx);
   });
 
   pi.on("session_compact", async (_event, ctx: ExtensionContext) => {
@@ -950,7 +1004,7 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
     handler: async (args, ctx) => {
       if (args.trim()) {
         ctx.ui.notify(
-          'antigravity: use "/agy-reset", "/agy-models", "/agy-agents", "/agy-subagents", or "/agy-doctor".',
+          'antigravity: use "/agy-reset", "/agy-models", "/agy-agents", "/agy-doctor", "/agy-subagents", "/agy-tasks", "/agy-artifacts", or "/agy-usage".',
           "error",
         );
         return;
@@ -971,7 +1025,7 @@ export default function antigravityExtension(pi: ExtensionAPI): void {
         `driver: ${snapshot.executor.mode}/${snapshot.executor.state}${snapshot.executor.pid ? ` pid=${snapshot.executor.pid}` : ""}`,
         observedContextTokens === undefined
           ? undefined
-          : `native context: ~${formatAgyContextTokens(observedContextTokens)}/185k`,
+          : `native context: ~${formatAgyContextTokens(observedContextTokens)}/${formatAgyContextTokens(AGY_PI_SCHEDULING_CONTEXT_WINDOW)}`,
         metadata?.metadata?.numSteps === undefined
           ? undefined
           : `native steps: ${metadata.metadata.numSteps}`,

--- a/packages/pi-antigravity/lib/agy-client.ts
+++ b/packages/pi-antigravity/lib/agy-client.ts
@@ -169,6 +169,7 @@ export async function runAgyTurn(request: AgyTurnRequest): Promise<AgyTurnOutcom
       // Own process group so one negative-pid SIGKILL reaps agy's whole
       // tree on timeout/abort instead of leaving grandchildren running.
       detached: true,
+      windowsHide: true,
     });
     trackAgyChild(child);
     const outcome = newTurnOutcome();

--- a/packages/pi-antigravity/lib/agy-driver.ts
+++ b/packages/pi-antigravity/lib/agy-driver.ts
@@ -14,6 +14,7 @@ import {
   agyHasRunningToolProcess,
   agyTurnTranscriptVerdict,
   recordAgyTaskOrphans,
+  recordAgyTaskOrphansAsync,
   type AgyTranscriptVerdict,
 } from "./tasks.ts";
 import { agyToolStepKey, trackActiveToolStep } from "./tool-steps.ts";
@@ -221,6 +222,16 @@ export class AgyDriverSession implements AgyTurnExecutor {
   ) => Promise<AgyTranscriptVerdict | undefined> = agyTurnTranscriptVerdict;
   #parkedPollMs = STALL_PARKED_POLL_MS;
   #parkedLimit = STALL_PARKED_LIMIT;
+  /**
+   * Async orphan-scan queue for tool-start activity. A `ps` snapshot is a
+   * subprocess spawn, so the line handler must not run it synchronously;
+   * scans coalesce because one fresh table already captures every
+   * group-leading child agy currently has — only the latest request needs a
+   * trailing run.
+   */
+  #orphanScanPending: { pid: number; conversationId: string } | undefined;
+  #orphanScanRunning = false;
+  #orphanScanTail: Promise<void> = Promise.resolve();
 
   /** Test hook: override the tool-liveness probe and its grace ceiling. */
   setStallLivenessProbe(
@@ -725,16 +736,17 @@ export class AgyDriverSession implements AgyTurnExecutor {
     for (const activity of applyEvent(turn.outcome, parsed)) {
       // agy can repeat the same ACTIVE step line; only a genuinely new tool
       // start may have spawned a process group worth recording. Repeated
-      // updates for a step already tracked skip the synchronous `ps` scan,
-      // but a NEW tool start never does — a missed snapshot means an agy
-      // crash later leaves the worker orphaned and unrecorded.
+      // updates for a step already tracked skip the scan, but a NEW tool
+      // start never does — a missed snapshot means an agy crash later leaves
+      // the worker orphaned and unrecorded.
       const newToolStart =
         activity.type === "tool_start" && !turn.activeTools.has(agyToolStepKey(activity));
       trackActiveToolStep(turn.activeTools, activity);
       // Snapshot task-shaped children while agy can still be their parent:
       // a later unexpected agy exit re-parents them and the linkage is gone.
+      // The scan is queued async so a `ps` spawn never blocks line handling.
       if (newToolStart && this.#child) {
-        recordAgyTaskOrphans(
+        this.#queueOrphanScan(
           this.#child.pid,
           turn.outcome.conversationId ?? this.#boundConversationId,
         );
@@ -767,6 +779,31 @@ export class AgyDriverSession implements AgyTurnExecutor {
     }
   }
 
+  /**
+   * Queue a process-table snapshot for a fresh tool start. Recording is
+   * advisory, so the `ps` spawn must not sit inside the line handler: one
+   * scan already captures every group-leading child agy currently has, so
+   * requests coalesce and only the latest needs a trailing run.
+   */
+  #queueOrphanScan(pid: number | undefined, conversationId: string | undefined): void {
+    if (pid === undefined || !conversationId) return;
+    this.#orphanScanPending = { pid, conversationId };
+    if (this.#orphanScanRunning) return;
+    this.#orphanScanRunning = true;
+    this.#orphanScanTail = (async () => {
+      try {
+        for (;;) {
+          const pending = this.#orphanScanPending;
+          this.#orphanScanPending = undefined;
+          if (!pending) break;
+          await recordAgyTaskOrphansAsync(pending.pid, pending.conversationId);
+        }
+      } finally {
+        this.#orphanScanRunning = false;
+      }
+    })();
+  }
+
   #onChildClose(generation: number, code: number | null, signal: NodeJS.Signals | null): void {
     if (generation !== this.#generation) return;
     if (this.#stdoutBuffer.trim() && this.#active) {
@@ -786,12 +823,20 @@ export class AgyDriverSession implements AgyTurnExecutor {
         : ` (no stderr${this.#config?.model ? ` model=${this.#config.model}` : ""}${
             this.#boundConversationId ? ` conv=${this.#boundConversationId.slice(0, 8)}` : ""
           }). The cause is unknown. Try /agy-reset before retrying, or set PI_ANTIGRAVITY_DRIVER=0 for one-shot mode. Check for commands still running before retrying; use pi's own bash for long-lived commands.`;
-      this.#settleTurn(turn, {
-        error: new AgySpawnError(
-          `agy exited with code ${code ?? signal ?? "signal"} before producing a result${hint}`,
-          this.#stderrTail,
-        ),
-      });
+      const settle = () =>
+        this.#settleTurn(turn, {
+          error: new AgySpawnError(
+            `agy exited with code ${code ?? signal ?? "signal"} before producing a result${hint}`,
+            this.#stderrTail,
+          ),
+        });
+      // Let any queued orphan snapshot land before reporting the turn dead:
+      // its scan was scheduled while this agy could still be the parent.
+      if (this.#orphanScanRunning || this.#orphanScanPending) {
+        void this.#orphanScanTail.then(settle, settle);
+      } else {
+        settle();
+      }
     }
   }
 

--- a/packages/pi-antigravity/lib/agy-paths.ts
+++ b/packages/pi-antigravity/lib/agy-paths.ts
@@ -1,0 +1,9 @@
+/** Shared on-disk locations for agy's own CLI state. */
+
+import * as os from "node:os";
+import * as path from "node:path";
+
+/** Per-conversation state root (`brain/<conversation-id>/`). */
+export function agyBrainDir(home = os.homedir()): string {
+  return path.join(home, ".gemini", "antigravity-cli", "brain");
+}

--- a/packages/pi-antigravity/lib/artifacts.ts
+++ b/packages/pi-antigravity/lib/artifacts.ts
@@ -1,8 +1,8 @@
 /** Safe discovery of user-facing files in an agy conversation brain directory. */
 
 import { promises as fs, type Dirent } from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
+import { agyBrainDir } from "./agy-paths.ts";
 
 export interface AgyArtifact {
   name: string;
@@ -11,10 +11,6 @@ export interface AgyArtifact {
   mediaType: "image" | "audio" | "video" | "pdf" | "markdown" | "other";
   bytes: number;
   modifiedMs: number;
-}
-
-export function agyBrainDir(): string {
-  return path.join(os.homedir(), ".gemini", "antigravity-cli", "brain");
 }
 
 const MEDIA_TYPES: Record<string, AgyArtifact["mediaType"]> = {

--- a/packages/pi-antigravity/lib/events.ts
+++ b/packages/pi-antigravity/lib/events.ts
@@ -37,7 +37,24 @@ export interface AgyToolInfo {
 }
 
 export type AgyStepState = "ACTIVE" | "DONE" | "ERROR" | string;
-export type AgyStepType = "user_input" | "checkpoint" | "agent_response" | "tool" | (string & {});
+export type AgyStepType =
+  | "user_input"
+  | "checkpoint"
+  | "agent_response"
+  | "tool"
+  | "subagent"
+  | "system_message"
+  | (string & {});
+
+/** One spawned subagent record inside a `subagent` step's `subagent_info`. */
+export interface AgySubagentSpawn {
+  type_name?: string;
+  role?: string;
+  initial_prompt?: string;
+  /** Set once the spawn completes (DONE state). */
+  conversation_id?: string;
+  log_uri?: string;
+}
 
 export interface AgyStepUpdate {
   conversation_id?: string;
@@ -46,6 +63,11 @@ export interface AgyStepUpdate {
   step_type?: AgyStepType;
   tool_name?: string;
   tool_info?: AgyToolInfo;
+  /**
+   * `step_type: "subagent"` steps (invoke_subagent & friends) carry their
+   * payload here instead of tool_info — parameters are absent entirely.
+   */
+  subagent_info?: { subagents?: AgySubagentSpawn[] };
   duration_seconds?: number;
   usage?: AgyUsage;
   output?: string;

--- a/packages/pi-antigravity/lib/reducer.ts
+++ b/packages/pi-antigravity/lib/reducer.ts
@@ -8,7 +8,7 @@
  * events the provider renders as native pi tool cards.
  */
 
-import type { AgyUsage, ParsedAgyEvent } from "./events.ts";
+import type { AgyStepUpdate, AgyUsage, ParsedAgyEvent } from "./events.ts";
 import { parseAgyLine } from "./events.ts";
 
 /**
@@ -94,6 +94,40 @@ export interface AgyTurnOutcome {
   finished: boolean;
 }
 
+/**
+ * Flatten `subagent_info.subagents` into the arg map the roster's
+ * pickName/pickDetail and the call renderer already read (Name/Type/Task).
+ * The first spawn leads; extra spawns in the same step fold into the name.
+ */
+function subagentStepArgs(step: AgyStepUpdate): Record<string, unknown> {
+  const subs = step.subagent_info?.subagents;
+  if (!subs?.length) return {};
+  const first = subs[0];
+  const args: Record<string, unknown> = {};
+  if (first.role) args.Name = subs.length > 1 ? `${first.role} +${subs.length - 1}` : first.role;
+  if (first.type_name) args.Type = first.type_name;
+  if (first.initial_prompt) args.Task = first.initial_prompt;
+  if (first.conversation_id) args.ConversationId = first.conversation_id;
+  if (first.log_uri) args.LogUri = first.log_uri;
+  return args;
+}
+
+/** DONE subagent steps carry no output field; summarize the spawn records. */
+function subagentStepOutput(step: AgyStepUpdate): string | undefined {
+  const subs = step.subagent_info?.subagents;
+  if (!subs?.length) return undefined;
+  return subs
+    .map((sub) =>
+      [
+        `subagent ${sub.role ?? sub.type_name ?? "spawned"}`,
+        sub.conversation_id ? `conversation ${sub.conversation_id}` : undefined,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+    )
+    .join("\n");
+}
+
 export function newTurnOutcome(): AgyTurnOutcome {
   return {
     conversationId: undefined,
@@ -120,14 +154,18 @@ export function applyEvent(outcome: AgyTurnOutcome, event: ParsedAgyEvent): AgyA
       if (step.conversation_id && !outcome.conversationId) {
         outcome.conversationId = step.conversation_id;
       }
-      if (step.step_type === "tool") {
+      if (step.step_type === "tool" || step.step_type === "subagent") {
+        // Subagent steps (invoke_subagent/send_message/manage_subagents/…)
+        // arrive as step_type "subagent" with the payload under subagent_info,
+        // not tool_info — normalize both into the activity arg/output shape.
         const name = step.tool_name ?? step.tool_info?.name ?? "tool";
+        const args = step.tool_info?.parameters ?? subagentStepArgs(step);
         if (step.state === "ACTIVE") {
           activities.push({
             type: "tool_start",
             stepId: step.step_index,
             name,
-            args: step.tool_info?.parameters ?? {},
+            args,
           });
         } else if (step.state === "DONE") {
           activities.push({
@@ -135,12 +173,12 @@ export function applyEvent(outcome: AgyTurnOutcome, event: ParsedAgyEvent): AgyA
             stepId: step.step_index,
             name,
             // agy nests tool output under tool_info on DONE steps.
-            output: step.output ?? step.tool_info?.output,
+            output: step.output ?? step.tool_info?.output ?? subagentStepOutput(step),
             durationSeconds:
               typeof step.duration_seconds === "number" ? step.duration_seconds : undefined,
             // Kept so call_mcp_tool completions can be correlated with the
             // bridged server (ServerName) by the provider.
-            args: step.tool_info?.parameters ?? {},
+            args,
           });
         } else if (step.state === "ERROR") {
           // agy puts the error detail under tool_info on ERROR steps (e.g.
@@ -150,7 +188,7 @@ export function applyEvent(outcome: AgyTurnOutcome, event: ParsedAgyEvent): AgyA
             type: "tool_error",
             stepId: step.step_index,
             name,
-            args: step.tool_info?.parameters ?? {},
+            args,
             message: message.replace(/\s+/g, " ").slice(0, 160),
           });
         }

--- a/packages/pi-antigravity/lib/tasks.ts
+++ b/packages/pi-antigravity/lib/tasks.ts
@@ -40,7 +40,6 @@
 
 import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import {
   agyTaskParentIsAlive,
@@ -87,9 +86,8 @@ export interface AgyTask {
   bytes: number;
 }
 
-export function agyBrainDir(): string {
-  return path.join(os.homedir(), ".gemini", "antigravity-cli", "brain");
-}
+import { agyBrainDir } from "./agy-paths.ts";
+export { agyBrainDir };
 
 /** Extract unique positive pids from `lsof -t` output. */
 export function parseLsofPids(output: string): number[] {
@@ -109,6 +107,25 @@ export function describeTaskLog(content: string): string {
     .find((entry) => entry && !entry.startsWith("npm warn"));
   if (!line) return "(no output)";
   return line.length > 64 ? `${line.slice(0, 63)}…` : line;
+}
+
+/**
+ * Only the head of a task log is ever used (the description line), so
+ * polling must not read whole files — a long-lived task's log grows without
+ * bound while the widget/dashboard rescans it every second or two.
+ */
+const TASK_LOG_HEAD_BYTES = 8_192;
+
+async function readTaskLogHead(logPath: string): Promise<string> {
+  const handle = await fs.open(logPath, "r").catch(() => undefined);
+  if (!handle) return "";
+  try {
+    const buffer = Buffer.alloc(TASK_LOG_HEAD_BYTES);
+    const { bytesRead } = await handle.read(buffer, 0, TASK_LOG_HEAD_BYTES, 0);
+    return buffer.toString("utf8", 0, bytesRead);
+  } finally {
+    await handle.close().catch(() => {});
+  }
 }
 
 /**
@@ -213,6 +230,35 @@ export async function agyGroupSurvivors(pids: Iterable<number>): Promise<number[
   return [...new Set(rows.filter((row) => wanted.has(row.pgid)).map((row) => row.pgid))];
 }
 
+function recordAgyTaskOrphansFromRows(
+  rows: AgyProcessRow[] | undefined,
+  agyPid: number,
+  conversationId: string,
+): void {
+  const parent = rows?.find((row) => row.pid === agyPid);
+  if (rows === undefined || parent === undefined) return;
+  const { taskOrphans } = getAgyChildrenRegistry();
+  for (const { pid, startMs } of selectAgyTaskDescendants(rows, [agyPid])) {
+    const members = new Map<number, number>();
+    for (const row of rows) {
+      if (row.pgid === pid) members.set(row.pid, row.startMs);
+    }
+    taskOrphans.set(pid, {
+      conversationId,
+      parent: { pid: parent.pid, startMs: parent.startMs },
+      startMs,
+      members,
+    });
+  }
+  // Entries prune lazily during task scans once their process disappears;
+  // the cap only guards processes that outlive every scan.
+  while (taskOrphans.size > 256) {
+    const oldest = taskOrphans.keys().next().value;
+    if (oldest === undefined) break;
+    taskOrphans.delete(oldest);
+  }
+}
+
 /**
  * Record an agy process's live task-shaped children as orphans of
  * `conversationId` — the only orphan attribution that survives reparenting.
@@ -223,6 +269,9 @@ export async function agyGroupSurvivors(pids: Iterable<number>): Promise<number[
  * the recorded one after its leader exits. A failed scan records nothing —
  * writing an unverifiable record would be worse than writing none.
  * Best effort — orphan bookkeeping must never delay a teardown.
+ *
+ * Synchronous by design: teardown paths are already committed to killing the
+ * child, so the `ps` scan's blocking spawn is not on any render hot path.
  */
 export function recordAgyTaskOrphans(
   agyPid: number | undefined,
@@ -230,31 +279,28 @@ export function recordAgyTaskOrphans(
 ): void {
   if (agyPid === undefined || !conversationId) return;
   try {
-    const rows = syncAgyProcessRows();
-    const parent = rows?.find((row) => row.pid === agyPid);
-    if (rows === undefined || parent === undefined) return;
-    const { taskOrphans } = getAgyChildrenRegistry();
-    for (const { pid, startMs } of selectAgyTaskDescendants(rows, [agyPid])) {
-      const members = new Map<number, number>();
-      for (const row of rows) {
-        if (row.pgid === pid) members.set(row.pid, row.startMs);
-      }
-      taskOrphans.set(pid, {
-        conversationId,
-        parent: { pid: parent.pid, startMs: parent.startMs },
-        startMs,
-        members,
-      });
-    }
-    // Entries prune lazily during task scans once their process disappears;
-    // the cap only guards processes that outlive every scan.
-    while (taskOrphans.size > 256) {
-      const oldest = taskOrphans.keys().next().value;
-      if (oldest === undefined) break;
-      taskOrphans.delete(oldest);
-    }
+    recordAgyTaskOrphansFromRows(syncAgyProcessRows(), agyPid, conversationId);
   } catch {
     // Orphan bookkeeping is advisory; never let it break a kill path.
+  }
+}
+
+/**
+ * Async variant for the stream hot path (tool-start activity). The `ps`
+ * snapshot runs in a subprocess instead of blocking the event loop inside
+ * the driver's line handler; it still lands while agy can be the children's
+ * parent. Only a crash inside the scan's own spawn window slips past —
+ * best-effort like every other recording path.
+ */
+export async function recordAgyTaskOrphansAsync(
+  agyPid: number | undefined,
+  conversationId: string | undefined,
+): Promise<void> {
+  if (agyPid === undefined || !conversationId) return;
+  try {
+    recordAgyTaskOrphansFromRows(await agyProcessRows(), agyPid, conversationId);
+  } catch {
+    // Orphan bookkeeping is advisory; never let it break a stream handler.
   }
 }
 
@@ -646,18 +692,22 @@ export async function listAgyTasks(
     return [];
   }
   const logs = entries.filter((name) => /^task-.+\.log$/.test(name)).sort(compareAgyTaskLogNames);
-  const metadata = await Promise.all(
-    logs.map(async (name) => {
-      const logPath = path.join(dir, name);
-      const stat = await fs.stat(logPath);
-      return {
-        name,
-        logPath,
-        stat,
-        birthMs: stat.birthtimeMs || stat.mtimeMs,
-      };
-    }),
-  );
+  const metadata = (
+    await Promise.all(
+      logs.map(async (name) => {
+        const logPath = path.join(dir, name);
+        // A log deleted mid-scan must not fail the whole listing.
+        const stat = await fs.stat(logPath).catch(() => undefined);
+        if (!stat) return undefined;
+        return {
+          name,
+          logPath,
+          stat,
+          birthMs: stat.birthtimeMs || stat.mtimeMs,
+        };
+      }),
+    )
+  ).filter((entry): entry is NonNullable<typeof entry> => entry !== undefined);
 
   // Liveness must be sampled before readFile opens the logs. Running both in
   // one Promise.all made lsof randomly identify pi itself as every task's pid.
@@ -669,7 +719,7 @@ export async function listAgyTasks(
   // re-matched to an unowned one by the ancestry/orphan heuristics.
   const claimedPids = new Set([...holders.values()].flat());
   const [contents, unowned] = await Promise.all([
-    Promise.all(metadata.map(({ logPath }) => fs.readFile(logPath, "utf8").catch(() => ""))),
+    Promise.all(metadata.map(({ logPath }) => readTaskLogHead(logPath))),
     scanUnownedProcesses(
       options.sessionCwd,
       options.agyPids ?? [],
@@ -753,7 +803,9 @@ export async function stopAgyTask(task: AgyTask): Promise<AgyTaskStopResult> {
       try {
         process.kill(-pgid, "SIGTERM");
         pgids.add(pgid);
+        // The group signal already covers the holder pid — count it once.
         signaled++;
+        continue;
       } catch {
         // Fall through to the single-pid kill.
       }

--- a/packages/pi-antigravity/lib/usage.ts
+++ b/packages/pi-antigravity/lib/usage.ts
@@ -223,6 +223,7 @@ function defaultExec(
   const child = spawn(file, [...args], {
     stdio: ["ignore", "pipe", "pipe"],
     detached: true,
+    windowsHide: true,
     signal: options.signal,
   });
   trackAgyChild(child);

--- a/packages/pi-antigravity/test/reducer.test.ts
+++ b/packages/pi-antigravity/test/reducer.test.ts
@@ -75,6 +75,71 @@ test("reducer reads tool output from tool_info when top-level output is absent",
   assert.equal(done.output, "./a.ts: hi");
 });
 
+test("reducer surfaces subagent steps as tool activities", () => {
+  // Captured from agy 1.2.1 stream-json: invoke_subagent arrives as
+  // step_type "subagent" with subagent_info instead of tool_info.
+  const outcome = reduceAgyStream(
+    [
+      JSON.stringify({
+        event: "step_update",
+        step_update: {
+          conversation_id: "c-sub-1",
+          step_index: 2,
+          state: "ACTIVE",
+          step_type: "subagent",
+          tool_name: "invoke_subagent",
+          subagent_info: {
+            subagents: [
+              {
+                type_name: "research",
+                role: "File Counter",
+                initial_prompt: "Count files in the current directory.",
+              },
+            ],
+          },
+        },
+      }),
+      JSON.stringify({
+        event: "step_update",
+        step_update: {
+          conversation_id: "c-sub-1",
+          step_index: 2,
+          state: "DONE",
+          step_type: "subagent",
+          tool_name: "invoke_subagent",
+          duration_seconds: 0.145,
+          subagent_info: {
+            subagents: [
+              {
+                type_name: "research",
+                role: "File Counter",
+                initial_prompt: "Count files in the current directory.",
+                conversation_id: "8b8d97c1-2409-435f-bbf6-926328a5a12f",
+                log_uri: "file:///brain/8b8d97c1/transcript.jsonl",
+              },
+            ],
+          },
+        },
+      }),
+      JSON.stringify({ event: "result", result: { status: "SUCCESS", response: "14" } }),
+    ].join("\n"),
+  );
+
+  const start = outcome.activities.find((a) => a.type === "tool_start");
+  assert.ok(start && start.type === "tool_start");
+  assert.equal(start.name, "invoke_subagent");
+  assert.equal(start.stepId, 2);
+  assert.equal(start.args.Name, "File Counter");
+  assert.equal(start.args.Type, "research");
+  assert.equal(start.args.Task, "Count files in the current directory.");
+
+  const done = outcome.activities.find((a) => a.type === "tool_done");
+  assert.ok(done && done.type === "tool_done");
+  assert.equal(done.name, "invoke_subagent");
+  assert.ok(done.output?.includes("8b8d97c1-2409-435f-bbf6-926328a5a12f"));
+  assert.equal(done.durationSeconds, 0.145);
+});
+
 test("reducer folds a successful turn", () => {
   const outcome = reduceAgyStream(OK_CAPTURE);
   assert.equal(outcome.status, "OK");


### PR DESCRIPTION
## Summary

End-to-end testing of the latest extension against real agy 1.2.1 stream-json (gemini-3.8-flash, pi 0.85.1, RPC-driven turns) surfaced two genuine bugs, both fixed here:

- **Subagent steps were invisible.** agy emits `invoke_subagent`/`send_message`/`manage_subagents` as `step_type: "subagent"` with the payload under `subagent_info` (not `tool_info`). The reducer only translated `"tool"` steps, so subagent activity never produced a tool card and `/agy-subagents` always reported nothing — the roster added in #48 was unreachable in production. Subagent steps now fold into normal tool activities with normalized `Name`/`Type`/`Task`/`ConversationId` args; verified live: `/agy-subagents` reports `• File Counter · done` and the spawn renders as a card.
- **`agent_settled` on a stale ctx produced `extension_error` noise.** Reproduced deterministically: a turn settling while the session is disposed or replaced (`/new`, quit) threw on `ctx.model`. Following the `probeCtx` pattern already used by pi-usage, `agent_start`/`agent_settled`/`model_select`/`session_tree` now probe before touching ctx, and `persistConversationState`/`appendConversationReset` read all session-bound fields before awaiting.

Also in this patch:

- The per-tool-start orphan snapshot moved off the driver's line handler to a coalesced async `ps` scan; turn settle still waits for a queued snapshot, preserving the "recorded before agy exits" guarantee from #50.
- `listAgyTasks` reads an 8 KiB log head instead of whole task logs (widget rescans every 2 s), and a log deleted mid-scan no longer fails the listing.
- `/agy` reports the 1m scheduling context window instead of hardcoded `185k`; `/agy` arg errors list every `agy-*` command; `session_tree` clears the subagent roster like `/agy-reset`; `stopAgyTask` no longer double-counts a holder already signalled via its process group; wrapper-tool activation sync tolerates unavailable tool APIs; one-shot/`/usage` spawns pass `windowsHide`; `agyBrainDir()` deduped into `lib/agy-paths.ts`.

#### Test plan

- [x] New reducer test locks `subagent` step normalization (real captured payload)
- [x] `pnpm run typecheck` / `pnpm run check` / `pnpm test` — 329/329 package tests, all workspace green
- [x] Live RPC e2e (gemini-3.8-flash): subagent spawn + `/agy-subagents`, thinking-level→effort driver recycle, abort→reap→recovery (no #43 regression), `-c` conversation resume, model switch round-trip, `/agy-reset`, failing command, steer mid-turn, process-leak checks

Generated with [Devin](https://devin.ai)
