### PR TITLE
fix(pi-devin-acp): harden cancellation and replay lifecycle

### DIFF
--- a/.changeset/fix-devin-acp-lifecycle.md
+++ b/.changeset/fix-devin-acp-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@tian.zuo/pi-devin-acp": patch
+---
+
+Fix cancellation and session replacement races during ACP startup, isolate restored session state, and preserve the accepted mode after invalid or rejected changes. Use unique replay tool IDs across Pi provider calls, honor thinking off, account for turn usage only once, and handle tools whose initial notification is already terminal. Queue task-stop requests as steering messages while Pi is running.

--- a/packages/pi-devin-acp/index.ts
+++ b/packages/pi-devin-acp/index.ts
@@ -842,9 +842,7 @@ export default function piDevinAcpExtension(pi: ExtensionAPI): void {
     if (sub === "tasks") {
       await runDevinTasksPicker(ctx, {
         listOps: async () => (await runDevin(runtime, service.snapshot)).liveOps,
-        sendToSession: (text) => {
-          void pi.sendUserMessage(text, { expandPromptTemplates: false });
-        },
+        sendToSession: (text, options) => pi.sendUserMessage(text, options),
       });
       return;
     }

--- a/packages/pi-devin-acp/lib/prompt.ts
+++ b/packages/pi-devin-acp/lib/prompt.ts
@@ -24,6 +24,11 @@ export function devinBackgroundToolNote(shellId: string | undefined): string {
   return `devin detached this command to background shell ${shellId ?? "?"}; it may still be running server-side.`;
 }
 
+/** User-confirmed request from the tasks picker. */
+export function devinKillShellPrompt(shellId: string): string {
+  return `Kill background shell ${shellId} and confirm it stopped.`;
+}
+
 /** `devin acp` has no system-role input; relay Pi instructions as a labeled resource. */
 export function piSystemInstructionsPrompt(instructions: string): string {
   return [

--- a/packages/pi-devin-acp/src/provider.ts
+++ b/packages/pi-devin-acp/src/provider.ts
@@ -11,6 +11,7 @@
  * session/prompt via the runtime's turn controller.
  */
 
+import { randomUUID } from "node:crypto";
 import {
   calculateCost,
   createAssistantMessageEventStream,
@@ -22,7 +23,12 @@ import {
 } from "@earendil-works/pi-ai";
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import type { DevinRuntimeInstance, DevinRuntimeShape } from "./runtime.ts";
-import type { DevinActivity, DevinTurnController, DevinUsage } from "./turn.ts";
+import {
+  TERMINAL_TOOL_STATUSES,
+  type DevinActivity,
+  type DevinTurnController,
+  type DevinUsage,
+} from "./turn.ts";
 import type { DevinReplayStore } from "../lib/replay.ts";
 import { devinBackgroundToolNote, devinIncompleteToolError } from "../lib/prompt.ts";
 import { summarizeDevinCall, type DevinToolView } from "../lib/tool-content.ts";
@@ -138,7 +144,8 @@ export function mapUsage(u: DevinUsage | undefined): AssistantMessage["usage"] {
     reasoning: undefined,
     cacheRead: cached,
     cacheWrite: 0,
-    totalTokens: u?.contextUsed ?? (u?.inputTokens ?? 0) + (u?.outputTokens ?? 0),
+    // Context occupancy lives in the runtime snapshot, not billable usage.
+    totalTokens: (u?.inputTokens ?? 0) + (u?.outputTokens ?? 0),
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
   };
 }
@@ -199,6 +206,7 @@ export function streamDevin(deps: DevinProviderDeps) {
         timestamp: Date.now(),
       };
 
+      let turnController: DevinTurnController | undefined;
       let turnCleared = false;
       const clearTurn = () => {
         if (turnCleared) return;
@@ -207,6 +215,10 @@ export function streamDevin(deps: DevinProviderDeps) {
       };
 
       const fail = (message: string) => {
+        // If the ACP turn fails between replay segments, this error message
+        // is its final accounting record too.
+        output.usage = mapUsage(turnController?.lastUsage);
+        calculateCost(model, output.usage);
         output.stopReason = options?.signal?.aborted ? "aborted" : "error";
         output.errorMessage = message;
         clearTurn();
@@ -228,7 +240,7 @@ export function streamDevin(deps: DevinProviderDeps) {
 
         const group = findDevinGroup(deps.families(), model.id);
         const concreteModelId = group
-          ? resolveDevinModelRow(group, options?.reasoning).id
+          ? resolveDevinModelRow(group, options?.reasoning ?? "off").id
           : model.id;
 
         const summaryRequest = isSummarizationRequest(prompt);
@@ -281,8 +293,10 @@ export function streamDevin(deps: DevinProviderDeps) {
             historyBootstrap: piHistoryBootstrap(context),
             signal: options?.signal,
           }),
+          options?.signal ? { signal: options.signal } : undefined,
         );
 
+        turnController = controller;
         let usage: DevinUsage | undefined = controller.lastUsage;
         let textIndex: number | null = null;
         let textBuffer = "";
@@ -290,7 +304,6 @@ export function streamDevin(deps: DevinProviderDeps) {
         let thinkingIndex: number | null = null;
         let thinkingBuffer = "";
         let thinkingMessageId: string | undefined;
-        let replayCallSeq = 0;
         const pendingTools = new Map<string, { id: string; index: number }>();
 
         const closeThinking = () => {
@@ -327,7 +340,8 @@ export function streamDevin(deps: DevinProviderDeps) {
         const endWithToolUse = () => {
           closeThinking();
           closeText();
-          attachUsage(usage);
+          // These are display-only segments of one ACP turn. Account once
+          // on its final message, not once per replay card.
           output.stopReason = "toolUse";
           stream.push({ type: "done", reason: "toolUse", message: output });
           stream.end();
@@ -337,7 +351,7 @@ export function streamDevin(deps: DevinProviderDeps) {
         const emitToolStart = (view: DevinToolView): void => {
           closeText();
           closeThinking();
-          const id = `devin-replay-${++replayCallSeq}`;
+          const id = `devin-replay-${randomUUID()}`;
           const toolCall = {
             type: "toolCall" as const,
             id,
@@ -358,7 +372,7 @@ export function streamDevin(deps: DevinProviderDeps) {
         /** Close a tool card and record its replayed result. */
         const emitToolEnd = (view: DevinToolView): void => {
           const pending = pendingTools.get(view.id);
-          const id = pending?.id ?? `devin-replay-${++replayCallSeq}`;
+          const id = pending?.id ?? `devin-replay-${randomUUID()}`;
           replay.record(id, {
             title: view.title ?? "tool call",
             kind: view.kind,
@@ -396,7 +410,7 @@ export function streamDevin(deps: DevinProviderDeps) {
           const incomplete = controller.takeIncompleteTools();
           for (const view of incomplete) {
             const pending = pendingTools.get(view.id);
-            const id = pending?.id ?? `devin-replay-${++replayCallSeq}`;
+            const id = pending?.id ?? `devin-replay-${randomUUID()}`;
             if (view.background) {
               // A detached shell outliving the turn is normal — replay it as a
               // note, not a failure.
@@ -508,14 +522,12 @@ export function streamDevin(deps: DevinProviderDeps) {
               break;
             }
             case "tool_start":
-              emitToolStart(activity.view);
-              break;
             case "tool_update": {
+              if (activity.type === "tool_start") emitToolStart(activity.view);
               // Progress-only updates keep the card pending; the controller
               // merges the view so the terminal update renders the full
               // picture without duplicate cards.
-              const terminal =
-                activity.view.status === "completed" || activity.view.status === "failed";
+              const terminal = TERMINAL_TOOL_STATUSES.has(activity.view.status ?? "");
               if (!terminal) break;
               emitToolEnd(activity.view);
               if (pendingTools.size === 0) {

--- a/packages/pi-devin-acp/src/runtime.ts
+++ b/packages/pi-devin-acp/src/runtime.ts
@@ -176,9 +176,7 @@ const makeRuntime = (createClient: DevinClientFactory) =>
           // A delayed exit from a replaced process must not clobber the
           // binding a newer client already established.
           if (client !== created) return;
-          const turn = active;
-          active = undefined;
-          turn?.fail(new Error("devin acp process exited."));
+          invalidateActiveTurn();
           if (sessionId && !pendingLoadId) {
             // Devin persists sessions server-side: retry session/load on the
             // next turn; its failure path falls back to a fresh session
@@ -190,7 +188,7 @@ const makeRuntime = (createClient: DevinClientFactory) =>
           client = undefined;
         });
         created.setCustomNotificationHandler((method, params) => {
-          if (method !== "_cognition.ai/agent_stopped") return;
+          if (client !== created || method !== "_cognition.ai/agent_stopped") return;
           const activity = agentStoppedToActivity(params);
           if (activity?.type !== "stopped") return;
           lastTurnStats = activity.stats;
@@ -225,7 +223,11 @@ const makeRuntime = (createClient: DevinClientFactory) =>
       contextTokens = undefined;
       contextSize = undefined;
       title = undefined;
+      model = undefined;
+      modeId = undefined;
       configOptions = undefined;
+      availableCommands = undefined;
+      lastTurnStats = undefined;
       needsBootstrap = bootstrap;
       lastSentSystemPrompt = undefined;
       liveOps.clear();
@@ -288,7 +290,10 @@ const makeRuntime = (createClient: DevinClientFactory) =>
 
     /** Wire a live controller to a session's update stream. */
     const attachSessionListener = (id: string, controller: DevinTurnController) => {
-      ensureClient().setSessionListener(id, (update) => {
+      const acp = ensureClient();
+      const listenerGeneration = generation;
+      acp.setSessionListener(id, (update) => {
+        if (client !== acp || sessionId !== id || generation !== listenerGeneration) return;
         const activities = acpUpdateToActivities(update);
         applyStateUpdate(activities);
         for (const activity of activities) {
@@ -305,16 +310,20 @@ const makeRuntime = (createClient: DevinClientFactory) =>
      * reports a missing session. The session listener must already be wired
      * to the turn controller so replayed state updates are captured.
      */
-    const ensureSession = async (cwd: string, controller: DevinTurnController): Promise<string> => {
+    const ensureSession = async (
+      cwd: string,
+      controller: DevinTurnController,
+      check: () => void,
+    ): Promise<string> => {
       const acp = ensureClient();
       await acp.ensureStarted();
+      check();
       if (sessionId && sessionCwd === cwd && !pendingLoadId) {
         // Re-point the session listener at this turn's controller — the
         // previous turn's controller is closed.
         attachSessionListener(sessionId, controller);
         return sessionId;
       }
-      if (sessionId && sessionCwd !== cwd) dropSession(true);
       if (pendingLoadId) {
         const loadId = pendingLoadId;
         sessionId = loadId;
@@ -322,8 +331,14 @@ const makeRuntime = (createClient: DevinClientFactory) =>
         attachSessionListener(loadId, controller);
         try {
           await acp.loadSession(loadId, cwd);
+          check();
+          pendingLoadId = undefined;
           return loadId;
         } catch {
+          // Cancellation/supersession is not a missing session. Never let
+          // an old load clear a newer binding or fall back to session/new.
+          check();
+          pendingLoadId = undefined;
           acp.setSessionListener(loadId, undefined);
           sessionId = undefined;
           syncedModelId = undefined;
@@ -334,11 +349,16 @@ const makeRuntime = (createClient: DevinClientFactory) =>
           contextTokens = undefined;
           contextSize = undefined;
           title = undefined;
-        } finally {
-          pendingLoadId = undefined;
         }
       }
       const created = await acp.newSession(cwd);
+      try {
+        check();
+      } catch (error) {
+        // A cancelled session/new may still have created an empty remote session.
+        void acp.deleteSession(created.sessionId).catch(() => {});
+        throw error;
+      }
       sessionId = created.sessionId;
       sessionCwd = cwd;
       modeId = created.modes?.currentModeId ?? modeId;
@@ -347,14 +367,21 @@ const makeRuntime = (createClient: DevinClientFactory) =>
       return created.sessionId;
     };
 
-    const syncConfig = async (id: string, concreteModelId: string): Promise<void> => {
+    const syncConfig = async (
+      id: string,
+      concreteModelId: string,
+      check: () => void,
+    ): Promise<void> => {
       const acp = ensureClient();
       if (desiredModeId && desiredModeId !== modeId) {
-        await acp.setMode(id, desiredModeId);
-        modeId = desiredModeId;
+        const next = desiredModeId;
+        await acp.setMode(id, next);
+        check();
+        modeId = next;
       }
       if (concreteModelId && syncedModelId !== concreteModelId) {
         await acp.setConfigOption(id, "model", concreteModelId);
+        check();
         syncedModelId = concreteModelId;
       }
     };
@@ -377,7 +404,7 @@ const makeRuntime = (createClient: DevinClientFactory) =>
         ensureOpen.pipe(
           Effect.andThen(
             Effect.sync(() => {
-              invalidateActiveTurn();
+              dropSession(false);
               sessionId = state.acpSessionId;
               sessionCwd = state.cwd;
               model = state.modelId;
@@ -396,120 +423,125 @@ const makeRuntime = (createClient: DevinClientFactory) =>
           Effect.andThen(
             Effect.tryPromise({
               try: async () => {
+                request.signal?.throwIfAborted();
+                if (sessionCwd !== undefined && sessionCwd !== request.cwd) dropSession(true);
                 if (
                   active &&
+                  !activeAbort?.signal.aborted &&
                   active.prompt === request.prompt &&
                   (!active.isClosed() || active.hasPending())
                 ) {
                   return active;
                 }
-                if (active) invalidateActiveTurn();
-
-                const acp = ensureClient();
-                await acp.ensureStarted();
-                const controller = new DevinTurnController(request.prompt, "");
-                const liveSessionId = await ensureSession(request.cwd, controller);
-                controller.sessionId = liveSessionId;
-                await syncConfig(liveSessionId, request.concreteModelId);
-
-                model = request.modelId;
-
+                invalidateActiveTurn();
+                const turnGeneration = generation;
                 const turnAbort = new AbortController();
                 activeAbort = turnAbort;
-                const turnGeneration = generation;
-                if (request.signal) {
-                  if (request.signal.aborted) turnAbort.abort();
-                  else
-                    request.signal.addEventListener("abort", () => turnAbort.abort(), {
-                      once: true,
-                    });
-                }
+                const onAbort = () => turnAbort.abort();
+                request.signal?.addEventListener("abort", onAbort, { once: true });
+                const check = () => {
+                  if (turnGeneration !== generation) throw new Error("devin turn was superseded.");
+                  if (turnAbort.signal.aborted) throw new Error("devin turn was aborted.");
+                };
+                const cleanup = () => {
+                  request.signal?.removeEventListener("abort", onAbort);
+                  if (activeAbort === turnAbort) activeAbort = undefined;
+                };
+                const controller = new DevinTurnController(request.prompt, "");
+                active = controller;
+                try {
+                  check();
+                  const acp = ensureClient();
+                  const liveSessionId = await ensureSession(request.cwd, controller, check);
+                  check();
+                  controller.sessionId = liveSessionId;
+                  await syncConfig(liveSessionId, request.concreteModelId, check);
+                  check();
+                  model = request.modelId;
 
-                // Compose prompt blocks: bootstrap resources on fresh
-                // sessions, an instruction snapshot when pi's system prompt
-                // changed, then the request's content blocks. A bare
-                // "/name args" prompt is a devin command — attaching
-                // resources makes devin treat it as plain text, so command
-                // turns carry no extras and leave bootstrap state pending
-                // for the next real turn.
-                const isCommandPrompt = /^\/\S/.test(request.prompt);
-                const blocks: ContentBlock[] = [];
-                if (!isCommandPrompt) {
-                  if (needsBootstrap && request.historyBootstrap) {
-                    blocks.push({
-                      type: "resource",
-                      resource: {
-                        uri: HISTORY_RESOURCE_URI,
-                        mimeType: "text/plain",
-                        text: restoredPiContextPrompt(request.historyBootstrap),
-                      },
-                    });
-                  }
-                  if (
-                    request.systemPrompt !== undefined &&
-                    request.systemPrompt !== lastSentSystemPrompt
-                  ) {
-                    blocks.push({
-                      type: "resource",
-                      resource: {
-                        uri: INSTRUCTIONS_RESOURCE_URI,
-                        mimeType: "text/plain",
-                        text: piSystemInstructionsPrompt(request.systemPrompt),
-                      },
-                    });
-                    lastSentSystemPrompt = request.systemPrompt;
-                  }
-                  needsBootstrap = false;
-                }
-                blocks.push(...request.blocks);
-
-                const cancelled = new Promise<never>((_resolve, reject) => {
-                  turnAbort.signal.addEventListener(
-                    "abort",
-                    () => reject(new Error("devin turn was aborted.")),
-                    { once: true },
-                  );
-                  if (turnAbort.signal.aborted) {
-                    reject(new Error("devin turn was aborted."));
-                  }
-                });
-
-                const promptPromise = acp.prompt(liveSessionId, blocks);
-                void Promise.race([promptPromise, cancelled])
-                  .then((result) => {
-                    if (turnGeneration !== generation) {
-                      controller.close();
-                      return;
+                  // Compose prompt blocks: bootstrap resources on fresh
+                  // sessions, an instruction snapshot when pi's system prompt
+                  // changed, then the request's content blocks. A bare
+                  // "/name args" prompt is a devin command — attaching
+                  // resources makes devin treat it as plain text, so command
+                  // turns carry no extras and leave bootstrap state pending
+                  // for the next real turn.
+                  const isCommandPrompt = /^\/\S/.test(request.prompt);
+                  const blocks: ContentBlock[] = [];
+                  if (!isCommandPrompt) {
+                    if (needsBootstrap && request.historyBootstrap) {
+                      blocks.push({
+                        type: "resource",
+                        resource: {
+                          uri: HISTORY_RESOURCE_URI,
+                          mimeType: "text/plain",
+                          text: restoredPiContextPrompt(request.historyBootstrap),
+                        },
+                      });
                     }
-                    if (result.stopReason !== "cancelled") turns += 1;
-                    controller.push({
-                      type: "result",
-                      stopReason: result.stopReason ?? "end_turn",
-                      usage: {
-                        inputTokens: result.usage?.inputTokens,
-                        outputTokens: result.usage?.outputTokens,
-                      },
-                    });
-                    controller.close();
-                  })
-                  .catch((cause: unknown) => {
-                    if (turnGeneration !== generation) {
-                      controller.close();
-                      return;
+                    if (
+                      request.systemPrompt !== undefined &&
+                      request.systemPrompt !== lastSentSystemPrompt
+                    ) {
+                      blocks.push({
+                        type: "resource",
+                        resource: {
+                          uri: INSTRUCTIONS_RESOURCE_URI,
+                          mimeType: "text/plain",
+                          text: piSystemInstructionsPrompt(request.systemPrompt),
+                        },
+                      });
+                      lastSentSystemPrompt = request.systemPrompt;
                     }
-                    controller.fail(cause instanceof Error ? cause : new Error(String(cause)));
+                    needsBootstrap = false;
+                  }
+                  blocks.push(...request.blocks);
+
+                  const cancelled = new Promise<never>((_resolve, reject) => {
+                    turnAbort.signal.addEventListener(
+                      "abort",
+                      () => {
+                        void acp.cancel(liveSessionId).catch(() => {});
+                        reject(new Error("devin turn was aborted."));
+                      },
+                      { once: true },
+                    );
                   });
 
-                turnAbort.signal.addEventListener(
-                  "abort",
-                  () => {
-                    void acp.cancel(liveSessionId).catch(() => {});
-                  },
-                  { once: true },
-                );
+                  const promptPromise = acp.prompt(liveSessionId, blocks);
+                  void Promise.race([promptPromise, cancelled])
+                    .then((result) => {
+                      if (turnGeneration !== generation) {
+                        controller.close();
+                        return;
+                      }
+                      if (result.stopReason !== "cancelled") turns += 1;
+                      controller.push({
+                        type: "result",
+                        stopReason: result.stopReason ?? "end_turn",
+                        usage: {
+                          inputTokens: result.usage?.inputTokens,
+                          outputTokens: result.usage?.outputTokens,
+                        },
+                      });
+                      controller.close();
+                    })
+                    .catch((cause: unknown) => {
+                      if (turnGeneration !== generation) {
+                        controller.close();
+                        return;
+                      }
+                      controller.fail(cause instanceof Error ? cause : new Error(String(cause)));
+                    })
+                    .finally(cleanup);
 
-                active = controller;
-                return controller;
+                  return controller;
+                } catch (error) {
+                  cleanup();
+                  controller.fail(error instanceof Error ? error : new Error(String(error)));
+                  if (active === controller) active = undefined;
+                  throw error;
+                }
               },
               catch: (error) => failSession(error),
             }),
@@ -525,48 +557,63 @@ const makeRuntime = (createClient: DevinClientFactory) =>
           Effect.andThen(
             Effect.tryPromise({
               try: async () => {
+                const summaryGeneration = generation;
+                const check = () => {
+                  signal?.throwIfAborted();
+                  if (closed || summaryGeneration !== generation) {
+                    throw new Error("devin summary turn was superseded.");
+                  }
+                };
+                check();
                 const acp = ensureClient();
                 await acp.ensureStarted();
+                check();
                 const created = await acp.newSession(sessionCwd ?? process.cwd());
-                if (modelId) {
-                  try {
-                    await acp.setConfigOption(created.sessionId, "model", modelId);
-                  } catch {
-                    // Best-effort: a summary on the session default beats none.
-                  }
-                }
-                const collected: string[] = [];
-                acp.setSessionListener(created.sessionId, (update) => {
-                  for (const activity of acpUpdateToActivities(update)) {
-                    if (activity.type === "text") collected.push(activity.delta);
-                  }
-                });
                 try {
-                  const abort = new AbortController();
-                  const onAbort = () => {
-                    abort.abort();
-                    void acp.cancel(created.sessionId).catch(() => {});
-                  };
-                  signal?.addEventListener("abort", onAbort, { once: true });
-                  try {
-                    await Promise.race([
-                      acp.prompt(created.sessionId, [{ type: "text", text: prompt }]),
-                      new Promise<never>((_r, reject) =>
-                        abort.signal.addEventListener(
-                          "abort",
-                          () => reject(new Error("devin summary turn aborted.")),
-                          { once: true },
-                        ),
-                      ),
-                    ]);
-                  } finally {
-                    signal?.removeEventListener("abort", onAbort);
+                  check();
+                  if (modelId) {
+                    try {
+                      await acp.setConfigOption(created.sessionId, "model", modelId);
+                    } catch {
+                      // Best-effort: a summary on the session default beats none.
+                    }
+                    check();
                   }
+                  const collected: string[] = [];
+                  acp.setSessionListener(created.sessionId, (update) => {
+                    for (const activity of acpUpdateToActivities(update)) {
+                      if (activity.type === "text") collected.push(activity.delta);
+                    }
+                  });
+                  try {
+                    const abort = new AbortController();
+                    const onAbort = () => {
+                      abort.abort();
+                      void acp.cancel(created.sessionId).catch(() => {});
+                    };
+                    const cancelled = new Promise<never>((_r, reject) =>
+                      abort.signal.addEventListener(
+                        "abort",
+                        () => reject(new Error("devin summary turn aborted.")),
+                        { once: true },
+                      ),
+                    );
+                    signal?.addEventListener("abort", onAbort, { once: true });
+                    try {
+                      await Promise.race([
+                        acp.prompt(created.sessionId, [{ type: "text", text: prompt }]),
+                        cancelled,
+                      ]);
+                    } finally {
+                      signal?.removeEventListener("abort", onAbort);
+                    }
+                  } finally {
+                    acp.setSessionListener(created.sessionId, undefined);
+                  }
+                  return { text: collected.join("") };
                 } finally {
-                  acp.setSessionListener(created.sessionId, undefined);
                   void acp.deleteSession(created.sessionId).catch(() => {});
                 }
-                return { text: collected.join("") };
               },
               catch: (error) => failSession(error),
             }),
@@ -578,11 +625,17 @@ const makeRuntime = (createClient: DevinClientFactory) =>
           Effect.andThen(
             Effect.tryPromise({
               try: async () => {
-                desiredModeId = next;
+                if (!["ask", "plan", "accept-edits", "bypass"].includes(next)) {
+                  throw new Error(`Invalid devin mode: ${next}`);
+                }
+                const modeGeneration = generation;
                 if (sessionId && !pendingLoadId) {
                   await ensureClient().setMode(sessionId, next);
+                  if (generation !== modeGeneration)
+                    throw new Error("devin session was superseded.");
                   modeId = next;
                 }
+                desiredModeId = next;
               },
               catch: (error) => failSession(error),
             }),

--- a/packages/pi-devin-acp/src/tasks-ui.ts
+++ b/packages/pi-devin-acp/src/tasks-ui.ts
@@ -3,7 +3,8 @@
  * detached background shells). Kept to ctx.ui.select/confirm prompts for v1.
  */
 
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { devinKillShellPrompt } from "../lib/prompt.ts";
 import type { DevinLiveOp } from "./runtime.ts";
 
 function formatElapsed(startedAt: number, now: number): string {
@@ -29,7 +30,7 @@ export function describeLiveOp(op: DevinLiveOp, now = Date.now()): string {
 export interface DevinTasksUiDeps {
   listOps: () => Promise<DevinLiveOp[]> | DevinLiveOp[];
   /** Send a plain-text instruction into the live devin session. */
-  sendToSession: (text: string) => void;
+  sendToSession: ExtensionAPI["sendUserMessage"];
 }
 
 /** Run the /devin tasks flow. */
@@ -53,6 +54,16 @@ export async function runDevinTasksPicker(
     `Ask devin to kill background shell ${op.view.shellId}? It runs in devin's process, so only devin can stop it.`,
   );
   if (!kill) return;
-  deps.sendToSession(`Kill background shell ${op.view.shellId} and confirm it stopped.`);
-  ctx.ui.notify(`devin: asked to kill shell ${op.view.shellId}.`, "info");
+  try {
+    deps.sendToSession(devinKillShellPrompt(op.view.shellId), {
+      deliverAs: "steer",
+      expandPromptTemplates: false,
+    });
+    ctx.ui.notify(`devin: queued request to kill shell ${op.view.shellId}.`, "info");
+  } catch (error) {
+    ctx.ui.notify(
+      `devin: could not request shell stop (${error instanceof Error ? error.message : error}).`,
+      "error",
+    );
+  }
 }

--- a/packages/pi-devin-acp/src/turn.ts
+++ b/packages/pi-devin-acp/src/turn.ts
@@ -62,7 +62,7 @@ export class DevinTurnController {
   sessionId: string;
   /**
    * Latest usage_update seen this turn, carried across pi message
-   * boundaries so each re-entered segment reports the cumulative counters.
+   * boundaries so the final message can account for the whole ACP turn.
    */
   lastUsage?: DevinUsage;
   #queue: DevinActivity[] = [];
@@ -88,7 +88,9 @@ export class DevinTurnController {
     if (this.#closed) return;
     let delivered = activity;
     if (activity.type === "tool_start") {
-      this.#incompleteTools.set(activity.view.id, activity.view);
+      if (!TERMINAL_TOOL_STATUSES.has(activity.view.status ?? "")) {
+        this.#incompleteTools.set(activity.view.id, activity.view);
+      }
     } else if (activity.type === "tool_update") {
       // Updates carry only changed fields (no title/kind/locations) — merge
       // over the started view so cards keep the full picture.

--- a/packages/pi-devin-acp/test/provider.test.ts
+++ b/packages/pi-devin-acp/test/provider.test.ts
@@ -162,6 +162,29 @@ test("streamDevin ends with toolUse after a completed tool call and replays the 
   assert.equal(recorded?.title, "Wrote /tmp/x");
 });
 
+for (const status of ["completed", "failed"]) {
+  test(`initial ${status} tool notifications produce terminal replay cards`, async () => {
+    const { service, runtime, controllers } = fakeRuntime([
+      { type: "tool_start", view: { id: "one", title: "one", status, output: "actual result" } },
+    ]);
+    const replay = new DevinReplayStore();
+    const message = await streamDevin({
+      runtime,
+      service,
+      replay,
+      families: () => FAMILIES,
+      cwd: () => "/tmp",
+    })(MODEL as never, CONTEXT).result();
+    assert.equal(message.stopReason, "toolUse");
+    const call = message.content.find((c) => c.type === "toolCall");
+    assert.ok(call);
+    const recorded = replay.take(call.id);
+    assert.equal(recorded?.output, "actual result");
+    assert.equal(recorded?.error, status === "failed" ? "actual result" : undefined);
+    assert.deepEqual(controllers[0].takeIncompleteTools(), []);
+  });
+}
+
 test("non-terminal tool updates keep the card pending; the terminal update closes it once", async () => {
   const { service, runtime } = fakeRuntime([
     {
@@ -267,7 +290,7 @@ test("usage merge never clobbers known fields and honors the prompt response", a
   assert.equal(done.message.usage.input, 9);
   assert.equal(done.message.usage.output, 6);
   assert.equal(done.message.usage.cacheRead, 3);
-  assert.equal(done.message.usage.totalTokens, 15);
+  assert.equal(done.message.usage.totalTokens, 18);
 });
 
 test("summarization requests run in a disposable session with the resolved model", async () => {

--- a/packages/pi-devin-acp/test/runtime.test.ts
+++ b/packages/pi-devin-acp/test/runtime.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { ContentBlock } from "@agentclientprotocol/sdk";
+import { getEventListeners } from "node:events";
+import { streamDevin } from "../src/provider.ts";
+import { DevinReplayStore } from "../lib/replay.ts";
+import type { AssistantMessage, Context, Model, Api } from "@earendil-works/pi-ai";
+import type { DevinModelFamily } from "../lib/models.ts";
 import type { DevinAcpClient } from "../lib/acp-client.ts";
 import {
   createDevinRuntime,
@@ -24,6 +29,7 @@ class FakeClient {
   failLoads = new Set<string>();
   deleted: string[] = [];
   modes: string[] = [];
+  cancelled: string[] = [];
   configSets: { configId: string; value: string }[] = [];
   onClose: (() => void) | undefined;
 
@@ -58,7 +64,9 @@ class FakeClient {
     } as never);
     return { stopReason: "end_turn" };
   }
-  async cancel() {}
+  async cancel(id: string) {
+    this.cancelled.push(id);
+  }
   async setMode(_id: string, modeId: string) {
     this.modes.push(modeId);
   }
@@ -336,3 +344,406 @@ test("devin acp process exit falls back to a bootstrapped fresh session", async 
   assert.equal(snapshot.turns, 1, "stale counters from the dead session are dropped");
   await runtime.dispose();
 });
+
+// Gates prove the operation reached an async boundary before we invalidate it;
+// no sleeps, real processes, or live Devin credentials are needed.
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function gate() {
+  const entered = deferred<void>();
+  const released = deferred<void>();
+  return {
+    entered: entered.promise,
+    release: () => released.resolve(),
+    wait: () => {
+      entered.resolve();
+      return released.promise;
+    },
+  };
+}
+
+for (const summary of [false, true]) {
+  test(`${summary ? "summary" : "stream"}: already-aborted requests never start ACP`, async (t) => {
+    const { fake, runtime, service } = await makeRuntime();
+    t.after(() => runtime.dispose());
+    const signal = AbortSignal.abort();
+    await assert.rejects(
+      summary
+        ? runDevin(runtime, service.runSummaryTurn("summary", signal))
+        : runDevin(runtime, service.beginStreamTurn(TURN({ signal }))),
+      /abort/i,
+    );
+    assert.equal(fake.started, false);
+    assert.equal(fake.prompts.length, 0);
+    assert.equal(fake.cancelled.length, 0);
+  });
+}
+
+for (const stage of ["start", "new", "load", "mode", "config"] as const) {
+  for (const action of ["abort", "reset", "restore"] as const) {
+    test(`${action} during ${stage} prevents stale setup from prompting`, async (t) => {
+      const { fake, runtime, service } = await makeRuntime();
+      t.after(() => runtime.dispose());
+      const blocked = gate();
+      const abort = new AbortController();
+      if (stage === "load") {
+        await runDevin(
+          runtime,
+          service.restoreSession({
+            acpSessionId: "A",
+            cwd: "/tmp/proj",
+            modelId: "swe-2",
+            turns: 3,
+          }),
+        );
+        fake.loadSession = async (id) => {
+          await blocked.wait();
+          return { sessionId: id };
+        };
+      } else if (stage === "new") {
+        const original = fake.newSession.bind(fake);
+        fake.newSession = async (cwd) => {
+          await blocked.wait();
+          return original(cwd);
+        };
+      } else if (stage === "start") {
+        fake.ensureStarted = () => blocked.wait();
+      } else if (stage === "mode") {
+        await runDevin(runtime, service.setMode("plan"));
+        fake.setMode = () => blocked.wait();
+      } else {
+        fake.setConfigOption = async () => {
+          await blocked.wait();
+          return [];
+        };
+      }
+      const result = runDevin(runtime, service.beginStreamTurn(TURN({ signal: abort.signal })));
+      const rejected = assert.rejects(result, /aborted|superseded/);
+      await blocked.entered;
+      if (action === "abort") abort.abort();
+      else if (action === "reset") await runDevin(runtime, service.reset);
+      else
+        await runDevin(
+          runtime,
+          service.restoreSession({
+            acpSessionId: "B",
+            cwd: "/tmp/proj",
+            modelId: "other",
+            turns: 9,
+          }),
+        );
+      blocked.release();
+      await rejected;
+      assert.equal(fake.prompts.length, 0);
+      assert.equal(fake.cancelled.length, 0, "no prompt was sent, so no cancel is needed");
+      assert.equal(getEventListeners(abort.signal, "abort").length, 0);
+      const snapshot = await runDevin(runtime, service.snapshot);
+      if (action === "reset") {
+        assert.equal(snapshot.sessionId, undefined);
+        assert.equal(snapshot.concreteModel, undefined);
+      } else if (action === "restore") {
+        assert.equal(snapshot.sessionId, "B");
+        assert.equal(snapshot.model, "other");
+        assert.equal(snapshot.turns, 9);
+        assert.equal(snapshot.concreteModel, undefined);
+      }
+    });
+  }
+}
+
+for (const stage of ["start", "new", "config"] as const) {
+  test(`summary cancelled during ${stage} never prompts and cleans up`, async (t) => {
+    const { fake, runtime, service } = await makeRuntime();
+    t.after(() => runtime.dispose());
+    const blocked = gate();
+    const abort = new AbortController();
+    if (stage === "start") fake.ensureStarted = () => blocked.wait();
+    else if (stage === "new") {
+      const original = fake.newSession.bind(fake);
+      fake.newSession = async (cwd) => {
+        await blocked.wait();
+        return original(cwd);
+      };
+    } else
+      fake.setConfigOption = async () => {
+        await blocked.wait();
+        return [];
+      };
+    const rejected = assert.rejects(
+      runDevin(runtime, service.runSummaryTurn("summary", abort.signal, "swe-2")),
+      /abort/i,
+    );
+    await blocked.entered;
+    abort.abort();
+    blocked.release();
+    await rejected;
+    assert.equal(fake.prompts.length, 0);
+    assert.deepEqual(fake.deleted, fake.createdSessions);
+    assert.equal(fake.sessions.size, 0);
+  });
+}
+
+test("abort sends exactly one cancel to the prompted session and releases listeners", async (t) => {
+  const { fake, runtime, service } = await makeRuntime();
+  t.after(() => runtime.dispose());
+  const abort = new AbortController();
+  fake.prompt = async () => new Promise(() => {});
+  const controller = await runDevin(
+    runtime,
+    service.beginStreamTurn(TURN({ signal: abort.signal })),
+  );
+  const rejected = assert.rejects(controller.next(), /aborted/);
+  abort.abort();
+  await rejected;
+  await Promise.resolve();
+  assert.deepEqual(fake.cancelled, ["sess-1"]);
+  assert.equal(getEventListeners(abort.signal, "abort").length, 0);
+});
+
+test("restore removes old listeners and all session-local live state", async (t) => {
+  const { fake, runtime, service } = await makeRuntime();
+  t.after(() => runtime.dispose());
+  await runDevin(runtime, service.beginStreamTurn(TURN()));
+  const oldListener = fake.sessions.get("sess-1")!;
+  oldListener({
+    sessionUpdate: "tool_call",
+    toolCallId: "old",
+    status: "in_progress",
+    title: "old shell",
+  } as never);
+  oldListener({ sessionUpdate: "session_info_update", title: "A title" } as never);
+  assert.equal((await runDevin(runtime, service.snapshot)).liveOps.length, 1);
+  await runDevin(
+    runtime,
+    service.restoreSession({ acpSessionId: "B", cwd: "/tmp/proj", modelId: "swe-2", turns: 0 }),
+  );
+  assert.equal(fake.sessions.has("sess-1"), false);
+  // Even a callback already captured for delivery must be harmless.
+  oldListener({ sessionUpdate: "session_info_update", title: "late A title" } as never);
+  oldListener({ sessionUpdate: "tool_call", toolCallId: "late", status: "in_progress" } as never);
+  const snapshot = await runDevin(runtime, service.snapshot);
+  assert.equal(snapshot.sessionId, "B");
+  assert.equal(snapshot.title, undefined);
+  assert.deepEqual(snapshot.liveOps, []);
+  assert.equal(snapshot.modeId, undefined);
+  assert.equal(snapshot.availableCommands, undefined);
+  assert.equal(snapshot.lastTurnStats, undefined);
+});
+
+test("invalid and server-rejected modes preserve the last accepted preference", async (t) => {
+  const { fake, runtime, service } = await makeRuntime();
+  t.after(() => runtime.dispose());
+  await assert.rejects(runDevin(runtime, service.setMode("typo")), /Invalid/);
+  await runDevin(runtime, service.setMode("plan"));
+  const first = await runDevin(runtime, service.beginStreamTurn(TURN()));
+  while (await first.next()) {}
+  fake.setMode = async (_id, mode) => {
+    fake.modes.push(mode);
+    if (mode === "bypass") throw new Error("mode rejected by server");
+  };
+  await assert.rejects(runDevin(runtime, service.setMode("typo")), /Invalid/);
+  await assert.rejects(runDevin(runtime, service.setMode("bypass")), /rejected/);
+  assert.equal((await runDevin(runtime, service.snapshot)).modeId, "plan");
+  // A fresh binding must still sync the accepted preference, never bypass/typo.
+  await runDevin(runtime, service.setSession("/tmp/proj", { rebootstrap: true }));
+  const second = await runDevin(runtime, service.beginStreamTurn(TURN()));
+  while (await second.next()) {}
+  assert.deepEqual(fake.modes, ["plan", "bypass", "plan"]);
+});
+
+const LIFECYCLE_MODEL: Model<Api> = {
+  id: "swe-2",
+  name: "SWE-2",
+  api: "devin-acp",
+  provider: "devin",
+  baseUrl: "devin://acp",
+  reasoning: true,
+  input: ["text"],
+  contextWindow: 262000,
+  maxTokens: 64000,
+  cost: { input: 2, output: 4, cacheRead: 1, cacheWrite: 0 },
+};
+const LIFECYCLE_FAMILIES: DevinModelFamily[] = [
+  {
+    id: "swe-2",
+    name: "SWE-2",
+    aliases: [],
+    rows: ["medium", "none"].map((effort) => ({
+      id: `swe-2-${effort}`,
+      name: effort,
+      effort: effort as "medium" | "none",
+      contextWindow: 262000,
+      cost: LIFECYCLE_MODEL.cost,
+    })),
+  },
+];
+
+test("provider abort returns during startup without waiting for ACP", async (t) => {
+  const { fake, runtime, service } = await makeRuntime();
+  t.after(async () => {
+    await runDevin(runtime, service.close);
+    await runtime.dispose();
+  });
+  const blocked = gate();
+  fake.ensureStarted = () => blocked.wait();
+  const abort = new AbortController();
+  const provider = streamDevin({
+    runtime,
+    service,
+    replay: new DevinReplayStore(),
+    families: () => LIFECYCLE_FAMILIES,
+    cwd: () => "/tmp/proj",
+  });
+  const stream = provider(
+    LIFECYCLE_MODEL,
+    { messages: [{ role: "user", content: "do it", timestamp: 0 }] },
+    { signal: abort.signal },
+  );
+  await blocked.entered;
+  abort.abort();
+  const message = await stream.result();
+  assert.equal(message.stopReason, "aborted");
+  blocked.release();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(fake.createdSessions.length, 0);
+  assert.equal(fake.prompts.length, 0);
+  assert.equal(getEventListeners(abort.signal, "abort").length, 0);
+});
+
+for (const buffered of [false, true]) {
+  test(`one ACP turn across multiple provider calls (${buffered ? "buffered" : "live"}) has unique cards and single accounting`, async (t) => {
+    const { fake, runtime, service } = await makeRuntime();
+    t.after(async () => {
+      await runDevin(runtime, service.close);
+      await runtime.dispose();
+    });
+    const replay = new DevinReplayStore();
+    const provider = streamDevin({
+      runtime,
+      service,
+      replay,
+      families: () => LIFECYCLE_FAMILIES,
+      cwd: () => "/tmp/proj",
+    });
+    const context: Context = { messages: [{ role: "user", content: "do it", timestamp: 0 }] };
+    const response = deferred<{
+      stopReason: string;
+      usage: { inputTokens: number; outputTokens: number };
+    }>();
+    const started = deferred<void>();
+    const emit = (update: unknown) => fake.sessions.get("sess-1")!(update as never);
+    const tool = (id: string, initial = false) => {
+      emit({
+        sessionUpdate: "tool_call",
+        toolCallId: id,
+        title: id,
+        status: initial ? "completed" : "in_progress",
+        content: initial
+          ? [{ type: "content", content: { type: "text", text: `${id} result` } }]
+          : undefined,
+      });
+      if (!initial)
+        emit({
+          sessionUpdate: "tool_call_update",
+          toolCallId: id,
+          status: "completed",
+          content: [{ type: "content", content: { type: "text", text: `${id} result` } }],
+        });
+    };
+    const finish = () => {
+      emit({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "all done" } });
+      response.resolve({ stopReason: "end_turn", usage: { inputTokens: 100, outputTokens: 20 } });
+    };
+    fake.prompt = async (sessionId, blocks) => {
+      fake.prompts.push({ sessionId, blocks });
+      emit({
+        sessionUpdate: "usage_update",
+        used: 9000,
+        size: 262000,
+        _meta: {
+          "cognition.ai/inputTokens": 100,
+          "cognition.ai/outputTokens": 10,
+          "cognition.ai/cachedReadTokens": 30,
+        },
+      });
+      tool("first");
+      if (buffered) {
+        tool("second", true);
+        finish();
+      }
+      started.resolve();
+      return response.promise;
+    };
+    const messages: AssistantMessage[] = [];
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const stream = provider(LIFECYCLE_MODEL, context, { reasoning: undefined });
+      await started.promise;
+      if (!buffered && i === 1) tool("second", true);
+      if (!buffered && i === 2) finish();
+      const message = await stream.result();
+      messages.push(message);
+      context.messages.push(message);
+      assert.equal(
+        message.stopReason,
+        i < 2 ? "toolUse" : "stop",
+        message.errorMessage ?? "unexpected stop reason",
+      );
+      for (const call of message.content) {
+        if (call.type !== "toolCall") continue;
+        ids.push(call.id);
+        const result = replay.take(call.id);
+        assert.ok(result);
+        assert.equal(result.error, undefined);
+        assert.equal(result.output, `${i === 0 ? "first" : "second"} result`);
+        context.messages.push({
+          role: "toolResult",
+          toolCallId: call.id,
+          toolName: call.name,
+          content: [{ type: "text", text: result.output! }],
+          isError: false,
+          timestamp: 0,
+        });
+      }
+    }
+    assert.equal(fake.prompts.length, 1, "provider re-entry must not re-prompt ACP");
+    assert.equal(new Set(ids).size, 2);
+    assert.deepEqual(
+      fake.configSets,
+      [{ configId: "model", value: "swe-2-none" }],
+      "Pi off must not select the default medium row",
+    );
+    assert.deepEqual(
+      messages.map((m) => m.usage.input),
+      [0, 0, 70],
+    );
+    assert.equal(
+      messages.reduce((sum, m) => sum + m.usage.cacheRead, 0),
+      30,
+    );
+    assert.equal(
+      messages.reduce((sum, m) => sum + m.usage.output, 0),
+      20,
+    );
+    assert.equal(
+      messages.reduce((sum, m) => sum + m.usage.totalTokens, 0),
+      120,
+    );
+    assert.ok(Math.abs(messages.reduce((sum, m) => sum + m.usage.cost.total, 0) - 0.00025) < 1e-12);
+    assert.equal((await runDevin(runtime, service.snapshot)).contextTokens, 9000);
+    // A later turn may reuse ACP tool IDs, but never Pi replay IDs.
+    const next = await provider(LIFECYCLE_MODEL, {
+      messages: [{ role: "user", content: "new request", timestamp: 1 }],
+    }).result();
+    const nextCall = next.content.find((c) => c.type === "toolCall");
+    assert.ok(nextCall);
+    assert.ok(!ids.includes(nextCall.id));
+    assert.equal(fake.prompts.length, 2);
+  });
+}

--- a/packages/pi-devin-acp/test/tasks-ui.test.ts
+++ b/packages/pi-devin-acp/test/tasks-ui.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { runDevinTasksPicker } from "../src/tasks-ui.ts";
+
+for (const busy of [false, true]) {
+  test(`tasks kill uses steer delivery (${busy ? "busy" : "idle"})`, async () => {
+    const notifications: string[] = [];
+    const ctx = {
+      isIdle: () => !busy,
+      ui: {
+        select: async (_title: string, labels: string[]) => labels[0],
+        confirm: async () => true,
+        notify: (message: string) => notifications.push(message),
+      },
+    } as unknown as ExtensionContext;
+    let sent = false;
+    await runDevinTasksPicker(ctx, {
+      listOps: () => [{ view: { id: "exec", shellId: "shell-1" }, startedAt: 0 }],
+      sendToSession: (text, options) => {
+        if (busy && !options?.deliverAs) throw new Error("Agent is busy; specify deliverAs");
+        assert.equal(text, "Kill background shell shell-1 and confirm it stopped.");
+        assert.equal(options?.deliverAs, "steer");
+        assert.equal(options?.expandPromptTemplates, false);
+        assert.deepEqual(notifications, [], "acknowledge only after submitting");
+        sent = true;
+      },
+    });
+    assert.equal(sent, true);
+    assert.match(notifications[0], /queued request/);
+  });
+}
+
+test("tasks kill reports send failures instead of acknowledging success", async () => {
+  const notifications: { message: string; level: string }[] = [];
+  await runDevinTasksPicker(
+    {
+      ui: {
+        select: async (_title: string, labels: string[]) => labels[0],
+        confirm: async () => true,
+        notify: (message: string, level: string) => notifications.push({ message, level }),
+      },
+    } as unknown as ExtensionContext,
+    {
+      listOps: () => [{ view: { id: "exec", shellId: "shell-1" }, startedAt: 0 }],
+      sendToSession: () => {
+        throw new Error("session closed");
+      },
+    },
+  );
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0].level, "error");
+  assert.match(notifications[0].message, /session closed/);
+});

--- a/packages/pi-devin-acp/test/turn.test.ts
+++ b/packages/pi-devin-acp/test/turn.test.ts
@@ -32,6 +32,15 @@ test("incomplete tools are tracked until terminal updates", () => {
   assert.deepEqual(c.takeIncompleteTools(), []);
 });
 
+for (const status of ["completed", "failed"]) {
+  test(`initial ${status} tool calls are not incomplete`, () => {
+    const c = new DevinTurnController("p", "s1");
+    c.push({ type: "tool_start", view: view("t1", status) });
+    c.close();
+    assert.deepEqual(c.takeIncompleteTools(), []);
+  });
+}
+
 test("deferResult keeps a result pending for re-entry after close", async () => {
   const c = new DevinTurnController("p", "s1");
   c.push({ type: "result", stopReason: "end_turn" });


### PR DESCRIPTION
## Summary

Address all eight findings from the Devin ACP review, on top of the package rename in #55 (`packages/pi-devin-acp`).

- Establish cancellation/generation boundaries before ACP startup; check after each awaited startup/session/config operation. Never prompt after cancellation or supersession, register prompt cancellation before sending, and remove external abort listeners on completion. Apply startup cancellation checks to disposable summary sessions too.
- Generate UUID-backed replay tool IDs across provider calls and turns.
- Interpret Pi's `reasoning: undefined` as thinking **off**, not Devin's default row.
- Account for ACP turn tokens/cost only on the final assistant message (including stream errors); keep context occupancy in the runtime snapshot rather than billable token totals.
- Detach old session listeners, reject stale callbacks, and clear session-local state on attach/reset.
- Validate mode names and commit the desired mode only after the server accepts it.
- Send task-stop instructions with `deliverAs: "steer"`; acknowledge queuing rather than stopping, and report synchronous send failures.
- Handle initial `completed`/`failed` tool notifications as terminal cards instead of sweeping them as incomplete.

Includes a patch Changeset.

## Regression coverage

33 added tests, including:
- Abort/reset/attach at startup, session/new, session/load, mode sync, and model sync boundaries.
- Prompt cancellation delivery, abort-listener cleanup, and immediate provider cancellation while ACP startup is blocked.
- One real runtime/controller/replay-store lifecycle spanning three provider calls, in both live-delivery and fully buffered sequences: one ACP prompt, two unique tool cards, and usage/cost recorded once.
- Thinking off, stale-session notifications, rejected mode recovery, task-stop delivery, and initially terminal tool calls.

## Validation

- `pnpm run typecheck` — passed (existing non-blocking Effect suggestion in pi-vscode-bridge).
- `pnpm run check` — passed.
- `DEVIN_BINARY=/nonexistent/pi-devin-test-disabled pnpm test` — full workspace passed.
- Final scoped Devin suite — **74 passed, 1 skipped** (the real ACP model round-trip).
- The existing real ACP prompt round-trip smoke test also passed during initial verification; subsequent runs explicitly skipped it to avoid repeated model calls.
- Biome checks on changed source/test files and `git diff --check` — passed.

The regression assertions use fake ACP boundaries, not live-model responses. The explicit `DEVIN_BINARY` override skips the existing real-model integration test during offline verification.
