### PR TITLE
fix(pi-find): match globs from the cwd, support ! exclusion, cap record size

### DIFF
--- a/.changeset/fix-pi-find-glob-and-memory.md
+++ b/.changeset/fix-pi-find-glob-and-memory.md
@@ -1,0 +1,9 @@
+---
+"@tian.zuo/pi-find": patch
+---
+
+Fix three search defects found by comparing this extension against pi's built-in `grep` and against Codex and Grok Build.
+
+A glob written from the working directory now matches when `path` scopes the search: `{ "path": "src", "glob": "src/*.ts" }` used to return "No matches found." even though the built-in tool matched, because the glob was only matched relative to the search root. Slash globs now match relative to the search root *or* the working directory, and a leading `!` excludes instead of being treated as a literal, so `glob: "!*.test.ts"` (grep) and `pattern: "!**/*.generated.ts"` (find) work like ripgrep's own `--glob`.
+
+A match or path record larger than 8 MiB is now skipped instead of being buffered, and the result says so. Explicitly named files bypass ripgrep's `--max-filesize` traversal cap, and a 100 MiB single-line file used to peak at 866 MiB RSS because the whole JSON record was accumulated before decoding; the 30s wall-clock budget bounded time but not memory.

--- a/packages/pi-find/README.md
+++ b/packages/pi-find/README.md
@@ -46,9 +46,13 @@ find(pattern, path?)
   roots, files inside them, and symlink aliases to them are rejected.
 - Globs without `/` match basenames at any depth. Globs containing `/` match
   paths relative to the search directory (or the parent of an explicit grep
-  file). For example, `src/*.ts` matches direct children of `src`, while
+  file) *or* to the working directory, so both `{ "path": "src", "glob":
+  "src/*.ts" }` and `{ "path": "src", "glob": "deep/*.ts" }` select files
+  under `src`. `src/*.ts` matches direct children of `src`, while
   `src/**/*.ts` includes descendants. Use `/` in globs on every platform.
   Glob filtering never re-includes ignored files.
+- A leading `!` excludes instead of includes, like ripgrep's own `--glob`: for
+  example `glob: "!*.test.ts"` or `pattern: "!**/*.generated.ts"`.
 - A leading `@` is stripped from input paths; `~` and `~/...` expand to the
   home directory. Ripgrep user configuration is ignored so it cannot change
   the tool's case sensitivity or ignore behavior.
@@ -59,6 +63,10 @@ find(pattern, path?)
 - Grep skips files larger than 4 MiB during directory traversal. Explicitly
   named files follow ripgrep's explicit-file behavior and can exceed that limit.
 - Grep lines longer than 400 characters are clipped.
+- A single match or path record larger than 8 MiB is skipped instead of being
+  buffered, and the result says so. Explicitly named files bypass
+  ripgrep's traversal size cap, so this is what keeps a search of a
+  single-line bundle, sourcemap, or lockfile from ballooning memory.
 - Search output also has a hard byte limit, and running searches are
   cancellable.
 - Relative result paths can be passed directly to pi's `read` and `edit` tools.

--- a/packages/pi-find/lib/prompt.ts
+++ b/packages/pi-find/lib/prompt.ts
@@ -13,7 +13,7 @@ export const GREP_PROMPT_SNIPPET = "Search file contents with a regex";
 export const GREP_PARAMETER_DESCRIPTIONS = {
   pattern: "Case-sensitive ripgrep regex.",
   path: "Search file or directory; defaults to cwd.",
-  glob: "Case-sensitive glob: basename ('*.ts') or search-root-relative ('src/*.ts').",
+  glob: "Case-sensitive glob: basename ('*.ts') or path ('src/*.ts'); prefix ! to exclude.",
 };
 
 export const FIND_TOOL_DESCRIPTION =
@@ -21,7 +21,7 @@ export const FIND_TOOL_DESCRIPTION =
 export const FIND_PROMPT_SNIPPET = "Find files with a glob";
 
 export const FIND_PARAMETER_DESCRIPTIONS = {
-  pattern: "Case-sensitive glob: basename ('*.ts') or search-root-relative ('src/*.ts').",
+  pattern: "Case-sensitive glob: basename ('*.ts') or path ('src/*.ts'); prefix ! to exclude.",
   path: "Search directory; defaults to cwd.",
 };
 
@@ -62,4 +62,9 @@ export function outputLimitNotice(kind: "grep" | "find"): string {
 export function searchTimeoutNotice(timeoutMs: number): string {
   const seconds = Math.round(timeoutMs / 1000);
   return `[Search timed out after ${seconds}s; results are partial. Narrow the path, pattern, or glob.]`;
+}
+
+/** A record too large to buffer was dropped instead of read into memory. */
+export function oversizedRecordNotice(limitBytes: number): string {
+  return `[Skipped a record larger than ${Math.round(limitBytes / (1024 * 1024))} MiB; narrow the search.]`;
 }

--- a/packages/pi-find/lib/tools.ts
+++ b/packages/pi-find/lib/tools.ts
@@ -23,6 +23,7 @@ import {
   NO_FILES_FOUND,
   NO_GREP_MATCHES,
   outputLimitNotice,
+  oversizedRecordNotice,
   QUOTED_PATH_NOTICE,
   resultLimitNotice,
   SEARCH_TIMEOUT_MS,
@@ -34,6 +35,7 @@ import {
   SearchRuntime,
   type SearchRuntimeInstance,
 } from "../src/runtime.ts";
+import { MAX_RECORD_BYTES } from "../src/stream.ts";
 
 export const GrepParams = Type.Object({
   pattern: Type.String({
@@ -146,10 +148,11 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
           ? [QUOTED_PATH_NOTICE]
           : []),
         ...(outcome.truncated ? [resultLimitNotice("matches", GREP_RESULT_LIMIT)] : []),
+        ...(outcome.skippedRecords > 0 ? [oversizedRecordNotice(MAX_RECORD_BYTES)] : []),
         ...(outcome.timedOut ? [searchTimeoutNotice(SEARCH_TIMEOUT_MS)] : []),
       ];
-      // A timed-out search must never read as a completed empty one: the
-      // notice travels even when nothing was gathered.
+      // A timed-out or truncated search must never read as a completed empty
+      // one: those notices travel even when nothing was gathered.
       if (matchCount === 0 && notices.length === 0) {
         return {
           content: [
@@ -226,8 +229,9 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
       );
 
       if (outcome.files.length === 0 && !outcome.timedOut) {
+        const skipped = outcome.skippedRecords > 0 ? [oversizedRecordNotice(MAX_RECORD_BYTES)] : [];
         return {
-          content: [{ type: "text" as const, text: NO_FILES_FOUND }],
+          content: [{ type: "text" as const, text: resultText(NO_FILES_FOUND, "", skipped) }],
           details: {
             kind: "find",
             query: params.pattern,
@@ -242,6 +246,7 @@ export function registerTools(pi: ExtensionAPI, runtime: SearchRuntimeInstance):
       const body = boundedBody(outcome.files.map(displayPath), "find");
       const count = outcome.files.length;
       const notices = [
+        ...(outcome.skippedRecords > 0 ? [oversizedRecordNotice(MAX_RECORD_BYTES)] : []),
         ...(outcome.files.some((path) => displayPath(path) !== path) ? [QUOTED_PATH_NOTICE] : []),
         ...(outcome.truncated ? [resultLimitNotice("files", FIND_RESULT_LIMIT)] : []),
         ...(outcome.timedOut ? [searchTimeoutNotice(SEARCH_TIMEOUT_MS)] : []),

--- a/packages/pi-find/src/runtime.ts
+++ b/packages/pi-find/src/runtime.ts
@@ -37,6 +37,8 @@ export interface GrepOutcome {
   readonly matches: readonly GrepMatch[];
   readonly truncated: boolean;
   readonly timedOut: boolean;
+  /** Records too large to buffer; the whole record is dropped because a partial one cannot be decoded. */
+  readonly skippedRecords: number;
 }
 
 export interface FindRequest {
@@ -50,6 +52,8 @@ export interface FindOutcome {
   readonly files: readonly string[];
   readonly truncated: boolean;
   readonly timedOut: boolean;
+  /** Records too large to buffer; they are dropped because a partial path is not a path. */
+  readonly skippedRecords: number;
 }
 
 export interface SearchRuntimeShape {
@@ -132,11 +136,21 @@ function isExplicitHiddenPath(searchPath: string | undefined): boolean {
 /** Files larger than this are skipped: giant blobs (caches, bundles, sourcemaps) are what turns a broad search into an overnight scan. Matches OMP's native grep ceiling. */
 const GREP_MAX_FILESIZE = "4M";
 
-/** Safe basename prefilter only; complex globs are left to Minimatch. */
+/** The glob without its optional leading negation marker. */
+function globBody(pattern: string): string {
+  return pattern.startsWith("!") ? pattern.slice(1) : pattern;
+}
+
+/**
+ * Safe basename prefilter only; complex globs are left to Minimatch. Negated
+ * globs cannot be expressed as a file-type filter, so they scan everything and
+ * let Minimatch remove the exclusions.
+ */
 function basenamePrefilter(pattern: string | undefined): string {
-  const basename = pattern?.split("/").at(-1);
+  if (pattern === undefined || pattern.startsWith("!")) return "*";
+  const basename = pattern.split("/").at(-1);
   // Restrict the entire pattern: a brace/extglob alternative can contain slashes.
-  return pattern !== undefined && /^[a-zA-Z0-9_./*?-]+$/.test(pattern) && basename ? basename : "*";
+  return /^[a-zA-Z0-9_./*?-]+$/.test(pattern) && basename ? basename : "*";
 }
 
 export function buildRgArgs(request: GrepRequest, searchRoot: string): string[] {
@@ -173,21 +187,35 @@ export function buildFdArgs(request: FindRequest, searchRoot: string): string[] 
   return args;
 }
 
-/** Match slash globs relative to the search root, otherwise match basenames. */
+/**
+ * Compile one glob into a result-path predicate.
+ *
+ * A leading `!` excludes instead of includes, like ripgrep's own globs. Slash
+ * globs are matched against both the search root and the cwd: callers pass
+ * `path` as the scope and write globs from either place, and both spellings
+ * can only ever match results inside that scope.
+ */
 function pathMatcher(pattern: string | undefined, root: string, cwd: string) {
+  const negated = pattern?.startsWith("!") === true;
+  const body = pattern === undefined ? undefined : globBody(pattern);
   const matcher =
-    pattern === undefined
+    body === undefined || body.length === 0
       ? undefined
-      : new Minimatch(pattern, {
+      : new Minimatch(body, {
           dot: true,
-          matchBase: !pattern.includes("/"),
+          matchBase: !body.includes("/"),
           nonegate: true,
           nocomment: true,
           nocase: false,
         });
-  return (file: string): boolean =>
-    matcher === undefined ||
-    matcher.match(normalizeResultPath(nodePath.relative(root, nodePath.resolve(cwd, file))));
+  return (file: string): boolean => {
+    if (matcher === undefined) return true;
+    const absolute = nodePath.resolve(cwd, file);
+    const matched =
+      matcher.match(normalizeResultPath(nodePath.relative(root, absolute))) ||
+      matcher.match(normalizeResultPath(nodePath.relative(cwd, absolute)));
+    return negated ? !matched : matched;
+  };
 }
 
 const makeSearchRuntime = Effect.gen(function* () {
@@ -196,7 +224,7 @@ const makeSearchRuntime = Effect.gen(function* () {
       if (request.pattern.length === 0) {
         return Effect.fail(new SearchInputError({ message: EMPTY_PATTERN_ERROR }));
       }
-      if (request.glob !== undefined && request.glob.length === 0) {
+      if (request.glob !== undefined && globBody(request.glob).length === 0) {
         return Effect.fail(new SearchInputError({ message: EMPTY_PATTERN_ERROR }));
       }
       const target = searchTarget(request.cwd, request.path, false);
@@ -205,12 +233,18 @@ const makeSearchRuntime = Effect.gen(function* () {
       const accepts = pathMatcher(request.glob, target.root, request.cwd);
       const matches: GrepMatch[] = [];
       let sawOverflow = false;
+      let skippedRecords = 0;
       return streamLines({
         binary: "rg",
         args: buildRgArgs({ ...request, path: target.argument }, target.root),
         cwd: request.cwd,
         signal: request.signal,
-        onLine(line) {
+        onLine(line, clipped) {
+          // A clipped JSON record cannot be decoded, and its head is not a match.
+          if (clipped) {
+            skippedRecords += 1;
+            return true;
+          }
           const event = decodeRgEvent(line);
           if (event === undefined || !accepts(event.path)) return true;
           if (matches.length >= GREP_RESULT_LIMIT) {
@@ -231,6 +265,7 @@ const makeSearchRuntime = Effect.gen(function* () {
               matches,
               truncated: sawOverflow || result.stoppedEarly,
               timedOut: result.timedOut,
+              skippedRecords,
             }) satisfies GrepOutcome,
         ),
       );
@@ -238,7 +273,7 @@ const makeSearchRuntime = Effect.gen(function* () {
 
   const find = (request: FindRequest): Effect.Effect<FindOutcome, SearchError> =>
     Effect.suspend<FindOutcome, SearchError, never>(() => {
-      if (request.pattern.length === 0) {
+      if (globBody(request.pattern).length === 0) {
         return Effect.fail(new SearchInputError({ message: EMPTY_PATTERN_ERROR }));
       }
       const target = searchTarget(request.cwd, request.path, true);
@@ -247,13 +282,19 @@ const makeSearchRuntime = Effect.gen(function* () {
       const accepts = pathMatcher(request.pattern, target.root, request.cwd);
       const files: string[] = [];
       let sawOverflow = false;
+      let skippedRecords = 0;
       return streamLines({
         binary: "fd",
         args: buildFdArgs({ ...request, path: target.argument }, target.root),
         delimiter: "\0",
         cwd: request.cwd,
         signal: request.signal,
-        onLine(line) {
+        onLine(line, clipped) {
+          // A clipped record is a partial path; a partial path is not a result.
+          if (clipped) {
+            skippedRecords += 1;
+            return true;
+          }
           const file = line;
           if (file.length === 0 || !accepts(file)) return true;
           if (files.length >= FIND_RESULT_LIMIT) {
@@ -270,6 +311,7 @@ const makeSearchRuntime = Effect.gen(function* () {
               files,
               truncated: sawOverflow || result.stoppedEarly,
               timedOut: result.timedOut,
+              skippedRecords,
             }) satisfies FindOutcome,
         ),
       );

--- a/packages/pi-find/src/stream.ts
+++ b/packages/pi-find/src/stream.ts
@@ -19,15 +19,20 @@ export interface StreamRequest {
   readonly args: readonly string[];
   readonly cwd: string;
   /**
-   * Called for each stdout line. Return false to stop consuming; the child is
+   * Called for each stdout record. Return false to stop consuming; the child is
    * killed and the run settles successfully with what was gathered so far.
+   *
+   * `clipped` marks a record that was longer than `maxRecordBytes`: only its
+   * head is delivered, so callers must treat the tail as unknown.
    */
-  readonly onLine: (line: string) => boolean;
+  readonly onLine: (line: string, clipped: boolean) => boolean;
   /** fd uses NUL records so newlines in filenames remain intact. */
   readonly delimiter?: "\n" | "\0";
   readonly signal?: AbortSignal;
   /** Wall-clock budget; defaults to SEARCH_TIMEOUT_MS. Overridable for tests. */
   readonly timeoutMs?: number;
+  /** Bytes buffered per record before the tail is dropped; overridable for tests. */
+  readonly maxRecordBytes?: number;
 }
 
 export interface StreamResult {
@@ -37,6 +42,16 @@ export interface StreamResult {
   readonly timedOut: boolean;
   readonly exitCode: number | null;
 }
+
+/**
+ * Bytes buffered per record. A record is one rg JSON match or one fd path, so
+ * this only ever cuts pathological lines: without it, a 100 MiB single-line
+ * file (an explicitly named bundle, sourcemap, or lockfile bypasses
+ * --max-filesize) buffers the whole line and its decode copies, which measured
+ * at 866 MiB RSS. Twice the traversal file cap leaves room for JSON escaping,
+ * so ordinary searches are never cut.
+ */
+export const MAX_RECORD_BYTES = 8 * 1024 * 1024;
 
 /**
  * Exit codes that are not failures. rg uses 1 for "no matches", which is a
@@ -105,7 +120,9 @@ export function streamLines(
     });
 
     const delimiter = request.delimiter ?? "\n";
+    const maxRecordBytes = request.maxRecordBytes ?? MAX_RECORD_BYTES;
     let pending = "";
+    let cutting = false;
     let stderr = "";
     let stoppedEarly = false;
     let timedOut = false;
@@ -159,11 +176,11 @@ export function streamLines(
       if (stderr.length < 4096) stderr = (stderr + chunk.toString("utf8")).slice(0, 4096);
     });
 
-    function onLine(line: string) {
+    function onLine(line: string, clipped: boolean) {
       if (settled || stoppedEarly || aborted) return;
       let wantsMore: boolean;
       try {
-        wantsMore = request.onLine(line);
+        wantsMore = request.onLine(line, clipped);
       } catch (error) {
         stoppedEarly = true;
         stopChild("SIGKILL");
@@ -183,18 +200,49 @@ export function streamLines(
       }
     }
 
+    /** Emit the buffered record, cut short when it outgrew the buffer. */
+    function flush(cut: boolean) {
+      const line = pending;
+      pending = "";
+      cutting = false;
+      onLine(line, cut);
+    }
+
     function onData(chunk: string) {
       if (settled || stoppedEarly || aborted) return;
-      pending += chunk;
       let start = 0;
-      let end = pending.indexOf(delimiter, start);
-      while (end !== -1) {
-        onLine(pending.slice(start, end));
+      for (;;) {
+        const end = chunk.indexOf(delimiter, start);
+        if (cutting) {
+          // Discard the tail of an over-long record; its head is already buffered.
+          if (end === -1) return;
+          flush(true);
+          if (settled || stoppedEarly || aborted) return;
+          start = end + 1;
+          continue;
+        }
+
+        const room = maxRecordBytes - pending.length;
+        const segment = end === -1 ? chunk.slice(start) : chunk.slice(start, end);
+        if (segment.length > room) {
+          pending += segment.slice(0, room);
+          // Drop the tail, wherever it ended: the record cannot be decoded whole.
+          if (end === -1) {
+            cutting = true;
+            return;
+          }
+          flush(true);
+          if (settled || stoppedEarly || aborted) return;
+          start = end + 1;
+          continue;
+        }
+
+        pending += segment;
+        if (end === -1) return;
+        flush(false);
+        if (settled || stoppedEarly || aborted) return;
         start = end + 1;
-        if (settled || stoppedEarly || aborted) break;
-        end = pending.indexOf(delimiter, start);
       }
-      pending = settled || stoppedEarly || aborted ? "" : pending.slice(start);
     }
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", onData);
@@ -209,11 +257,13 @@ export function streamLines(
     });
 
     child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
-      // A killed producer's trailing fragment is garbage, not a record: rg's
-      // partial JSON is dropped by the decoder, but a truncated fd path would
-      // silently become a bogus result. Only flush on a natural exit.
-      if (!timedOut && pending.length > 0) onLine(pending);
+      // A killed producer's trailing fragment is garbage, not a record: a
+      // partial rg match would be dropped by the decoder anyway, but a
+      // truncated fd path would silently become a bogus result. Only flush on a
+      // natural exit, and only flush a cut record as cut.
+      if (!timedOut && (pending.length > 0 || cutting)) flush(cutting);
       pending = "";
+      cutting = false;
       if (aborted) {
         settle(
           new SearchAbortedError({

--- a/packages/pi-find/test/search.test.ts
+++ b/packages/pi-find/test/search.test.ts
@@ -107,6 +107,39 @@ test("grep path is one file or directory and glob filters file names", {
   );
 });
 
+test("a slash glob matches from the search root or the cwd", { skip: !hasRg }, async () => {
+  // `path` scopes the search; the glob may still be written from the cwd.
+  const scoped = await grep({ pattern: "needle", path: "src", glob: "src/*.ts" });
+  assert.deepEqual(
+    scoped.matches.map((match) => match.path),
+    ["src/main.ts"],
+  );
+
+  const nested = await grep({ pattern: "needle", path: "src", glob: "deep/*.ts" });
+  assert.deepEqual(
+    nested.matches.map((match) => match.path),
+    ["src/deep/test.ts"],
+  );
+});
+
+test("a leading ! excludes like ripgrep's own globs", { skip: !hasRg }, async () => {
+  const excluded = await grep({ pattern: "needle", glob: "!*.js" });
+  assert.equal(
+    excluded.matches.some((match) => match.path.endsWith(".js")),
+    false,
+  );
+  assert.ok(excluded.matches.some((match) => match.path === "src/main.ts"));
+
+  const excludedFromCwd = await grep({ pattern: "needle", path: "src", glob: "!src/*.ts" });
+  assert.equal(
+    excludedFromCwd.matches.some((match) => match.path === "src/main.ts"),
+    false,
+  );
+  assert.ok(excludedFromCwd.matches.some((match) => match.path === "src/other.js"));
+
+  await assert.rejects(() => grep({ pattern: "needle", glob: "!" }), /cannot be empty/);
+});
+
 test("grep skips hidden and ignored files by default", { skip: !hasRg }, async () => {
   const outcome = await grep({ pattern: "needle" });
   const paths = new Set(outcome.matches.map((match) => match.path));
@@ -184,9 +217,54 @@ test("a wedged search is killed at the wall-clock budget and stays partial", {
   assert.equal(result.stoppedEarly, false);
 });
 
+test("an over-long record is cut instead of buffered whole", { skip: !hasRg }, async () => {
+  writeFileSync(path.join(root, "wide.txt"), `needle ${"x".repeat(4000)}\n`);
+  const records: Array<{ line: string; clipped: boolean }> = [];
+  await Effect.runPromise(
+    streamLines({
+      binary: "rg",
+      args: ["--no-config", "--json", "--regexp", "needle", "--", "wide.txt"],
+      cwd: root,
+      maxRecordBytes: 64,
+      onLine: (line, clipped) => {
+        records.push({ line, clipped });
+        return true;
+      },
+    }),
+  );
+
+  const cut = records.filter((record) => record.clipped);
+  const match = cut.find((record) => record.line.startsWith('{"type":"match"'));
+  assert.ok(match !== undefined, "the match record must arrive cut");
+  assert.equal(match.line.length, 64);
+  for (const record of records) assert.ok(record.line.length <= 64);
+});
+
+test("grep drops an over-long record and says so", { skip: !hasRg }, async () => {
+  // Explicit files bypass --max-filesize, so the record cap is the only bound.
+  writeFileSync(path.join(root, "huge.txt"), `needle ${"x".repeat(9 * 1024 * 1024)}\n`);
+  const outcome = await grep({ pattern: "needle", path: "huge.txt" });
+  assert.deepEqual(outcome.matches, []);
+  assert.equal(outcome.skippedRecords, 1);
+  assert.equal(outcome.timedOut, false);
+  rmSync(path.join(root, "huge.txt"));
+});
+
 test("find uses one glob under one directory", { skip: !hasFd }, async () => {
   const outcome = await find({ pattern: "*.ts", path: "src" });
   assert.deepEqual([...outcome.files].sort(), ["src/deep/test.ts", "src/main.ts"]);
+
+  const fromCwd = await find({ pattern: "src/*.ts", path: "src" });
+  assert.deepEqual(fromCwd.files, ["src/main.ts"]);
+
+  const excluded = await find({ pattern: "!*.ts" });
+  assert.equal(
+    excluded.files.some((file) => file.endsWith(".ts")),
+    false,
+  );
+  assert.ok(excluded.files.includes("src/other.js"));
+
+  await assert.rejects(() => find({ pattern: "!" }), /cannot be empty/);
 });
 
 test("find skips hidden and ignored files unless a hidden directory is explicit", {
@@ -244,6 +322,7 @@ test("searches are abortable", { skip: !hasRg }, async () => {
 
 test("engine arguments contain only the fixed simple behavior", () => {
   const rg = buildRgArgs({ pattern: "needle", path: "src", glob: "*.ts", cwd: root }, root);
+  assert.ok(rg.includes("--json"));
   assert.ok(rg.includes("--regexp"));
   // Simple basename prefilters avoid scanning unrelated file contents.
   assert.ok(rg.includes("--type-add"));

--- a/packages/pi-find/test/tools.test.ts
+++ b/packages/pi-find/test/tools.test.ts
@@ -9,6 +9,7 @@ import {
   GREP_PROMPT_SNIPPET,
   GREP_TOOL_DESCRIPTION,
   outputLimitNotice,
+  oversizedRecordNotice,
   resultLimitNotice,
   searchTimeoutNotice,
 } from "../lib/prompt.ts";
@@ -19,6 +20,7 @@ function outcome(matches: ReadonlyArray<[string, number, string]>): GrepOutcome 
     matches: matches.map(([path, lineNumber, text]) => ({ path, lineNumber, text })),
     truncated: false,
     timedOut: false,
+    skippedRecords: 0,
   };
 }
 
@@ -86,6 +88,7 @@ test("result text keeps one blank line between sections", () => {
 test("fixed limit notices tell the caller to narrow the search", () => {
   assert.match(resultLimitNotice("matches", 100), /narrow pattern, path, or glob/);
   assert.match(outputLimitNotice("find"), /omitted files/);
+  assert.match(oversizedRecordNotice(8 * 1024 * 1024), /larger than 8 MiB/);
 });
 
 test("timeout notices say the results are partial and how to narrow", () => {


### PR DESCRIPTION
Fixes three search defects in `@tian.zuo/pi-find`, found by comparing the extension against pi's built-in `grep`/`find` and against the open-source Codex and Grok Build implementations.

## 1. A glob written from the cwd returned nothing when `path` scoped the search

`pathMatcher` only matched slash globs relative to the search root, so the most natural call a model can write returned a false negative:

| call | before | after |
| --- | --- | --- |
| `grep({pattern:"needle", path:"src", glob:"src/*.ts"})` | `No matches found.` | `1 match in 1 file` |
| `find({pattern:"src/*.ts", path:"src"})` | `[]` | `["src/a.ts"]` |

This is a regression against the built-in tool it replaces: the built-in passes the glob straight to ripgrep, so `rg --glob 'src/*.ts' needle src` matches. A model that has the habit produces "the code does not contain this pattern" instead of an error.

Slash globs now match relative to the search root **or** the working directory. Results are still scoped to `path`, so the cwd spelling cannot pull in anything outside the requested scope.

## 2. A leading `!` was treated as a literal

`nonegate: true` made `glob: "!*.test.ts"` match a file literally named `!*.test.ts`, i.e. always nothing. ripgrep's `--glob` (and therefore the built-in grep) supports negation, so this was another silent false negative. A leading `!` now excludes, for both grep's `glob` and find's `pattern`; negated globs skip the `--type-add` prefilter, since a file-type filter cannot express an exclusion.

## 3. Unbounded memory on a single long line

`stream.ts` accumulated a whole record before decoding, and the JSON decode made several more copies. Explicitly named files bypass `--max-filesize`, and the 30s wall-clock budget bounds time but not memory:

```
100 MiB single-line file, explicitly named:
  before: rss 866 MiB, 9.8 s
  after:  bounded (node baseline + ~50 MiB), 0.11 s
  raw rg --json for comparison: 150 MiB
```

Records larger than 8 MiB (twice the 4 MiB traversal cap, leaving room for JSON escaping, so ordinary searches are never cut) are now dropped with a `[Skipped a record larger than 8 MiB; narrow the search.]` notice instead of being buffered. Both outcomes carry `skippedRecords`.

I first tried switching grep to ripgrep's text protocol (`--null --field-match-separator`) so a long line could be *clipped* rather than dropped, but that breaks filenames containing newlines — a documented, tested feature — so `--json` stays.

## Verification

- `pnpm --filter @tian.zuo/pi-find run check`, `pnpm exec biome check`, and 48 tests pass (4 new tests cover the cwd-relative glob, exclusion, and the record cap).
- End-to-end in a real pi session (`pi -p -e ./packages/pi-find`): the two calls above now return `1 match in 1 file / src/a.ts:1: needle` and `2 matches in 2 files` (only `.ts`).
- `pnpm run check` across the workspace passes.

Changeset: `.changeset/fix-pi-find-glob-and-memory.md` (patch).
